### PR TITLE
Add tests for tool template limits and autocheck precedence

### DIFF
--- a/tests/test_tools_autocheck.py
+++ b/tests/test_tools_autocheck.py
@@ -25,11 +25,19 @@ def test_entry_flag_takes_precedence(write_entry):
     assert not tools_autocheck.should_autocheck("s1", "col", config)
 
 
+def test_entry_flag_true_overrides_global(write_entry):
+    config = {"tools": {"auto_check_on_status_global": []}}
+    write_entry("col", "s4", {"auto_check_on_entry": True})
+    assert tools_autocheck.should_autocheck("s4", "col", config)
+
+
 def test_global_list_used_when_no_entry_flag(write_entry):
     config = {"tools": {"auto_check_on_status_global": ["s2"]}}
+    write_entry("col", "s2", {"other": 1})
     assert tools_autocheck.should_autocheck("s2", "col", config)
 
 
 def test_none_returns_false(write_entry):
     config = {"tools": {"auto_check_on_status_global": []}}
+    write_entry("col", "s3", {"other": 2})
     assert not tools_autocheck.should_autocheck("s3", "col", config)

--- a/tests/test_tools_templates.py
+++ b/tests/test_tools_templates.py
@@ -12,7 +12,8 @@ def template_factory(tmp_path: Path):
         col_dir = tmp_path / collection
         col_dir.mkdir(exist_ok=True)
         path = col_dir / name
-        path.write_text(json.dumps({"id": ident}, indent=2), encoding="utf-8")
+        payload = {"id": ident, "name": f"Tool {ident}"}
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return path
 
     return _create
@@ -27,9 +28,9 @@ def test_limit_8x8(template_factory) -> None:
         tools_templates.load_templates(paths)
 
 
-def test_duplicate_detection(template_factory) -> None:
-    p1 = template_factory("a.json", "01")
-    p2 = template_factory("b.json", "01")
+def test_duplicate_detection_within_collection(template_factory) -> None:
+    p1 = template_factory("a.json", "01", collection="col")
+    p2 = template_factory("b.json", "01", collection="col")
     with pytest.raises(ValueError):
         tools_templates.load_templates([p1, p2])
 


### PR DESCRIPTION
## Summary
- expand tool template tests to ensure 8×8 limit and per-collection duplicate detection
- extend autocheck tests for entry flag precedence and global fallback

## Testing
- `pytest tests/test_tools_templates.py tests/test_tools_autocheck.py -q`
- `pytest -q` *(fails: KeyError in test_logika_magazyn.py::test_rezerwuj_partial, AssertionError in test_logika_magazyn.py::test_delete_item)*

------
https://chatgpt.com/codex/tasks/task_e_68c106dd9fdc8323ae2c8049622f1265