### PR TITLE
feat: support collection-based tool task schema

### DIFF
--- a/data/zadania_narzedzia.json
+++ b/data/zadania_narzedzia.json
@@ -1,3 +1,10 @@
 {
-  "types": []
+  "collections": {
+    "NN": {
+      "types": []
+    },
+    "ST": {
+      "types": []
+    }
+  }
 }

--- a/data/zadania_narzedzia.json.sample
+++ b/data/zadania_narzedzia.json.sample
@@ -1,48 +1,54 @@
 {
-  "types": [
-    {
-      "id": "press",
-      "name": "Prasa",
-      "statuses": [
+  "collections": {
+    "NN": {
+      "types": [
         {
-          "id": "prod",
-          "name": "Produkcja",
-          "tasks": [
-            "Kontrola poziomu oleju",
-            "Test na sucho"
+          "id": "press",
+          "name": "Prasa",
+          "statuses": [
+            {
+              "id": "prod",
+              "name": "Produkcja",
+              "tasks": [
+                "Kontrola poziomu oleju",
+                "Test na sucho"
+              ]
+            },
+            {
+              "id": "serwis",
+              "name": "Serwis",
+              "tasks": [
+                "Czyszczenie",
+                "Przegląd elementów"
+              ]
+            }
           ]
         },
         {
-          "id": "serwis",
-          "name": "Serwis",
-          "tasks": [
-            "Czyszczenie",
-            "Przegląd elementów"
+          "id": "cutter",
+          "name": "Wykrawarka",
+          "statuses": [
+            {
+              "id": "prod",
+              "name": "Produkcja",
+              "tasks": [
+                "Kontrola matrycy"
+              ]
+            },
+            {
+              "id": "serwis",
+              "name": "Serwis",
+              "tasks": [
+                "Wymiana noży",
+                "Smarowanie"
+              ]
+            }
           ]
         }
       ]
     },
-    {
-      "id": "cutter",
-      "name": "Wykrawarka",
-      "statuses": [
-        {
-          "id": "prod",
-          "name": "Produkcja",
-          "tasks": [
-            "Kontrola matrycy"
-          ]
-        },
-        {
-          "id": "serwis",
-          "name": "Serwis",
-          "tasks": [
-            "Wymiana noży",
-            "Smarowanie"
-          ]
-        }
-      ]
+    "ST": {
+      "types": []
     }
-  ]
+  }
 }
-

--- a/logi_gui.txt
+++ b/logi_gui.txt
@@ -2262,3 +2262,22 @@
 [2025-09-09 13:20:53] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_rezerwuj_materialy_braki_0/magazyn.json
 [2025-09-09 13:20:53] Upsert item MAT-B (B)
 [2025-09-09 13:20:53] Nie udało się wczytać data/zadania_narzedzia.json: 'str' object has no attribute 'get'
+[2025-09-09 18:56:47] [PROFILE] Nie można przeskalować avatara ghost: 'Img' object has no attribute 'thumbnail'
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_rezerwuj_partial0/magazyn.json
+[2025-09-09 18:56:47] Upsert item MAT-X (Test)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_alert_after_zuzycie_below0/magazyn.json
+[2025-09-09 18:56:47] Upsert item MAT-AL (Aluminium)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_load_magazyn_adds_progi_a0/magazyn.json
+[2025-09-09 18:56:47] Upsert item X (X)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_set_order_persists0/magazyn.json
+[2025-09-09 18:56:47] Upsert item A (A)
+[2025-09-09 18:56:47] Upsert item B (B)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_delete_item0/magazyn.json
+[2025-09-09 18:56:47] Upsert item A (A)
+[2025-09-09 18:56:47] Upsert item B (B)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_parallel_saves_are_serial0/magazyn.json
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_rezerwuj_materialy_update0/magazyn.json
+[2025-09-09 18:56:47] Upsert item MAT-A (A)
+[2025-09-09 18:56:47] Tworzę nowy magazyn: /tmp/pytest-of-root/pytest-0/test_rezerwuj_materialy_braki_0/magazyn.json
+[2025-09-09 18:56:47] Upsert item MAT-B (B)
+[2025-09-09 18:56:48] [WM-DBG][TASKS] Nie udało się wczytać data/zadania_narzedzia.json: 'str' object has no attribute 'get'

--- a/logi_magazyn.txt
+++ b/logi_magazyn.txt
@@ -23,3 +23,5 @@
 {"ts": "2025-09-06 14:18:01", "akcja": "rezerwacja_materialu", "dane": {"item_id": "MAT-A", "ilosc": 6.0}}
 {"ts": "2025-09-09 13:20:52", "akcja": "rezerwacja", "dane": {"item_id": "MAT-X", "ilosc": 5.0, "by": "test", "ctx": "pytest"}}
 {"ts": "2025-09-09 13:20:53", "akcja": "rezerwacja_materialu", "dane": {"item_id": "MAT-A", "ilosc": 6.0}}
+{"ts": "2025-09-09 18:56:47", "akcja": "rezerwacja", "dane": {"item_id": "MAT-X", "ilosc": 5.0, "by": "test", "ctx": "pytest"}}
+{"ts": "2025-09-09 18:56:47", "akcja": "rezerwacja_materialu", "dane": {"item_id": "MAT-A", "ilosc": 6.0}}

--- a/tests/test_logika_zadan_tasks.py
+++ b/tests/test_logika_zadan_tasks.py
@@ -15,30 +15,43 @@ def _write(tmp_path, content):
 
 
 def test_duplicate_type_ids(monkeypatch, tmp_path):
-    data = {"types": [{"id": "T1", "statuses": []}, {"id": "T1", "statuses": []}]}
-    path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
-    with pytest.raises(LZ.ToolTasksError) as exc:
-        LZ.get_tool_types_list()
-    assert "Powtarzające się id typu" in str(exc.value)
-
-
-def test_duplicate_status_ids(monkeypatch, tmp_path):
     data = {
-        "types": [
-            {
-                "id": "T1",
-                "statuses": [
-                    {"id": "S1", "tasks": []},
-                    {"id": "S1", "tasks": []},
-                ],
+        "collections": {
+            "NN": {
+                "types": [
+                    {"id": "T1", "statuses": []},
+                    {"id": "T1", "statuses": []},
+                ]
             }
-        ]
+        }
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
     LZ._TOOL_TASKS_CACHE = None
     with pytest.raises(LZ.ToolTasksError) as exc:
-        LZ.get_statuses_for_type("T1")
+        LZ.get_tool_types_list(collection="NN")
+    assert "Powtarzające się id typu" in str(exc.value)
+
+
+def test_duplicate_status_ids(monkeypatch, tmp_path):
+    data = {
+        "collections": {
+            "NN": {
+                "types": [
+                    {
+                        "id": "T1",
+                        "statuses": [
+                            {"id": "S1", "tasks": []},
+                            {"id": "S1", "tasks": []},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    path = _write(tmp_path, data)
+    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    LZ._TOOL_TASKS_CACHE = None
+    with pytest.raises(LZ.ToolTasksError) as exc:
+        LZ.get_statuses_for_type("T1", collection="NN")
     assert "Powtarzające się id statusu" in str(exc.value)

--- a/tests/test_tools_types_statuses.py
+++ b/tests/test_tools_types_statuses.py
@@ -6,14 +6,16 @@ def test_zadania_narzedzia_limits_and_structure():
     path = Path("data/zadania_narzedzia.json")
     with path.open(encoding="utf-8") as f:
         data = json.load(f)
-    types = data.get("types")
-    assert isinstance(types, list)
-    assert len(types) <= 8, "Limit typów przekroczony"
-    for typ in types:
-        assert {"id", "name", "statuses"} <= typ.keys()
-        statuses = typ.get("statuses") or []
-        assert len(statuses) <= 8, f"Za dużo statusów dla typu {typ.get('id')}"
-        for st in statuses:
-            assert {"id", "name", "tasks"} <= st.keys()
-            tasks = st.get("tasks") or []
-            assert isinstance(tasks, list)
+    collections = data.get("collections")
+    assert isinstance(collections, dict)
+    for coll in collections.values():
+        types = coll.get("types") or []
+        assert len(types) <= 8, "Limit typów przekroczony"
+        for typ in types:
+            assert {"id", "name", "statuses"} <= typ.keys()
+            statuses = typ.get("statuses") or []
+            assert len(statuses) <= 8, f"Za dużo statusów dla typu {typ.get('id')}"
+            for st in statuses:
+                assert {"id", "name", "tasks"} <= st.keys()
+                tasks = st.get("tasks") or []
+                assert isinstance(tasks, list)


### PR DESCRIPTION
## Summary
- migrate zadania_narzedzia.json to collection-based schema and auto-create missing collections
- update tool task API to respect collections
- adjust tests for new schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c077079ea08323a56b545cf2e81c90