### PR TITLE
Normalize LF endings for Python and JSON files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 avatars/default.jpg -filter -merge -diff -text
 *.xlsm filter=lfs diff=lfs merge=lfs -text
+
+*.py text eol=lf
+*.json text eol=lf
+patches/*.wmpatch text eol=lf


### PR DESCRIPTION
## Summary
- specify LF line endings for Python, JSON, and patch files in .gitattributes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfd19840e88323855f6bf71fc324dd