### PR TITLE
fix: remove outdated marker comment

### DIFF
--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -3,7 +3,6 @@
 # Zmiany 1.0.0:
 # - Pomost między zadaniami a magazynem: zużycie materiałów zdefiniowanych w zadaniu albo z definicji produktu
 # - API: consume_for_task(tool_id, task_dict, uzytkownik)
-# ⏹ KONIEC KODU
 
 import json
 import os


### PR DESCRIPTION
## Summary
- remove stray marker comment from `logika_zadan.py`
- restore accidentally modified log files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c112111a2c8323b2dfd4a18eeaed65