### PR TITLE
Load materials in half-product form from warehouse

### DIFF
--- a/gui_products.py
+++ b/gui_products.py
@@ -256,6 +256,7 @@ class ProductsMaterialsTab(ttk.Frame):
                     "Magazyn", "Nie można wczytać danych magazynu", parent=self
                 )
                 return
+        self.surowce = list(items.values())
         if not isinstance(items, dict) or not items:
             print("[WM-DBG] [WARN] magazyn brak danych lub nieprawidłowy")
             messagebox.showinfo(
@@ -480,6 +481,19 @@ class ProductsMaterialsTab(ttk.Frame):
         self.refresh_all()
 
     def _polprodukt_form(self, item: dict[str, Any] | None = None) -> None:
+        try:
+            with open(self.paths["magazyn"], encoding="utf-8") as f:
+                data = json.load(f) or {}
+            items = data.get("items")
+            if not isinstance(items, dict):
+                raise KeyError("items")
+            self.surowce = list(items.values())
+        except Exception:
+            self.surowce = []
+            messagebox.showwarning(
+                "Magazyn", "Nie można wczytać danych magazynu", parent=self
+            )
+
         win = tk.Toplevel(self)
         win.title("Półprodukt")
         apply_theme(win)


### PR DESCRIPTION
## Summary
- Refresh materials list keeps in-memory copy for reuse
- Half-product form loads materials directly from `data/magazyn/magazyn.json` with graceful fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffee099a08323bb5f52cfb47f5650