### PR TITLE
Refactor MagazynAddDialog and improve dialog fallbacks

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -16,7 +16,6 @@
 # - Zarządzanie typami + dynamiczny combobox Typ
 #
 # Zmiany 1.1.1: Podpowiedz ID
-# ⏹ KONIEC KODU
 
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog

--- a/gui_magazyn_add.py
+++ b/gui_magazyn_add.py
@@ -1,5 +1,9 @@
 # Plik: gui_magazyn_add.py
-# Wersja pliku: 1.1.0
+# Wersja pliku: 1.2.0
+# Zmiany 1.2.0:
+# - Rozszerzono ``MagazynAddDialog`` o parametry ``config`` i ``profiles``,
+#   wykorzystując ``self.top`` oraz obsługę zamiennych modułów ``tk``.
+#
 # Zmiany 1.1.0:
 # - Przepisano okno na klasę ``MagazynAddDialog`` z opcjonalną re-autoryzacją
 #   i callbackiem ``on_saved``.


### PR DESCRIPTION
## Summary
- document new MagazynAddDialog config/profile parameters and top-level behavior
- remove stray end-of-code marker from gui_magazyn header

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c12c7c3220832394bf05b6808c9072