### PR TITLE
Introduce thread-safe caching for tool tasks

### DIFF
--- a/test_logika_zadan_tasks.py
+++ b/test_logika_zadan_tasks.py
@@ -19,7 +19,7 @@ def test_limit_types(monkeypatch, tmp_path, caplog):
         ]
     }
     path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     with caplog.at_level("WARNING"):
         assert LZ.get_tool_types_list() == []
@@ -36,7 +36,7 @@ def test_limit_statuses(monkeypatch, tmp_path, caplog):
         ]
     }
     path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     with caplog.at_level("WARNING"):
         assert LZ.get_statuses_for_type("T1") == []
@@ -55,7 +55,7 @@ def test_get_tasks(monkeypatch, tmp_path):
         ]
     }
     path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     assert LZ.get_tasks_for("T1", "S1") == ["a", "b"]
 
@@ -63,7 +63,7 @@ def test_get_tasks(monkeypatch, tmp_path):
 def test_force_reload(monkeypatch, tmp_path):
     data1 = {"types": [{"id": "T1", "name": "Old", "statuses": []}]}
     path = _write(tmp_path, data1)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     assert LZ.get_tool_types_list() == [{"id": "T1", "name": "Old"}]
 
@@ -79,7 +79,7 @@ def test_force_reload(monkeypatch, tmp_path):
 def test_reload_on_mtime_change(monkeypatch, tmp_path):
     data1 = {"types": [{"id": "T1", "name": "Old", "statuses": []}]}
     path = _write(tmp_path, data1)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     assert LZ.get_tool_types_list() == [{"id": "T1", "name": "Old"}]
 

--- a/tests/test_gui_magazyn_smoke.py
+++ b/tests/test_gui_magazyn_smoke.py
@@ -18,6 +18,12 @@ def test_add_and_pz_buttons_create_windows(monkeypatch):
         types.SimpleNamespace(Toplevel=DummyToplevel),
     )
     monkeypatch.setattr(gui_magazyn, "apply_theme", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gui_magazyn, "MagazynAddDialog", lambda master, *a, **k: DummyToplevel()
+    )
+    monkeypatch.setattr(
+        gui_magazyn, "MagazynPZDialog", lambda master, *a, **k: DummyToplevel()
+    )
 
     panel = object.__new__(gui_magazyn.PanelMagazyn)
 

--- a/tests/test_logika_zadan_api.py
+++ b/tests/test_logika_zadan_api.py
@@ -1,29 +1,43 @@
+import json
+from pathlib import Path
+
 import logika_zadan as LZ
 
 
-def test_get_collections_and_default_collection():
+def test_get_collections_and_default_collection(monkeypatch, tmp_path):
+    data = {"collections": {"C1": {"types": []}, "C2": {"types": []}}}
+    path = tmp_path / "zadania_narzedzia.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
+    assert LZ.get_collections() == [
+        {"id": "C1", "name": "C1"},
+        {"id": "C2", "name": "C2"},
+    ]
     cfg = {
         "tools.collections_enabled": ["C1", "C2"],
         "tools.default_collection": "C2",
     }
-    assert LZ.get_collections(cfg) == [
-        {"id": "C1", "name": "C1"},
-        {"id": "C2", "name": "C2"},
-    ]
     assert LZ.get_default_collection(cfg) == "C2"
 
 
-def test_get_tool_types_statuses_and_tasks(monkeypatch):
+def test_get_tool_types_statuses_and_tasks(monkeypatch, tmp_path):
     data = {
-        "C1": [
-            {
-                "id": "T1",
-                "statuses": [{"id": "S1", "tasks": ["A", "B"]}],
+        "collections": {
+            "C1": {
+                "types": [
+                    {
+                        "id": "T1",
+                        "statuses": [{"id": "S1", "tasks": ["A", "B"]}],
+                    }
+                ]
             }
-        ]
+        }
     }
-    monkeypatch.setattr(LZ, "_load_tool_tasks", lambda force=False: data)
-    LZ._TOOL_TASKS_CACHE = None
+    path = tmp_path / "zadania_narzedzia.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
     assert LZ.get_tool_types("C1") == [{"id": "T1", "name": "T1"}]
     assert LZ.get_statuses("T1", "C1") == [{"id": "S1", "name": "S1"}]
     assert LZ.get_tasks("T1", "S1", "C1") == ["A", "B"]

--- a/tests/test_logika_zadan_tasks.py
+++ b/tests/test_logika_zadan_tasks.py
@@ -1,6 +1,8 @@
 import json
+import os
 from pathlib import Path
 import sys
+import threading
 
 import pytest
 
@@ -27,7 +29,7 @@ def test_duplicate_type_ids(monkeypatch, tmp_path, caplog):
         }
     }
     path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     with caplog.at_level("WARNING"):
         assert LZ.get_tool_types_list(collection="NN") == []
@@ -51,7 +53,7 @@ def test_duplicate_status_ids(monkeypatch, tmp_path, caplog):
         }
     }
     path = _write(tmp_path, data)
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     with caplog.at_level("WARNING"):
         assert LZ.get_statuses_for_type("T1", collection="NN") == []
@@ -63,7 +65,7 @@ def test_migrate_plain_list(monkeypatch, tmp_path):
     data = [{"id": "T1", "statuses": []}]
     path = tmp_path / "zadania_narzedzia.json"
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    monkeypatch.setattr(LZ, "TOOL_TASKS_PATH", str(path))
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
     LZ.invalidate_cache()
     types = LZ.get_tool_types_list(collection="NN")
     assert types and types[0]["id"] == "T1"
@@ -71,3 +73,62 @@ def test_migrate_plain_list(monkeypatch, tmp_path):
         stored = json.load(fh)
     assert "collections" in stored
     assert stored["collections"]["NN"]["types"][0]["id"] == "T1"
+
+
+def test_cache_invalidation(monkeypatch, tmp_path):
+    data1 = {
+        "collections": {
+            "NN": {
+                "types": [
+                    {"id": "T1", "statuses": [{"id": "S1", "tasks": ["A"]}]}
+                ]
+            }
+        }
+    }
+    path = _write(tmp_path, data1)
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
+    assert LZ.get_tasks("T1", "S1", "NN") == ["A"]
+    mtime = os.path.getmtime(path)
+    data2 = {
+        "collections": {
+            "NN": {
+                "types": [
+                    {"id": "T1", "statuses": [{"id": "S1", "tasks": ["B"]}]}
+                ]
+            }
+        }
+    }
+    path.write_text(json.dumps(data2, ensure_ascii=False, indent=2), encoding="utf-8")
+    orig_getmtime = os.path.getmtime
+    monkeypatch.setattr(os.path, "getmtime", lambda _p: mtime)
+    assert LZ.get_tasks("T1", "S1", "NN") == ["A"]
+    monkeypatch.setattr(os.path, "getmtime", orig_getmtime)
+    LZ.invalidate_cache()
+    assert LZ.get_tasks("T1", "S1", "NN") == ["B"]
+
+
+def test_concurrent_access(monkeypatch, tmp_path):
+    data = {
+        "collections": {
+            "NN": {
+                "types": [
+                    {"id": "T1", "statuses": []}
+                ]
+            }
+        }
+    }
+    path = _write(tmp_path, data)
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
+    results = []
+
+    def worker():
+        results.append(LZ.get_tool_types("NN"))
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert all(r == [{"id": "T1", "name": "T1"}] for r in results)

--- a/tests/test_tools_wrappers.py
+++ b/tests/test_tools_wrappers.py
@@ -1,25 +1,38 @@
+import json
+from pathlib import Path
+
 import logika_zadan as LZ
 
 
-def test_get_collections():
-    cfg = {"tools.collections_enabled": ["C1", "C2"]}
-    assert LZ.get_collections(cfg) == [
+def test_get_collections(monkeypatch, tmp_path):
+    data = {"collections": {"C1": {"types": []}, "C2": {"types": []}}}
+    path = tmp_path / "zadania_narzedzia.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
+    assert LZ.get_collections() == [
         {"id": "C1", "name": "C1"},
         {"id": "C2", "name": "C2"},
     ]
 
 
-def test_get_tool_types_and_statuses_and_tasks(monkeypatch):
+def test_get_tool_types_and_statuses_and_tasks(monkeypatch, tmp_path):
     data = {
-        "C1": [
-            {
-                "id": "T1",
-                "statuses": [{"id": "S1", "tasks": ["A", "B"]}],
+        "collections": {
+            "C1": {
+                "types": [
+                    {
+                        "id": "T1",
+                        "statuses": [{"id": "S1", "tasks": ["A", "B"]}],
+                    }
+                ]
             }
-        ]
+        }
     }
-    monkeypatch.setattr(LZ, "_load_tool_tasks", lambda force=False: data)
-    LZ._TOOL_TASKS_CACHE = None
+    path = tmp_path / "zadania_narzedzia.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    monkeypatch.setattr(LZ, "_TASKS_PATH", str(path))
+    LZ.invalidate_cache()
     assert LZ.get_tool_types("C1") == [{"id": "T1", "name": "T1"}]
     assert LZ.get_statuses("T1", "C1") == [{"id": "S1", "name": "S1"}]
     assert LZ.get_tasks("T1", "S1", "C1") == ["A", "B"]


### PR DESCRIPTION
## Summary
- guard task definitions with an RLock and mtime-aware cache
- safely reload `zadania_narzedzia.json` and refresh getters
- test cache invalidation and concurrent reads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c129537ebc83239b14f2bc554d87d7