### PR TITLE
Refactor materials tree headers

### DIFF
--- a/gui_products.py
+++ b/gui_products.py
@@ -107,8 +107,9 @@ class ProductsMaterialsTab(ttk.Frame):
             "jednostka": "Jednostka",
             "stan": "Stan",
         }
-        mcols = tuple(headers)
-        self.mat_tree = ttk.Treeview(mat_frame, columns=mcols, show="headings")
+        self.mat_tree = ttk.Treeview(
+            mat_frame, columns=tuple(headers.keys()), show="headings"
+        )
         for col, hdr in headers.items():
             self.mat_tree.heading(col, text=hdr)
         self.mat_tree.pack(fill="both", expand=True, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- build materials tree headers using mapping dict
- pass Treeview column identifiers directly from headers keys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bebd219f60832384f876fe9a4078bf