### PR TITLE
Add tool task wrapper tests and GUI smoke tests

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -429,10 +429,18 @@ class PanelMagazyn(ttk.Frame):
             messagebox.showerror("Magazyn", f"Błąd drukowania: {e}")
 
     def _act_dodaj(self):
-        print("[WM-DBG] _act_dodaj")
+        """Open a minimal dialog for adding a warehouse item."""
+
+        win = tk.Toplevel(self)
+        win.title("Dodaj pozycję")
+        apply_theme(win)
 
     def _act_przyjecie(self):
-        print("[WM-DBG] _act_przyjecie")
+        """Open a minimal dialog for recording a goods receipt (PZ)."""
+
+        win = tk.Toplevel(self)
+        win.title("Przyjęcie (PZ)")
+        apply_theme(win)
 
     def _show_historia(self):
         iid = self._sel_id()

--- a/tests/test_gui_magazyn_smoke.py
+++ b/tests/test_gui_magazyn_smoke.py
@@ -1,0 +1,27 @@
+import types
+import gui_magazyn
+
+
+def test_add_and_pz_buttons_create_windows(monkeypatch):
+    created = []
+
+    class DummyToplevel:
+        def __init__(self, *args, **kwargs):
+            created.append(self)
+
+        def title(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        gui_magazyn,
+        "tk",
+        types.SimpleNamespace(Toplevel=DummyToplevel),
+    )
+    monkeypatch.setattr(gui_magazyn, "apply_theme", lambda *a, **k: None)
+
+    panel = object.__new__(gui_magazyn.PanelMagazyn)
+
+    gui_magazyn.PanelMagazyn._act_dodaj(panel)
+    gui_magazyn.PanelMagazyn._act_przyjecie(panel)
+
+    assert len(created) == 2

--- a/tests/test_tools_wrappers.py
+++ b/tests/test_tools_wrappers.py
@@ -1,0 +1,31 @@
+import logika_zadan as LZ
+
+
+def test_get_collections():
+    cfg = {"tools.collections_enabled": ["C1", "C2"]}
+    assert LZ.get_collections(cfg) == [
+        {"id": "C1", "name": "C1"},
+        {"id": "C2", "name": "C2"},
+    ]
+
+
+def test_get_tool_types_and_statuses_and_tasks(monkeypatch):
+    data = {
+        "C1": [
+            {
+                "id": "T1",
+                "statuses": [{"id": "S1", "tasks": ["A", "B"]}],
+            }
+        ]
+    }
+    monkeypatch.setattr(LZ, "_load_tool_tasks", lambda force=False: data)
+    LZ._TOOL_TASKS_CACHE = None
+    assert LZ.get_tool_types("C1") == [{"id": "T1", "name": "T1"}]
+    assert LZ.get_statuses("T1", "C1") == [{"id": "S1", "name": "S1"}]
+    assert LZ.get_tasks("T1", "S1", "C1") == ["A", "B"]
+
+
+def test_should_autocheck():
+    cfg = {"tools": {"auto_check_on_status_global": ["S1"]}}
+    assert LZ.should_autocheck("S1", "C1", cfg)
+    assert not LZ.should_autocheck("S2", "C1", cfg)


### PR DESCRIPTION
## Summary
- Implement minimal dialogs for warehouse add and PZ actions
- Add tests for tool task wrapper functions
- Add GUI smoke test for “+ Dodaj” and “PZ” buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1196459948323adebd4afc8981c42