### PR TITLE
Ensure tool tasks schema initialization and migration

### DIFF
--- a/data/zadania_narzedzia.json.sample
+++ b/data/zadania_narzedzia.json.sample
@@ -1,51 +1,7 @@
 {
   "collections": {
     "NN": {
-      "types": [
-        {
-          "id": "press",
-          "name": "Prasa",
-          "statuses": [
-            {
-              "id": "prod",
-              "name": "Produkcja",
-              "tasks": [
-                "Kontrola poziomu oleju",
-                "Test na sucho"
-              ]
-            },
-            {
-              "id": "serwis",
-              "name": "Serwis",
-              "tasks": [
-                "Czyszczenie",
-                "Przegląd elementów"
-              ]
-            }
-          ]
-        },
-        {
-          "id": "cutter",
-          "name": "Wykrawarka",
-          "statuses": [
-            {
-              "id": "prod",
-              "name": "Produkcja",
-              "tasks": [
-                "Kontrola matrycy"
-              ]
-            },
-            {
-              "id": "serwis",
-              "name": "Serwis",
-              "tasks": [
-                "Wymiana noży",
-                "Smarowanie"
-              ]
-            }
-          ]
-        }
-      ]
+      "types": []
     },
     "ST": {
       "types": []

--- a/gui_tools_config.py
+++ b/gui_tools_config.py
@@ -386,6 +386,9 @@ class ToolsConfigWindow(tk.Toplevel):
     # Saving ---------------------------------------------------------------
     def _save(self) -> None:
         path = os.path.join("data", "zadania_narzedzia.json")
+        collections = self.cfg.get("tools.collections_enabled", []) or []
+        for cid in collections:
+            self.data.setdefault(cid, {"types": []})
         payload = {"collections": self.data}
         tmp = path + ".tmp"
         try:

--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -67,13 +67,20 @@ def _load_tool_tasks(force: bool = False) -> dict[str, list[dict]]:
         data = {"collections": {cid: {"types": []} for cid in enabled}}
         _save_tasks_file(data)
 
-    if "types" in data and "collections" not in data:
+    if isinstance(data, list):
+        types = data
+        data = {"collections": {cid: {"types": []} for cid in enabled}}
+        data["collections"].setdefault(default_coll, {"types": []})["types"] = types
+        _save_tasks_file(data)
+    elif "types" in data and "collections" not in data:
         types = data.get("types") or []
         data = {"collections": {cid: {"types": []} for cid in enabled}}
         data["collections"].setdefault(default_coll, {"types": []})["types"] = types
         _save_tasks_file(data)
 
-    collections: dict = data.get("collections") or {}
+    collections = data.get("collections") or {}
+    if not isinstance(collections, dict):
+        raise ToolTasksError("Nieprawidłowa struktura kolekcji")
     changed = False
     for cid in enabled:
         if cid not in collections:


### PR DESCRIPTION
## Summary
- replace tool tasks sample with collection-based schema
- auto-create missing collections when saving tool tasks
- migrate legacy tool task formats on load and validate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1101d51088323b4bfdd66ff22e607