### PR TITLE
Fix BOM settings tab initialization

### DIFF
--- a/gui_settings.py
+++ b/gui_settings.py
@@ -394,8 +394,9 @@ class SettingsPanel:
         nb.add(ustawienia_frame, text="Ustawienia magazynu")
         self._populate_tab(ustawienia_frame, self._magazyn_schema)
 
-        bom_frame = ustawienia_produkty_bom.make_tab(nb)
+        bom_frame = ttk.Frame(nb)
         nb.add(bom_frame, text="Produkty (BOM)")
+        ustawienia_produkty_bom.make_tab(bom_frame)
 
         self._magazyn_initialized = True
 


### PR DESCRIPTION
## Summary
- create a dedicated frame for the BOM tab in settings
- populate the frame after adding it to the notebook to avoid AttributeError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beaf8b4c808323ac07378b08af906d