### PR TITLE
Add warehouse add and receipt dialogs with tests

### DIFF
--- a/gui_magazyn_pz.py
+++ b/gui_magazyn_pz.py
@@ -118,7 +118,7 @@ def open_window(parent: tk.Widget) -> None:
 
         try:
             record_pz(item_id, qty, user_login, comment)
-        except Exception as e:  # pragma: no cover - błędy trudne do odwzorowania
+        except Exception as e:  # pragma: no cover - errors hard to reproduce
             messagebox.showerror("Błąd", str(e), parent=win)
             return
 


### PR DESCRIPTION
## Summary
- translate coverage pragma comment in goods receipt dialog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c11b1f2b788323b2a17aaa93301722