### PR TITLE
Validate unique IDs for tool tasks

### DIFF
--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -42,12 +42,28 @@ def _load_tool_tasks() -> list[dict]:
     types = data.get("types") or []
     if len(types) > 8:
         raise ToolTasksError("Przekroczono maksymalną liczbę typów (8)")
+
+    type_ids: set[str] = set()
     for typ in types:
+        type_id = typ.get("id")
+        if type_id in type_ids:
+            raise ToolTasksError(f"Powtarzające się id typu: {type_id}")
+        type_ids.add(type_id)
+
         statuses = typ.get("statuses") or []
         if len(statuses) > 8:
             raise ToolTasksError(
-                f"Przekroczono maksymalną liczbę statusów dla typu {typ.get('id')}"
+                f"Przekroczono maksymalną liczbę statusów dla typu {type_id}"
             )
+
+        status_ids: set[str] = set()
+        for status in statuses:
+            status_id = status.get("id")
+            if status_id in status_ids:
+                raise ToolTasksError(
+                    f"Powtarzające się id statusu {status_id} w typie {type_id}"
+                )
+            status_ids.add(status_id)
     _TOOL_TASKS_CACHE = types
     return types
 

--- a/tests/test_logika_zadan_tasks.py
+++ b/tests/test_logika_zadan_tasks.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import logika_zadan as LZ
+
+
+def _write(tmp_path, content):
+    path = tmp_path / "zadania_narzedzia.json"
+    path.write_text(json.dumps(content, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def test_duplicate_type_ids(monkeypatch, tmp_path):
+    data = {"types": [{"id": "T1", "statuses": []}, {"id": "T1", "statuses": []}]}
+    path = _write(tmp_path, data)
+    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    LZ._TOOL_TASKS_CACHE = None
+    with pytest.raises(LZ.ToolTasksError) as exc:
+        LZ.get_tool_types_list()
+    assert "Powtarzające się id typu" in str(exc.value)
+
+
+def test_duplicate_status_ids(monkeypatch, tmp_path):
+    data = {
+        "types": [
+            {
+                "id": "T1",
+                "statuses": [
+                    {"id": "S1", "tasks": []},
+                    {"id": "S1", "tasks": []},
+                ],
+            }
+        ]
+    }
+    path = _write(tmp_path, data)
+    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    LZ._TOOL_TASKS_CACHE = None
+    with pytest.raises(LZ.ToolTasksError) as exc:
+        LZ.get_statuses_for_type("T1")
+    assert "Powtarzające się id statusu" in str(exc.value)


### PR DESCRIPTION
## Summary
- enforce unique type and status IDs in tool task loading
- add tests guarding against duplicate tool task identifiers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0290397c48323bb119d912d9c3d4e