### PR TITLE
docs: note BOM removal, tool limits, TopMost helper and ZIP patcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.1 - 2025-09-09
+- [USTAWIENIA] Zapis plików bez znaku BOM.
+- [NARZĘDZIA] Limit typów i statusów do 8 × 8.
+- [UI] Helper `TopMost` wymusza okno na wierzchu.
+- [PATCHER] Obsługa paczek ZIP.
+
 ## 1.1.3 - 2025-08-19
 - [NOWE] Okno z listą zmian wyświetlane po aktualizacji.
 - [NOWE] Obsługa pliku CHANGELOG.md w aplikacji.

--- a/README_PATCH.txt
+++ b/README_PATCH.txt
@@ -1,3 +1,9 @@
+PATCH: Ustawienia bez BOM, limity narzędzi 8×8, helper TopMost, paczki ZIP
+- Ustawienia zapisują się bez znaku BOM.
+- Konfiguracja narzędzi ogranicza typy i statusy do 8 × 8.
+- Dodano helper `TopMost` do okien zawsze na wierzchu.
+- Patcher obsługuje paczki ZIP.
+
 PATCH: H2c + theme fallback + user files
 - Podmień gui_profil.py na ten z paczki.
 - Theme: jeśli ui_theme.apply_theme nie działa, panel profil wymusi 'clam' (fallback).


### PR DESCRIPTION
## Summary
- document removal of BOM in settings
- mention 8x8 tool type/status limit
- describe new TopMost helper
- note ZIP package support in patcher

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bffee95c9c8323b88ce9bb423481c4