### PR TITLE
Add PZ window and warehouse I/O utilities

### DIFF
--- a/logika_magazyn.py
+++ b/logika_magazyn.py
@@ -28,6 +28,7 @@ OP_TRANSLATIONS = {
     "RESERVE": "rezerwacja",
     "UNRESERVE": "zwolnienie",
     "CREATE": "utworzenie",
+    "DELETE": "usun",
 }
 try:
     from tkinter import messagebox
@@ -447,7 +448,7 @@ def delete_item(item_id: str, uzytkownik: str = "system", kontekst=None) -> bool
             raise KeyError(f"Brak pozycji {item_id} w magazynie")
         item = items[item_id]
         try:
-            _append_history(items, item_id, uzytkownik, "usun", float(item.get("stan", 0)), kontekst)
+            _append_history(items, item_id, uzytkownik, "DELETE", float(item.get("stan", 0)), kontekst)
         except TypeError:
             _append_history({
                 "operacja": "usun",

--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -14,6 +14,7 @@ ALLOWED_OPS = {
     "RW",
     "RESERVE",
     "UNRESERVE",
+    "DELETE",
 }
 
 MAGAZYN_PATH = "data/magazyn/magazyn.json"

--- a/test_logika_magazyn.py
+++ b/test_logika_magazyn.py
@@ -134,9 +134,14 @@ def test_set_order_persists(tmp_path, monkeypatch):
 def test_delete_item(tmp_path, monkeypatch):
     monkeypatch.setattr(lm, 'MAGAZYN_PATH', str(tmp_path / 'magazyn.json'))
     logs = []
-    history = []
+    history_ops = []
     monkeypatch.setattr(lm, '_log_mag', lambda a, d: logs.append((a, d)))
-    monkeypatch.setattr(lm, '_append_history', lambda e: history.append(e))
+
+    def fake_append_history(items, item_id, user, op, qty, comment, ts=None):
+        history_ops.append(op)
+        return {"ts": "0", "user": user, "op": op, "qty": qty, "comment": comment}
+
+    monkeypatch.setattr(lm, 'append_history', fake_append_history)
 
     lm.load_magazyn()
     lm.upsert_item({
@@ -160,7 +165,7 @@ def test_delete_item(tmp_path, monkeypatch):
     m = lm.load_magazyn()
     assert 'A' not in m['items']
     assert 'A' not in m['meta']['order']
-    assert history and history[-1]['operacja'] == 'usun'
+    assert history_ops and history_ops[-1] == 'DELETE'
     assert any(a == 'usun' and d['item_id'] == 'A' for a, d in logs)
 
     with pytest.raises(KeyError):


### PR DESCRIPTION
## Summary
- add DELETE op code for item removal and translate to `usun`
- cover delete_item history via test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c10bf22e5c83238ebca3dd548294a5