### PR TITLE
Fix mat_tree heading mapping in GUI products tab

### DIFF
--- a/gui_products.py
+++ b/gui_products.py
@@ -101,8 +101,10 @@ class ProductsMaterialsTab(ttk.Frame):
         nb.add(mat_frame, text="Surowce")
         mcols = ("id", "typ", "rozmiar", "dlugosc", "jednostka", "stan")
         self.mat_tree = ttk.Treeview(mat_frame, columns=mcols, show="headings")
-        for col in ("ID", "Typ", "Rozmiar", "Długość", "Jednostka", "Stan"):
-            self.mat_tree.heading(col.lower(), text=col)
+        for col, header in zip(
+            mcols, ("ID", "Typ", "Rozmiar", "Długość", "Jednostka", "Stan")
+        ):
+            self.mat_tree.heading(col, text=header)
         self.mat_tree.pack(fill="both", expand=True, padx=5, pady=5)
         mat_btns = ttk.Frame(mat_frame)
         mat_btns.pack(fill="x", padx=5, pady=5)


### PR DESCRIPTION
## Summary
- map Treeview columns to display headers using zip to avoid invalid index errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beaf8a9a288323b05e74f4038cc8d9