### PR TITLE
Add require_reauth magazyn setting

### DIFF
--- a/config.defaults.json
+++ b/config.defaults.json
@@ -103,6 +103,9 @@
     },
     "modes": {}
   },
+  "magazyn": {
+    "require_reauth": true
+  },
   "magazyn_rezerwacje": true,
   "magazyn_precision_mb": 3,
   "produkty_dir": "data/produkty/",

--- a/config.json
+++ b/config.json
@@ -25,5 +25,8 @@
   },
   "backup": {
     "keep_last": 10
+  },
+  "magazyn": {
+    "require_reauth": true
   }
 }

--- a/config_manager.py
+++ b/config_manager.py
@@ -136,6 +136,10 @@ class ConfigManager:
         self.secrets = self._load_json(SECRETS_PATH) or {}
         self._ensure_dirs()
         self.merged = self._merge_all()
+        print(
+            "[WM-DBG][SETTINGS] require_reauth="
+            f"{self.get('magazyn.require_reauth', True)}"
+        )
         self._validate_all()
 
         # Settings for unsaved changes handling

--- a/settings_schema.json
+++ b/settings_schema.json
@@ -178,6 +178,12 @@
               "label": "Precyzja (MB)",
               "min": 0,
               "max": 6
+            },
+            {
+              "key": "magazyn.require_reauth",
+              "type": "bool",
+              "label": "Re-auth przy zmianach",
+              "default": true
             }
           ]
         },


### PR DESCRIPTION
## Summary
- add `magazyn.require_reauth` default and user config entries
- expose new setting in schema and log setting when configs merge

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0770e0078832397d543b196d70131