### PR TITLE
feat: support collection-oriented tool tasks schema

### DIFF
--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -116,11 +116,11 @@ def _load_tool_tasks(force: bool = False) -> dict[str, list[dict]]:
 
 
 def save_tool_tasks(data: dict) -> None:
-    """Zapisz definicje zadań do :data:`TOOL_TASKS_PATH`.
+    """Zapisuje definicje zadań do :data:`TOOL_TASKS_PATH`.
 
     Tworzy brakujący plik zgodnie z ustawieniami ``tools.collections_enabled``.
-    Akceptuje zarówno nową strukturę z kluczem ``collections`` jak i
-    legacyjny format z ``types``.
+    Akceptuje zarówno nową strukturę z kluczem ``collections`` jak i stary
+    format z ``types``.
     """
 
     cfg = ConfigManager()


### PR DESCRIPTION
## Summary
- expand zadania_narzedzia.json sample with collection-based structure for NN and ST
- add `save_tool_tasks` helper that creates missing task files and migrates legacy format
- adjust tests for new schema and history field names
- refine `save_tool_tasks` comment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c10c03aa408323bfc7a1b1dc54e53c