### PR TITLE
Refactor magazyn dialog actions

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -517,14 +517,14 @@ class PanelMagazyn(ttk.Frame):
             messagebox.showerror("Magazyn", f"Błąd drukowania: {e}")
 
     def _act_dodaj(self):
-        """Open dialog for adding a warehouse item."""
+        """Open dialog for adding a warehouse item and wait until it closes."""
         dlg = MagazynAddDialog(
             self.root, self.config, self.profiles, on_saved=self._reload_data
         )
         self.root.wait_window(dlg.top)
 
     def _act_przyjecie(self):
-        """Open dialog for registering a goods receipt (PZ)."""
+        """Open dialog for registering a goods receipt (PZ) and wait until it closes."""
         selected = self.tree.selection()
         selected_id = selected[0] if selected else None
         dlg = MagazynPZDialog(


### PR DESCRIPTION
## Summary
- Use stored root, config and profile attributes to open add and PZ dialogs
- Hook tree selection into PZ dialog and wait on dialog windows
- Extend dialog classes and smoke tests to new API
- Clarify magazyn dialog docstrings about waiting for dialog closure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12c81041c8323a856049a1290a057