### PR TITLE
Add tools configuration GUI and path-aware saving

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -3,6 +3,7 @@
 # Zmiany 1.6.17:
 # - Dodano przycisk w stopce otwierający changelog.
 # - Zapamiętywanie czasu ostatniego obejrzenia changeloga.
+# - Dodano w menu Ustawienia pozycję "Narzędzia" otwierającą konfigurację.
 # Poprzednio (1.6.16):
 # - Dodano przycisk „Magazyn” (wymaga gui_magazyn.open_panel_magazyn)
 # - Pasek nagłówka pokazuje kto jest zalogowany (label po prawej)


### PR DESCRIPTION
## Summary
- add `gui_tools_config.py` for editing tool task collections with path-aware atomic JSON writes and cache refresh
- link settings menu to open the new tools configuration window
- test structure and save logic for tool collections
- document settings menu entry for tool configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00f8a83608323975c321ca50c3c4b