### PR TITLE
Ustaw gałąź aktualizacji na Rozwiniecie

### DIFF
--- a/config.defaults.json
+++ b/config.defaults.json
@@ -46,8 +46,8 @@
   "updates": {
     "auto": true,
     "remote": "origin",
-    "branch": "proby-rozwoju",
-    "push_branch": "git-push"
+    "branch": "Rozwiniecie",
+    "push_branch": "Rozwiniecie"
   },
   "feedback": {
     "url": ""

--- a/config.json
+++ b/config.json
@@ -66,7 +66,7 @@
     "auto": true,
     "remote": "origin",
     "branch": "Rozwiniecie",
-    "push_branch": "git-push"
+    "push_branch": "Rozwiniecie"
   },
   "modules": {
     "service": {

--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -291,7 +291,7 @@ def ekran_logowania(root=None, on_login=None, update_available=False):
     lbl_update = ttk.Label(root, text=update_text, style="WM.Muted.TLabel")
     lbl_update.pack(side="bottom", pady=(0, 2))
     remote = cfg.get("updates.remote", "origin")
-    branch = cfg.get("updates.branch", "proby-rozwoju")
+    branch = cfg.get("updates.branch", "Rozwiniecie")
     try:
         if remote_branch_exists(remote, branch):
             subprocess.run(["git", "fetch", remote, branch], check=True)

--- a/updater.py
+++ b/updater.py
@@ -502,7 +502,7 @@ class UpdatesUI(ttk.Frame):
     def _on_git_push(self):
         cfg = ConfigManager()
         remote = cfg.get("updates.remote", "origin")
-        branch = cfg.get("updates.push_branch", "git-push")
+        branch = cfg.get("updates.push_branch", "Rozwiniecie")
         stamp = _now_stamp()
         try:
             self._append_out("[INFO] Rozpoczynam git push…")


### PR DESCRIPTION
## Summary
- Domyślnie ustawiaj aktualizacje na gałąź `Rozwiniecie` w konfiguracjach
- Dopasuj logowanie i narzędzie aktualizacji do nowej gałęzi

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffee35aa08323acb93b877c699e5d