### PR TITLE
Refine magazyn add handler

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -510,8 +510,9 @@ class PanelMagazyn(ttk.Frame):
 
     def _act_dodaj(self):
         print("[WM-DBG][MAG] _act_dodaj -> okno dodawania")
-        dlg = MagazynAddDialog(self.root, self.config, self.profiles, on_saved=self._reload_data)
-        self.root.wait_window(dlg.top)
+        root = self.winfo_toplevel()
+        dlg = MagazynAddDialog(root, self.config, self.profiles, on_saved=self._reload_data)
+        root.wait_window(dlg.top)
 
     def _act_przyjecie(self):
         """Open dialog for registering a goods receipt (PZ)."""

--- a/tests/test_gui_magazyn_smoke.py
+++ b/tests/test_gui_magazyn_smoke.py
@@ -18,7 +18,8 @@ def test_add_and_pz_buttons_create_windows(monkeypatch):
     monkeypatch.setattr(gui_magazyn, "MagazynPZDialog", DummyPZDialog)
 
     panel = object.__new__(gui_magazyn.PanelMagazyn)
-    panel.root = types.SimpleNamespace(wait_window=lambda _win: None)
+    root = types.SimpleNamespace(wait_window=lambda _win: None)
+    panel.winfo_toplevel = lambda: root
     panel.config = None
     panel.profiles = None
     panel._reload_data = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- use `winfo_toplevel` to resolve root before opening `MagazynAddDialog`
- update smoke test to stub `winfo_toplevel`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c12b4942bc8323a031a37da3477974