### PR TITLE
Add tests for tools templates, autocheck and history

### DIFF
--- a/tests/test_tools_autocheck.py
+++ b/tests/test_tools_autocheck.py
@@ -1,0 +1,19 @@
+import tools_autocheck
+
+
+def test_status_flag_takes_precedence(monkeypatch):
+    monkeypatch.setattr(tools_autocheck, "AUTOCHECK_IDS", {"1"})
+    tool = {"id": "1", "autocheck": False}
+    assert not tools_autocheck.should_autocheck(tool)
+
+
+def test_global_list_used_when_no_flag(monkeypatch):
+    monkeypatch.setattr(tools_autocheck, "AUTOCHECK_IDS", {"2"})
+    tool = {"id": "2"}
+    assert tools_autocheck.should_autocheck(tool)
+
+
+def test_none_returns_false(monkeypatch):
+    monkeypatch.setattr(tools_autocheck, "AUTOCHECK_IDS", set())
+    tool = {"id": "3"}
+    assert not tools_autocheck.should_autocheck(tool)

--- a/tests/test_tools_history.py
+++ b/tests/test_tools_history.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+import tools_history
+
+
+def test_append_tool_history_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "hist.jsonl"
+    entry1 = {"tool": "a", "action": "add"}
+    entry2 = {"tool": "b", "action": "remove"}
+    tools_history.append_tool_history(path, entry1)
+    tools_history.append_tool_history(path, entry2)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert json.loads(lines[0]) == entry1
+    assert json.loads(lines[1]) == entry2

--- a/tests/test_tools_templates.py
+++ b/tests/test_tools_templates.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import tools_templates
+
+
+def _write_template(path: Path, ident: str) -> None:
+    path.write_text(json.dumps({"id": ident}), encoding="utf-8")
+
+
+def test_limit_8x8(tmp_path: Path) -> None:
+    paths = []
+    for i in range(tools_templates.MAX_TEMPLATES + 1):
+        p = tmp_path / f"{i:03}.json"
+        _write_template(p, f"{i:03}")
+        paths.append(p)
+    with pytest.raises(ValueError):
+        tools_templates.load_templates(paths)
+
+
+def test_duplicate_detection(tmp_path: Path) -> None:
+    p1 = tmp_path / "a.json"
+    p2 = tmp_path / "b.json"
+    _write_template(p1, "01")
+    _write_template(p2, "01")
+    with pytest.raises(ValueError):
+        tools_templates.load_templates([p1, p2])
+
+
+def test_missing_file_is_ignored(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    result = tools_templates.load_templates([missing])
+    assert result == []

--- a/tools_autocheck.py
+++ b/tools_autocheck.py
@@ -1,0 +1,25 @@
+"""Helpers for determining if a tool should be automatically checked."""
+
+from __future__ import annotations
+
+from typing import Dict, Any, Set
+
+# Global set of tool identifiers that require auto checking when
+# no explicit flag is provided.
+AUTOCHECK_IDS: Set[str] = set()
+
+def should_autocheck(tool: Dict[str, Any]) -> bool:
+    """Return ``True`` when ``tool`` should be auto checked.
+
+    Precedence rules:
+    1. ``tool`` may contain an explicit ``autocheck`` boolean flag. When
+       present it takes precedence over global settings.
+    2. Otherwise, if the tool's ``id`` is present in :data:`AUTOCHECK_IDS`
+       the function returns ``True``.
+    3. If none of the above apply the function returns ``False``.
+    """
+    flag = tool.get("autocheck")
+    if flag is not None:
+        return bool(flag)
+    tool_id = tool.get("id")
+    return tool_id in AUTOCHECK_IDS

--- a/tools_history.py
+++ b/tools_history.py
@@ -1,0 +1,25 @@
+"""Utilities for tracking tool history in JSON Lines format."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def append_tool_history(path: Path, entry: Dict[str, Any]) -> None:
+    """Append ``entry`` as a JSON line to ``path``.
+
+    Parameters
+    ----------
+    path:
+        Destination file. Parents are created automatically.
+    entry:
+        Mapping that will be serialised to JSON. ``ensure_ascii`` is disabled
+        to preserve any non ASCII characters.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        json.dump(entry, fh, ensure_ascii=False)
+        fh.write("\n")

--- a/tools_templates.py
+++ b/tools_templates.py
@@ -1,0 +1,55 @@
+"""Utilities for reading tool templates.
+
+This module provides :func:`load_templates` which reads JSON files
+representing tool templates. Each template must contain a unique ``id``
+field. The loader enforces a maximum of 64 templates (8×8 limit) and will
+skip missing files gracefully. If duplicate ``id`` values are encountered
+or the limit is exceeded a :class:`ValueError` is raised.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Dict, Any
+
+MAX_TEMPLATES = 64  # 8x8 limit
+
+
+def load_templates(paths: Iterable[Path]) -> List[Dict[str, Any]]:
+    """Load templates from ``paths``.
+
+    Parameters
+    ----------
+    paths:
+        An iterable of file system paths pointing to JSON files. Missing
+        files are ignored.
+
+    Returns
+    -------
+    list of dict
+        Parsed templates.
+
+    Raises
+    ------
+    ValueError
+        If more than :data:`MAX_TEMPLATES` templates are loaded or
+        duplicate ``id`` values are encountered.
+    """
+    templates: Dict[str, Dict[str, Any]] = {}
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.exists():
+            # Gracefully ignore missing files.
+            continue
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        template_id = data.get("id")
+        if template_id is None:
+            raise ValueError("template missing 'id'")
+        if template_id in templates:
+            raise ValueError(f"duplicate template id: {template_id}")
+        templates[template_id] = data
+        if len(templates) > MAX_TEMPLATES:
+            raise ValueError("too many templates (limit 64)")
+    return list(templates.values())


### PR DESCRIPTION
## Summary
- add helper modules for tool templates, autocheck logic and history logging
- cover 8×8 limits, duplicates and missing file handling in templates
- check `should_autocheck` precedence between explicit flags and global list
- ensure tool history appends valid JSONL records

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_tools_autocheck.py tests/test_tools_history.py tests/test_tools_templates.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00a1661c08323a4fcd757cad13d58