### PR TITLE
Manage tooltip lifecycle in PanelMagazyn

### DIFF
--- a/tests/test_attach_tooltip_magazyn.py
+++ b/tests/test_attach_tooltip_magazyn.py
@@ -54,7 +54,9 @@ def setup_dummy(monkeypatch):
 def test_attach_tooltip_shows_text(monkeypatch):
     setup_dummy(monkeypatch)
     widget = DummyWidget()
-    tip = gm._attach_tooltip(widget, "tekst")
+    panel = object.__new__(gm.PanelMagazyn)
+    panel._tooltip_windows = set()
+    tip = gm.PanelMagazyn._attach_tooltip(panel, widget, "tekst")
     widget.trigger("<Enter>")
     assert tip["w"] is not None
     assert tip["w"].label.text == "tekst"

--- a/tests/test_gui_magazyn_smoke.py
+++ b/tests/test_gui_magazyn_smoke.py
@@ -19,6 +19,13 @@ def test_add_and_pz_buttons_create_windows(monkeypatch):
     )
     monkeypatch.setattr(gui_magazyn, "apply_theme", lambda *a, **k: None)
 
+    class DummyDialog:
+        def __init__(self, parent, **_):
+            gui_magazyn.tk.Toplevel(parent)
+
+    monkeypatch.setattr(gui_magazyn, "MagazynAddDialog", DummyDialog)
+    monkeypatch.setattr(gui_magazyn, "MagazynPZDialog", DummyDialog)
+
     panel = object.__new__(gui_magazyn.PanelMagazyn)
 
     gui_magazyn.PanelMagazyn._act_dodaj(panel)

--- a/tests/test_panel_magazyn_do_zam_tooltip.py
+++ b/tests/test_panel_magazyn_do_zam_tooltip.py
@@ -6,11 +6,11 @@ import gui_magazyn as gm
 def test_btn_do_zam_attaches_tooltip(monkeypatch):
     recorded: list[str] = []
 
-    def fake_attach(widget, text):  # noqa: ANN001 - test helper
+    def fake_attach(self, widget, text):  # noqa: ANN001 - test helper
         recorded.append(text)
         return {}
 
-    monkeypatch.setattr(gm, "_attach_tooltip", fake_attach)
+    monkeypatch.setattr(gm.PanelMagazyn, "_attach_tooltip", fake_attach)
 
     class DummyWidget:
         def __init__(self, *_, **__):


### PR DESCRIPTION
## Summary
- track tooltip windows via a dedicated set in `PanelMagazyn`
- integrate tooltip helper as a class method and clean up on root destroy
- update tests for new tooltip helper API and dialog stubs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c129529e888323aa9b3bed328883ac