### PR TITLE
Handle invalid tool task definitions gracefully

### DIFF
--- a/tests/test_logika_zadan_tasks.py
+++ b/tests/test_logika_zadan_tasks.py
@@ -15,7 +15,7 @@ def _write(tmp_path, content):
     return path
 
 
-def test_duplicate_type_ids(monkeypatch, tmp_path):
+def test_duplicate_type_ids(monkeypatch, tmp_path, caplog):
     data = {
         "collections": {
             "NN": {
@@ -29,12 +29,12 @@ def test_duplicate_type_ids(monkeypatch, tmp_path):
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
     LZ.invalidate_cache()
-    with pytest.raises(LZ.ToolTasksError) as exc:
-        LZ.get_tool_types_list(collection="NN")
-    assert "Powtarzające się id typu" in str(exc.value)
+    with caplog.at_level("WARNING"):
+        assert LZ.get_tool_types_list(collection="NN") == []
+    assert "Powtarzające się id typu" in caplog.text
 
 
-def test_duplicate_status_ids(monkeypatch, tmp_path):
+def test_duplicate_status_ids(monkeypatch, tmp_path, caplog):
     data = {
         "collections": {
             "NN": {
@@ -53,9 +53,9 @@ def test_duplicate_status_ids(monkeypatch, tmp_path):
     path = _write(tmp_path, data)
     monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
     LZ.invalidate_cache()
-    with pytest.raises(LZ.ToolTasksError) as exc:
-        LZ.get_statuses_for_type("T1", collection="NN")
-    assert "Powtarzające się id statusu" in str(exc.value)
+    with caplog.at_level("WARNING"):
+        assert LZ.get_statuses_for_type("T1", collection="NN") == []
+    assert "Powtarzające się id statusu" in caplog.text
 
 
 def test_migrate_plain_list(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Avoid crashing on malformed `zadania_narzedzia.json`; log a warning and return empty data
- Allow tool type/status helpers to cope with missing definitions
- Adjust tests to expect warnings instead of exceptions when data is invalid

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c11c02146883238bb927a61ec93eb2