### PR TITLE
feat(gui): add tools configuration window

### DIFF
--- a/gui_tools_config.py
+++ b/gui_tools_config.py
@@ -401,6 +401,12 @@ class ToolsConfigWindow(tk.Toplevel):
             except OSError:
                 pass
             return
+
+        try:
+            __import__("logika_zadan").invalidate_cache()
+        except Exception:  # pragma: no cover
+            logger.warning("invalidate_cache failed", exc_info=True)
+
         if self.on_save:
             try:
                 self.on_save()
@@ -410,7 +416,16 @@ class ToolsConfigWindow(tk.Toplevel):
 
 
 def open_tools_config(master: tk.Widget | None = None, on_save=None) -> ToolsConfigWindow:
-    """Convenience function to open :class:`ToolsConfigWindow`."""
+    """Convenience function to open :class:`ToolsConfigWindow`.
 
+    When *on_save* is ``None`` the function connects the window's callback
+    to :func:`logika_zadan.invalidate_cache` so that other parts of the
+    application see updated definitions immediately after saving.
+    """
+
+    if on_save is None:
+        from logika_zadan import invalidate_cache
+
+        on_save = invalidate_cache
     return ToolsConfigWindow(master=master, on_save=on_save)
 


### PR DESCRIPTION
## Summary
- add topmost GUI for editing tool tasks with list controls
- invalidate tool-task cache and provide default callback on save

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1101c0b9883238c7e6f076c6df7a4