### PR TITLE
feat: add magazyn add dialog

### DIFF
--- a/gui_magazyn_add.py
+++ b/gui_magazyn_add.py
@@ -1,5 +1,9 @@
 # Plik: gui_magazyn_add.py
-# Wersja pliku: 1.0.0
+# Wersja pliku: 1.1.0
+# Zmiany 1.1.0:
+# - Przepisano okno na klasę ``MagazynAddDialog`` z opcjonalną re-autoryzacją
+#   i callbackiem ``on_saved``.
+#
 # Zmiany 1.0.0:
 # - Dodano okno dodawania pozycji magazynowej.
 
@@ -15,79 +19,113 @@ import logika_magazyn as LM
 _CFG = ConfigManager()
 
 
-def open_window(parent):
-    """Otwórz okno dialogowe dodawania pozycji magazynowej."""
-    win = tk.Toplevel(parent)
-    apply_theme(win)
-    win.title("Dodaj pozycję")
-    win.resizable(False, False)
+class MagazynAddDialog:
+    """Dialog umożliwiający dodanie nowej pozycji magazynowej."""
 
-    vars_ = {
-        "id": tk.StringVar(),
-        "nazwa": tk.StringVar(),
-        "typ": tk.StringVar(),
-        "jm": tk.StringVar(),
-        "stan": tk.StringVar(),
-        "min": tk.StringVar(),
-        "komentarz": tk.StringVar(),
-    }
+    def __init__(self, parent, on_saved=None):
+        self.parent = parent
+        self.on_saved = on_saved
 
-    frm = ttk.Frame(win, padding=12, style="WM.TFrame")
-    frm.grid(row=0, column=0, sticky="nsew")
-    win.columnconfigure(0, weight=1)
+        self.win = tk.Toplevel(parent)
+        apply_theme(self.win)
+        self.win.title("Dodaj pozycję")
+        self.win.resizable(False, False)
 
-    for r, (lbl, key) in enumerate(
-        [
+        self.vars = {
+            "id": tk.StringVar(),
+            "nazwa": tk.StringVar(),
+            "typ": tk.StringVar(),
+            "jednostka": tk.StringVar(),
+            "stan": tk.StringVar(),
+            "min_poziom": tk.StringVar(),
+        }
+
+        frm = ttk.Frame(self.win, padding=12, style="WM.TFrame")
+        frm.grid(row=0, column=0, sticky="nsew")
+        self.win.columnconfigure(0, weight=1)
+
+        fields = [
             ("ID", "id"),
             ("Nazwa", "nazwa"),
             ("Typ", "typ"),
-            ("J.m.", "jm"),
+            ("J.m.", "jednostka"),
             ("Stan pocz.", "stan"),
-            ("Minimum", "min"),
-            ("Komentarz", "komentarz"),
+            ("Minimum", "min_poziom"),
         ]
-    ):
-        ttk.Label(frm, text=f"{lbl}:", style="WM.TLabel").grid(row=r, column=0, sticky="w", pady=2)
-        ttk.Entry(frm, textvariable=vars_[key]).grid(row=r, column=1, sticky="ew", pady=2)
-    frm.columnconfigure(1, weight=1)
 
-    btns = ttk.Frame(win, style="WM.TFrame")
-    btns.grid(row=1, column=0, padx=12, pady=(4, 8), sticky="e")
+        for r, (lbl, key) in enumerate(fields):
+            ttk.Label(frm, text=f"{lbl}:", style="WM.TLabel").grid(
+                row=r, column=0, sticky="w", pady=2
+            )
+            ttk.Entry(frm, textvariable=self.vars[key]).grid(
+                row=r, column=1, sticky="ew", pady=2
+            )
+        frm.columnconfigure(1, weight=1)
 
-    def on_cancel():
-        win.destroy()
+        btns = ttk.Frame(self.win, style="WM.TFrame")
+        btns.grid(row=1, column=0, padx=12, pady=(4, 8), sticky="e")
 
-    def on_save():
-        user_login = getattr(parent.winfo_toplevel(), "login", "")
+        ttk.Button(
+            btns,
+            text="Zapisz",
+            command=self.on_save,
+            style="WM.Side.TButton",
+        ).pack(side="right", padx=(8, 0))
+        ttk.Button(
+            btns,
+            text="Anuluj",
+            command=self.on_cancel,
+            style="WM.Side.TButton",
+        ).pack(side="right")
+
+        self.win.transient(parent)
+        self.win.grab_set()
+        self.win.protocol("WM_DELETE_WINDOW", self.on_cancel)
+        self.win.wait_window(self.win)
+
+    # ------------------------------------------------------------------
+    def on_cancel(self):
+        self.win.destroy()
+
+    # ------------------------------------------------------------------
+    def on_save(self):
+        user_login = getattr(self.parent.winfo_toplevel(), "login", "")
         if _CFG.get("magazyn.require_reauth", True):
-            login = simpledialog.askstring("Re-autoryzacja", "Login:", parent=win)
+            login = simpledialog.askstring(
+                "Re-autoryzacja", "Login:", parent=self.win
+            )
             if login is None:
                 return
-            pin = simpledialog.askstring("Re-autoryzacja", "PIN:", show="*", parent=win)
+            pin = simpledialog.askstring(
+                "Re-autoryzacja", "PIN:", show="*", parent=self.win
+            )
             if pin is None:
                 return
             user = authenticate(login, pin)
             if not user:
-                messagebox.showerror("Błąd", "Nieprawidłowy login lub PIN", parent=win)
+                messagebox.showerror(
+                    "Błąd", "Nieprawidłowy login lub PIN", parent=self.win
+                )
                 return
             user_login = user.get("login", login)
 
         try:
-            stan = float(vars_["stan"].get() or 0)
-            minimum = float(vars_["min"].get() or 0)
+            stan = float(self.vars["stan"].get() or 0)
+            minimum = float(self.vars["min_poziom"].get() or 0)
         except ValueError:
-            messagebox.showerror("Błąd", "Stan i minimum muszą być liczbami", parent=win)
+            messagebox.showerror(
+                "Błąd", "Stan i minimum muszą być liczbami", parent=self.win
+            )
             return
 
-        item_id = vars_["id"].get().strip()
-        name = vars_["nazwa"].get().strip()
-        typ = vars_["typ"].get().strip()
-        jm = vars_["jm"].get().strip()
-        comment = vars_["komentarz"].get().strip()
+        item_id = self.vars["id"].get().strip()
+        name = self.vars["nazwa"].get().strip()
+        typ = self.vars["typ"].get().strip()
+        jm = self.vars["jednostka"].get().strip()
 
         if not all([item_id, name, typ, jm]):
             messagebox.showerror(
-                "Błąd", "Wszystkie pola oprócz komentarza są wymagane", parent=win
+                "Błąd", "Wszystkie pola są wymagane", parent=self.win
             )
             return
 
@@ -96,7 +134,9 @@ def open_window(parent):
         data = load()
 
         if item_id in data.get("items", {}):
-            messagebox.showerror("Błąd", "ID już istnieje w magazynie", parent=win)
+            messagebox.showerror(
+                "Błąd", "ID już istnieje w magazynie", parent=self.win
+            )
             return
 
         data.setdefault("items", {})[item_id] = {
@@ -108,34 +148,36 @@ def open_window(parent):
             "min_poziom": minimum,
             "rezerwacje": 0,
             "historia": [],
-            "komentarz": comment,
+            "komentarz": "",
             "progi_alertow_pct": [100.0],
         }
         data.setdefault("meta", {}).setdefault("order", []).append(item_id)
 
-        magazyn_io.append_history(
+        LM.append_history(
             data["items"],
             item_id,
             user=user_login or "",
             op="CREATE",
             qty=stan,
-            comment=comment,
+            comment="",
         )
 
-        print("[WM-DBG] przed zapisem")
+        print("[WM-DBG][MAGAZYN-ADD] saving")
         save(data)
-        print("[WM-DBG] po zapisie")
+        print("[WM-DBG][MAGAZYN-ADD] saved")
 
-        win.destroy()
+        if self.on_saved:
+            try:
+                self.on_saved(item_id)
+            except TypeError:
+                self.on_saved()
 
-    ttk.Button(btns, text="Zapisz", command=on_save, style="WM.Side.TButton").pack(
-        side="right", padx=(8, 0)
-    )
-    ttk.Button(btns, text="Anuluj", command=on_cancel, style="WM.Side.TButton").pack(side="right")
+        self.win.destroy()
 
-    win.transient(parent)
-    win.grab_set()
-    win.wait_window(win)
+
+def open_window(parent, on_saved=None):
+    """Zachowana dla kompatybilności funkcja otwierająca dialog."""
+    MagazynAddDialog(parent, on_saved=on_saved)
 
 
 # ⏹ KONIEC KODU


### PR DESCRIPTION
## Summary
- refactor magazyn add window into MagazynAddDialog class with item fields
- support optional re-authentication and log history via logika_magazyn
- trigger optional on_saved callback and add debug logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c126a63fd08323b97453c7096c5ab2