### PR TITLE
Add patch application utilities and audit logging

### DIFF
--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -1,0 +1,125 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tools import patcher
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "Rozwiniecie"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    (path / "audit").mkdir()
+    (path / "audit" / "config_changes.jsonl").write_text("", encoding="utf-8")
+
+
+def test_get_commits() -> None:
+    with TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _init_repo(repo)
+        (repo / "a.txt").write_text("a\n", encoding="utf-8")
+        subprocess.run([
+            "git",
+            "add",
+            "a.txt",
+        ], cwd=repo, check=True, capture_output=True)
+        subprocess.run([
+            "git",
+            "commit",
+            "-m",
+            "msg1",
+        ], cwd=repo, check=True, capture_output=True)
+        (repo / "a.txt").write_text("b\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "commit", "-am", "msg2"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        os.environ["WM_AUDIT_FILE"] = str(
+            repo / "audit" / "config_changes.jsonl"
+        )
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(repo)
+            commits = patcher.get_commits(limit=5, branch="Rozwiniecie")
+        finally:
+            os.chdir(prev_cwd)
+        assert [msg for _, msg in commits] == ["msg2", "msg1"]
+        audit_lines = (
+            repo / "audit" / "config_changes.jsonl"
+        ).read_text(encoding="utf-8").strip().splitlines()
+        last_entry = json.loads(audit_lines[-1])
+        assert last_entry["action"] == "get_commits"
+
+
+def test_apply_patch_and_rollback() -> None:
+    with TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _init_repo(repo)
+        file_path = repo / "file.txt"
+        file_path.write_text("Hello\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "file.txt"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        base = (
+            subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+        patch = (
+            "--- a/file.txt\n"
+            "+++ b/file.txt\n"
+            "@@ -1 +1 @@\n"
+            "-Hello\n"
+            "+Hello world\n"
+        )
+        patch_file = repo / "change.patch"
+        patch_file.write_text(patch, encoding="utf-8")
+        os.environ["WM_AUDIT_FILE"] = str(
+            repo / "audit" / "config_changes.jsonl"
+        )
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(repo)
+            patcher.apply_patch(str(patch_file), dry_run=True)
+            assert file_path.read_text(encoding="utf-8") == "Hello\n"
+            patcher.apply_patch(str(patch_file))
+            assert file_path.read_text(encoding="utf-8") == "Hello world\n"
+            subprocess.run(
+                ["git", "commit", "-am", "update"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+            patcher.rollback_to(base, hard=True)
+        finally:
+            os.chdir(prev_cwd)
+        assert file_path.read_text(encoding="utf-8") == "Hello\n"
+        audit_lines = (
+            repo / "audit" / "config_changes.jsonl"
+        ).read_text(encoding="utf-8").strip().splitlines()
+        actions = [json.loads(line)["action"] for line in audit_lines]
+        assert actions.count("apply_patch") == 2
+        assert "rollback_to" in actions

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Helper tools for Warsztat Menager."""

--- a/tools/patcher.py
+++ b/tools/patcher.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Tuple
+
+
+def _get_audit_file() -> Path:
+    return Path(
+        os.environ.get(
+            "WM_AUDIT_FILE",
+            Path(__file__).resolve().parents[1] / "audit" / "config_changes.jsonl",
+        )
+    )
+
+
+def _append_audit(entry: dict) -> None:
+    audit_file = _get_audit_file()
+    audit_file.parent.mkdir(parents=True, exist_ok=True)
+    with audit_file.open("a", encoding="utf-8") as fh:
+        json.dump(entry, fh, ensure_ascii=False)
+        fh.write("\n")
+
+
+def apply_patch(path: str, dry_run: bool = False) -> None:
+    """Apply a git patch from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the patch file.
+    dry_run:
+        When ``True``, run ``git apply --check`` to verify patch without
+        applying it.
+    """
+    cmd = ["git", "apply"]
+    if dry_run:
+        cmd.append("--check")
+    cmd.append(path)
+    print(f"[WM-DBG] Running {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+    _append_audit(
+        {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "action": "apply_patch",
+            "path": path,
+            "dry_run": dry_run,
+        }
+    )
+    print("[WM-DBG] apply_patch complete")
+
+
+def get_commits(limit: int = 20, branch: str = "Rozwiniecie") -> List[Tuple[str, str]]:
+    """Return last commits from ``branch``.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of commits to return.
+    branch:
+        Branch name to inspect.
+    """
+    cmd = ["git", "log", f"-n{limit}", "--format=%H%x09%s", branch]
+    print(f"[WM-DBG] Running {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    commits: List[Tuple[str, str]] = []
+    for line in result.stdout.strip().splitlines():
+        commit_hash, message = line.split("\t", 1)
+        commits.append((commit_hash, message))
+    _append_audit(
+        {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "action": "get_commits",
+            "limit": limit,
+            "branch": branch,
+        }
+    )
+    print("[WM-DBG] get_commits complete")
+    return commits
+
+
+def rollback_to(commit_hash: str, hard: bool = True) -> None:
+    """Reset repository to ``commit_hash``.
+
+    Parameters
+    ----------
+    commit_hash:
+        Commit to reset to.
+    hard:
+        When ``True`` perform ``--hard`` reset, otherwise ``--soft``.
+    """
+    cmd = ["git", "reset", "--hard" if hard else "--soft", commit_hash]
+    print(f"[WM-DBG] Running {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+    _append_audit(
+        {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "action": "rollback_to",
+            "commit": commit_hash,
+            "hard": hard,
+        }
+    )
+    print("[WM-DBG] rollback_to complete")


### PR DESCRIPTION
## Summary
- introduce `tools.patcher` with functions to apply patches, list commits, and rollback
- log configuration changes to `audit/config_changes.jsonl`
- test patcher utilities in isolated temporary repositories

## Testing
- `pytest tests/test_patcher.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfd196d6cc8323a2b8ed916a517373