### PR TITLE
Track tool task definition mtime for cache invalidation

### DIFF
--- a/test_logika_zadan_tasks.py
+++ b/test_logika_zadan_tasks.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 
@@ -19,7 +20,7 @@ def test_limit_types(monkeypatch, tmp_path):
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     with pytest.raises(LZ.ToolTasksError):
         LZ.get_tool_types_list()
 
@@ -35,7 +36,7 @@ def test_limit_statuses(monkeypatch, tmp_path):
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     with pytest.raises(LZ.ToolTasksError):
         LZ.get_statuses_for_type("T1")
 
@@ -53,7 +54,7 @@ def test_get_tasks(monkeypatch, tmp_path):
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     assert LZ.get_tasks_for("T1", "S1") == ["a", "b"]
 
 
@@ -61,7 +62,7 @@ def test_force_reload(monkeypatch, tmp_path):
     data1 = {"types": [{"id": "T1", "name": "Old", "statuses": []}]}
     path = _write(tmp_path, data1)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     assert LZ.get_tool_types_list() == [{"id": "T1", "name": "Old"}]
 
     data2 = {"types": [{"id": "T1", "name": "New", "statuses": []}]}
@@ -69,4 +70,17 @@ def test_force_reload(monkeypatch, tmp_path):
 
     assert LZ.get_tool_types_list()[0]["name"] == "Old"
     assert LZ.get_tool_types_list(force=True)[0]["name"] == "New"
-    LZ._TOOL_TASKS_CACHE = None
+
+
+def test_reload_on_mtime_change(monkeypatch, tmp_path):
+    data1 = {"types": [{"id": "T1", "name": "Old", "statuses": []}]}
+    path = _write(tmp_path, data1)
+    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
+    assert LZ.get_tool_types_list() == [{"id": "T1", "name": "Old"}]
+
+    data2 = {"types": [{"id": "T1", "name": "New", "statuses": []}]}
+    path.write_text(json.dumps(data2, ensure_ascii=False, indent=2), encoding="utf-8")
+    prev_mtime = path.stat().st_mtime
+    os.utime(path, (prev_mtime + 1, prev_mtime + 1))
+    assert LZ.get_tool_types_list()[0]["name"] == "New"

--- a/tests/test_logika_zadan_tasks.py
+++ b/tests/test_logika_zadan_tasks.py
@@ -28,7 +28,7 @@ def test_duplicate_type_ids(monkeypatch, tmp_path):
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     with pytest.raises(LZ.ToolTasksError) as exc:
         LZ.get_tool_types_list(collection="NN")
     assert "Powtarzające się id typu" in str(exc.value)
@@ -52,7 +52,7 @@ def test_duplicate_status_ids(monkeypatch, tmp_path):
     }
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     with pytest.raises(LZ.ToolTasksError) as exc:
         LZ.get_statuses_for_type("T1", collection="NN")
     assert "Powtarzające się id statusu" in str(exc.value)
@@ -64,7 +64,7 @@ def test_migrate_plain_list(monkeypatch, tmp_path):
     path = tmp_path / "zadania_narzedzia.json"
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
-    LZ._TOOL_TASKS_CACHE = None
+    LZ.invalidate_cache()
     types = LZ.get_tool_types_list(collection="NN")
     assert types and types[0]["id"] == "T1"
     with path.open(encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- track modification time for `zadania_narzedzia.json` alongside cached definitions
- reload tool task definitions when file mtime changes
- reset cached data and stored mtime via `invalidate_cache`
- add regression test ensuring cache refresh on file update

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1195f3dd8832386f39630282f3240