### PR TITLE
Refresh tool task selections after configuration changes

### DIFF
--- a/gui_settings.py
+++ b/gui_settings.py
@@ -17,6 +17,7 @@ from config_manager import ConfigManager
 from gui_products import ProductsMaterialsTab
 import ustawienia_produkty_bom
 from ui_utils import _ensure_topmost
+import logika_zadan as LZ
 
 
 def _is_deprecated(node: dict) -> bool:
@@ -439,10 +440,14 @@ class SettingsPanel:
             )
             return
 
-        if hasattr(gui_tools_config, "open_window"):
-            win = gui_tools_config.open_window(parent)  # type: ignore[assignment]
+        callback = getattr(LZ, "invalidate_cache", lambda: None)
+
+        if hasattr(gui_tools_config, "open_tools_config"):
+            win = gui_tools_config.open_tools_config(parent, on_save=callback)  # type: ignore[assignment]
+        elif hasattr(gui_tools_config, "open_window"):
+            win = gui_tools_config.open_window(parent, on_save=callback)  # type: ignore[assignment]
         elif hasattr(gui_tools_config, "ToolsConfigWindow"):
-            win = gui_tools_config.ToolsConfigWindow(parent)  # type: ignore[assignment]
+            win = gui_tools_config.ToolsConfigWindow(parent, on_save=callback)  # type: ignore[assignment]
         else:  # pragma: no cover - unexpected api
             messagebox.showerror(
                 "Błąd",

--- a/tests/test_settings_tools_config_refresh.py
+++ b/tests/test_settings_tools_config_refresh.py
@@ -1,0 +1,50 @@
+import sys
+import types
+
+import gui_settings
+
+
+def test_open_tools_config_invalidates_cache(monkeypatch):
+    called = {"n": 0}
+
+    def invalidate():
+        called["n"] += 1
+
+    monkeypatch.setattr(
+        gui_settings, "LZ", types.SimpleNamespace(invalidate_cache=invalidate)
+    )
+    monkeypatch.setattr(
+        gui_settings,
+        "messagebox",
+        types.SimpleNamespace(showerror=lambda *a, **k: None, showwarning=lambda *a, **k: None),
+    )
+
+    dummy_module = types.SimpleNamespace()
+
+    class DummyWin:
+        def __init__(self, master=None, on_save=None):
+            self.on_save = on_save
+            dummy_module.instance = self
+
+        def transient(self, parent):  # pragma: no cover - no-op
+            pass
+
+        def attributes(self, *args, **kwargs):  # pragma: no cover - no-op
+            pass
+
+        def grab_set(self):  # pragma: no cover - no-op
+            pass
+
+    dummy_module.ToolsConfigWindow = DummyWin
+    monkeypatch.setitem(sys.modules, "gui_tools_config", dummy_module)
+
+    dummy_self = types.SimpleNamespace(
+        master=types.SimpleNamespace(winfo_toplevel=lambda: None)
+    )
+
+    gui_settings.SettingsPanel._open_tools_config(dummy_self)
+
+    dummy_module.instance.on_save()
+
+    assert called["n"] == 1
+


### PR DESCRIPTION
## Summary
- Invalidate task cache when opening the tools configuration and wire callback so saving the editor refreshes collection/type/status selections.
- Add regression test ensuring that saving the tool task configuration triggers cache invalidation.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1101ae35883238f8beed0505d5103