### PR TITLE
Add magazyn I/O helpers and history logging

### DIFF
--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -11,6 +11,8 @@ from io_utils import read_json, write_json
 from logger import log_akcja
 
 MAGAZYN_PATH = "data/magazyn/magazyn.json"
+MAGAZYN_HISTORY_PATH = "data/magazyn/magazyn_history.json"
+PRZYJECIA_PATH = "data/magazyn/przyjecia.json"
 
 
 def load_magazyn(path: str = MAGAZYN_PATH) -> Dict[str, Any]:
@@ -110,6 +112,23 @@ def append_history(item_id: str, entry: Dict[str, Any], path_or_items) -> Dict[s
 
     if data is not None:
         save_magazyn(data, path_or_items)
+
+    # Persist history to global logs
+    history_entry = dict(norm)
+    history_entry["item_id"] = item_id
+
+    hist = read_json(MAGAZYN_HISTORY_PATH)
+    if not isinstance(hist, list):
+        hist = []
+    hist.append(history_entry)
+    write_json(MAGAZYN_HISTORY_PATH, hist)
+
+    if norm["op"] == "PZ":
+        pz = read_json(PRZYJECIA_PATH)
+        if not isinstance(pz, list):
+            pz = []
+        pz.append(history_entry)
+        write_json(PRZYJECIA_PATH, pz)
 
     return norm
 

--- a/test_magazyn_io_history.py
+++ b/test_magazyn_io_history.py
@@ -1,0 +1,23 @@
+import magazyn_io as mio
+from io_utils import read_json
+
+
+def test_append_history_persists_global_logs(tmp_path, monkeypatch):
+    hist_path = tmp_path / "magazyn_history.json"
+    pz_path = tmp_path / "przyjecia.json"
+    monkeypatch.setattr(mio, "MAGAZYN_HISTORY_PATH", str(hist_path))
+    monkeypatch.setattr(mio, "PRZYJECIA_PATH", str(pz_path))
+
+    items = {}
+    mio.append_history("A", {"user": "u", "op": "ZW", "qty": 1, "comment": "c"}, items)
+    assert hist_path.exists()
+    hist = read_json(str(hist_path))
+    assert hist and hist[-1]["item_id"] == "A"
+    assert not pz_path.exists()
+
+    mio.append_history("A", {"user": "u", "op": "PZ", "qty": 2, "comment": "d"}, items)
+    hist = read_json(str(hist_path))
+    pz = read_json(str(pz_path))
+    assert hist and hist[-1]["item_id"] == "A" and hist[-1]["op"] == "PZ"
+    assert pz and pz[-1]["op"] == "PZ"
+


### PR DESCRIPTION
## Summary
- ensure magazyn history entries are written to global history and przyjecia logs
- add regression test for append_history persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c10bf1d72c8323a2795495fed70418