### PR TITLE
Add sample tool task definitions for NN and ST

### DIFF
--- a/data/zadania_narzedzia.json
+++ b/data/zadania_narzedzia.json
@@ -1,10 +1,39 @@
 {
   "collections": {
     "NN": {
-      "types": []
+      "types": [
+        {
+          "id": "NN1",
+          "name": "Narzędzie NN",
+          "statuses": [
+            {
+              "id": "NOWE",
+              "name": "Nowe",
+              "tasks": [
+                "Kontrola wizualna",
+                "Test działania"
+              ]
+            }
+          ]
+        }
+      ]
     },
     "ST": {
-      "types": []
+      "types": [
+        {
+          "id": "ST1",
+          "name": "Narzędzie ST",
+          "statuses": [
+            {
+              "id": "READY",
+              "name": "Gotowe",
+              "tasks": [
+                "Sprawdź baterię"
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/tests/test_tools_types_statuses.py
+++ b/tests/test_tools_types_statuses.py
@@ -8,6 +8,18 @@ def test_zadania_narzedzia_limits_and_structure():
         data = json.load(f)
     collections = data.get("collections")
     assert isinstance(collections, dict)
+
+    for cid in ("NN", "ST"):
+        assert cid in collections, f"Brak kolekcji {cid}"
+        types = collections[cid].get("types") or []
+        assert types, f"Kolekcja {cid} nie zawiera typów"
+        assert any(t.get("statuses") for t in types), f"Kolekcja {cid} bez statusów"
+        assert any(
+            st.get("tasks")
+            for t in types
+            for st in t.get("statuses") or []
+        ), f"Kolekcja {cid} bez zadań"
+
     for coll in collections.values():
         types = coll.get("types") or []
         assert len(types) <= 8, "Limit typów przekroczony"


### PR DESCRIPTION
## Summary
- populate zadania_narzedzia.json with sample NN and ST collections including types, statuses, and tasks
- expand tests to verify required collections and non-empty structure

## Testing
- `pytest -q tests/test_tools_types_statuses.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1196175548323a7d53ae827ced583