### PR TITLE
Validate warehouse history operations and timestamps

### DIFF
--- a/gui_magazyn_add.py
+++ b/gui_magazyn_add.py
@@ -114,7 +114,12 @@ def open_window(parent):
         data.setdefault("meta", {}).setdefault("order", []).append(item_id)
 
         magazyn_io.append_history(
-            data["items"], item_id, user_login or "", "CREATE", stan, comment
+            data["items"],
+            item_id,
+            user=user_login or "",
+            op="CREATE",
+            qty=stan,
+            comment=comment,
         )
 
         print("[WM-DBG] przed zapisem")

--- a/gui_magazyn_pz.py
+++ b/gui_magazyn_pz.py
@@ -1,0 +1,41 @@
+"""Helpers for recording goods receipts (PZ) in the warehouse GUI."""
+
+from __future__ import annotations
+
+import logika_magazyn as LM
+import magazyn_io
+
+
+def record_pz(item_id: str, qty: float, user: str, comment: str = "") -> None:
+    """Register a goods receipt for ``item_id``.
+
+    Parameters
+    ----------
+    item_id:
+        Identifier of the item in the warehouse.
+    qty:
+        Received quantity (positive).
+    user:
+        Login of the user performing the operation.
+    comment:
+        Optional free-form comment.
+    """
+
+    data = LM.load_magazyn()
+    items = data.get("items") or {}
+    if item_id not in items:
+        raise KeyError(f"Brak pozycji {item_id} w magazynie")
+
+    qty_f = float(qty)
+    items[item_id]["stan"] = float(items[item_id].get("stan", 0)) + qty_f
+
+    magazyn_io.append_history(
+        items,
+        item_id,
+        user=user,
+        op="PZ",
+        qty=qty_f,
+        comment=comment,
+    )
+    LM.save_magazyn(data)
+

--- a/logika_magazyn.py
+++ b/logika_magazyn.py
@@ -250,7 +250,14 @@ def _append_history(*args, **kwargs):
     items, item_id, uzytkownik, op, ilosc, *rest = args
     kontekst = rest[0] if rest else kwargs.get("kontekst")
 
-    append_history(items, item_id, uzytkownik, op, ilosc, kontekst or "")
+    append_history(
+        items,
+        item_id,
+        user=uzytkownik,
+        op=op,
+        qty=ilosc,
+        comment=kontekst or "",
+    )
 
     mapping = {
         "RESERVE": "rezerwacja",
@@ -480,7 +487,9 @@ def zuzyj(item_id, ilosc, uzytkownik, kontekst=None):
                 f"Niewystarczający stan {item_id}: {it['stan']} < {dok}"
             )
         it["stan"] -= dok
-        _append_history(m["items"], item_id, uzytkownik, "RW", dok, kontekst)
+        _append_history(
+            m["items"], item_id, uzytkownik, "RW", dok, kontekst=kontekst
+        )
         save_magazyn(m)
         zapisz_stan_magazynu(m)
         _log_mag(
@@ -502,7 +511,9 @@ def zwrot(item_id, ilosc, uzytkownik, kontekst=None):
             raise KeyError(f"Brak pozycji {item_id} w magazynie")
         dok = float(ilosc)
         it["stan"] += dok
-        _append_history(m["items"], item_id, uzytkownik, "ZW", dok, kontekst)
+        _append_history(
+            m["items"], item_id, uzytkownik, "ZW", dok, kontekst=kontekst
+        )
         save_magazyn(m)
         zapisz_stan_magazynu(m)
         _log_mag(
@@ -531,7 +542,9 @@ def rezerwuj(item_id, ilosc, uzytkownik, kontekst=None):
         if faktyczne <= 0:
             return 0.0
         it["rezerwacje"] = float(it.get("rezerwacje", 0.0)) + faktyczne
-        _append_history(m["items"], item_id, uzytkownik, "RESERVE", faktyczne, kontekst)
+        _append_history(
+            m["items"], item_id, uzytkownik, "RESERVE", faktyczne, kontekst=kontekst
+        )
         save_magazyn(m)
         zapisz_stan_magazynu(m)
         _log_mag(
@@ -554,7 +567,9 @@ def zwolnij_rezerwacje(item_id, ilosc, uzytkownik, kontekst=None):
         if float(it.get("rezerwacje", 0.0)) < dok:
             raise ValueError(f"Nie można zwolnić {dok}, rezerwacje={it.get('rezerwacje',0.0)}")
         it["rezerwacje"] = float(it.get("rezerwacje", 0.0)) - dok
-        _append_history(m["items"], item_id, uzytkownik, "UNRESERVE", dok, kontekst)
+        _append_history(
+            m["items"], item_id, uzytkownik, "UNRESERVE", dok, kontekst=kontekst
+        )
         save_magazyn(m)
         zapisz_stan_magazynu(m)
         _log_mag(
@@ -597,7 +612,14 @@ def rezerwuj_materialy(bom, ilosc):
             else:
                 zuzyte = req
                 it["stan"] = stan - req
-            _append_history(items, kod, "system", "RESERVE", zuzyte, "rezerwuj_materialy")
+            _append_history(
+                items,
+                kod,
+                "system",
+                "RESERVE",
+                zuzyte,
+                kontekst="rezerwuj_materialy",
+            )
             _log_mag("rezerwacja_materialu", {"item_id": kod, "ilosc": zuzyte})
         save_magazyn(m)
         zapisz_stan_magazynu(m)

--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timezone
-from typing import Dict, Any
+from typing import Any, Dict
 
 ALLOWED_OPS = {
     "CREATE",
@@ -62,15 +62,24 @@ def append_history(
     an additional record is stored in :data:`PRZYJECIA_PATH`.
     """
 
+    op = op.upper()
     if op not in ALLOWED_OPS:
         raise ValueError(f"Unknown op: {op}")
+
     qty = float(qty)
     if qty <= 0:
         raise ValueError("qty must be > 0")
-    if ts is None:
+
+    if not ts:
         ts = datetime.now(timezone.utc).isoformat()
 
-    entry = {"ts": ts, "user": user, "op": op, "qty": qty, "comment": comment}
+    entry = {
+        "ts": ts,
+        "user": user,
+        "op": op,
+        "qty": qty,
+        "comment": comment,
+    }
 
     item = items.setdefault(item_id, {})
     history = item.setdefault("historia", [])


### PR DESCRIPTION
## Summary
- restrict warehouse history operations to known types and auto-fill missing timestamps
- pass explicit user, operation, quantity and comment when recording history entries
- add helper to register PZ receipts through the GUI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c10c23f36483239786464c6a512b2c