### PR TITLE
Add module visibility settings

### DIFF
--- a/gui_uzytkownicy.py
+++ b/gui_uzytkownicy.py
@@ -5,8 +5,10 @@
 # - Admin może dodatkowo dodawać i usuwać konta.
 # ⏹ KONIEC KODU
 
+import tkinter as tk
 from tkinter import ttk
 
+import profile_utils
 from ui_theme import apply_theme_safe as apply_theme
 from utils.gui_helpers import clear_frame
 
@@ -16,6 +18,41 @@ def _build_tab_profil(parent, login, rola):
     frame.pack(fill="both", expand=True)
     # Wywołanie nowego panelu profilu w ramach zakładki
     gui_profile.panel_profil(parent, frame, login, rola)
+    return frame
+
+
+def _build_tab_visibility(parent, login):
+    frame = ttk.Frame(parent)
+    frame.pack(fill="both", expand=True)
+    box = ttk.LabelFrame(frame, text="Widoczność modułów")
+    box.pack(fill="both", expand=True, padx=10, pady=10)
+
+    user = profile_utils.get_user(login) or {"login": login, "disabled_modules": []}
+    disabled = {str(m).strip().lower() for m in user.get("disabled_modules", [])}
+
+    modules = [
+        ("zlecenia", "Zlecenia"),
+        ("narzedzia", "Narzędzia"),
+        ("maszyny", "Maszyny"),
+        ("magazyn", "Magazyn"),
+        ("hale", "Hale"),
+        ("ustawienia", "Ustawienia"),
+        ("uzytkownicy", "Użytkownicy"),
+        ("feedback", "Feedback"),
+    ]
+
+    vars: dict[str, tk.BooleanVar] = {}
+
+    def _toggle(mod: str) -> None:
+        profile_utils.set_module_visibility(login, mod, vars[mod].get())
+
+    for mod, label in modules:
+        var = tk.BooleanVar(value=mod not in disabled)
+        vars[mod] = var
+        ttk.Checkbutton(
+            box, text=label, variable=var, command=lambda m=mod: _toggle(m)
+        ).pack(anchor="w", padx=4, pady=2)
+
     return frame
 
 def panel_uzytkownicy(root, frame, login=None, rola=None):
@@ -29,6 +66,10 @@ def panel_uzytkownicy(root, frame, login=None, rola=None):
     tab_profil = ttk.Frame(nb); nb.add(tab_profil, text="Profil")
     _build_tab_profil(tab_profil, login, rola)
 
+    if login:
+        tab_vis = ttk.Frame(nb)
+        nb.add(tab_vis, text="Widoczność modułów")
+        _build_tab_visibility(tab_vis, login)
 
     return nb
 

--- a/profile_utils.py
+++ b/profile_utils.py
@@ -112,6 +112,26 @@ def save_user(user: dict):
         users.append(user)
     return write_users(users)
 
+
+def set_module_visibility(login, module, visible):
+    """Update visibility of ``module`` for user ``login``.
+
+    ``visible`` set to ``False`` adds the module to ``disabled_modules``.
+    ``True`` removes it. Returns ``True`` if user exists, otherwise ``False``.
+    """
+    user = get_user(login)
+    if not user:
+        return False
+    mods = {str(m).strip().lower() for m in user.get("disabled_modules", []) if m}
+    name = str(module).strip().lower()
+    if visible:
+        mods.discard(name)
+    else:
+        mods.add(name)
+    user["disabled_modules"] = sorted(mods)
+    save_user(user)
+    return True
+
 def ensure_user_fields(users):
     """Uzupełnia brakujące pola w przekazanej liście użytkowników."""
     changed = False

--- a/tests/test_gui_panel_disabled_modules.py
+++ b/tests/test_gui_panel_disabled_modules.py
@@ -1,6 +1,7 @@
 import pytest
 import tkinter as tk
 import gui_panel
+import profile_utils
 
 
 @pytest.fixture
@@ -14,12 +15,16 @@ def root():
     r.destroy()
 
 
-def test_disabled_modules_hide_buttons(root, monkeypatch):
-    monkeypatch.setattr(
-        gui_panel, "get_user", lambda login: {"login": login, "disabled_modules": ["narzedzia"]}
-    )
-    gui_panel.uruchom_panel(root, "demo", "user")
-    side = root.winfo_children()[0]
-    texts = [w.cget("text") for w in side.winfo_children() if hasattr(w, "cget")]
-    assert "Narzędzia" not in texts
-    assert "Zlecenia" in texts
+def test_disabled_modules_hide_buttons(root):
+    user = profile_utils.get_user("dawid")
+    assert user is not None
+    backup = dict(user)
+    try:
+        profile_utils.set_module_visibility("dawid", "narzedzia", False)
+        gui_panel.uruchom_panel(root, "dawid", user.get("rola"))
+        side = root.winfo_children()[0]
+        texts = [w.cget("text") for w in side.winfo_children() if hasattr(w, "cget")]
+        assert "Narzędzia" not in texts
+        assert "Zlecenia" in texts
+    finally:
+        profile_utils.save_user(backup)


### PR DESCRIPTION
## Summary
- add `set_module_visibility` helper to update `disabled_modules`
- expose module visibility checkboxes in user panel
- adjust panel test to verify hidden modules via new API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffee570e88323970bb96ae811f8ac