### PR TITLE
Add structured debug logging for magazyn dialogs

### DIFF
--- a/gui_magazyn_add.py
+++ b/gui_magazyn_add.py
@@ -7,6 +7,7 @@
 # Zmiany 1.0.0:
 # - Dodano okno dodawania pozycji magazynowej.
 
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog
 
@@ -15,6 +16,8 @@ from config_manager import ConfigManager
 from services.profile_service import authenticate
 import magazyn_io
 import logika_magazyn as LM
+
+logger = logging.getLogger(__name__)
 
 _CFG = ConfigManager()
 
@@ -162,9 +165,9 @@ class MagazynAddDialog:
             comment="",
         )
 
-        print("[WM-DBG][MAGAZYN-ADD] saving")
+        logger.debug("[WM-DBG][MAG][ADD] saving")
         save(data)
-        print("[WM-DBG][MAGAZYN-ADD] saved")
+        logger.debug("[WM-DBG][MAG][ADD] saved")
 
         if self.on_saved:
             try:

--- a/gui_magazyn_order.py
+++ b/gui_magazyn_order.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, messagebox
 
 from ui_theme import apply_theme_safe as apply_theme
+
+logger = logging.getLogger(__name__)
 
 ORDERS_PATH = Path("data/zamowienia_oczekujace.json")
 
@@ -57,10 +60,12 @@ class MagazynOrderDialog:
                 data = []
 
         data.append({"id": self.var_id.get(), "ilosc": qty})
+        logger.debug("[WM-DBG][MAG][ORDER] saving")
         ORDERS_PATH.parent.mkdir(parents=True, exist_ok=True)
         ORDERS_PATH.write_text(
             json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
         )
+        logger.debug("[WM-DBG][MAG][ORDER] saved")
 
         if callable(self.on_saved):
             self.on_saved()

--- a/gui_magazyn_pz.py
+++ b/gui_magazyn_pz.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
 
@@ -10,6 +11,9 @@ from config_manager import ConfigManager
 from services.profile_service import authenticate
 import logika_magazyn as LM
 import magazyn_io
+
+
+logger = logging.getLogger(__name__)
 
 
 def record_pz(item_id: str, qty: float, user: str, comment: str = "") -> None:
@@ -35,6 +39,7 @@ def record_pz(item_id: str, qty: float, user: str, comment: str = "") -> None:
     qty_f = float(qty)
     items[item_id]["stan"] = float(items[item_id].get("stan", 0)) + qty_f
 
+    logger.debug("[WM-DBG][MAG][PZ] saving")
     magazyn_io.append_history(
         items,
         item_id,
@@ -43,7 +48,9 @@ def record_pz(item_id: str, qty: float, user: str, comment: str = "") -> None:
         qty=qty_f,
         comment=comment,
     )
+    logger.debug("[WM-DBG][MAG][PZ] history updated")
     LM.save_magazyn(data)
+    logger.debug("[WM-DBG][MAG][PZ] saved")
 
 
 class MagazynPZDialog:
@@ -164,7 +171,7 @@ class MagazynPZDialog:
                 raise KeyError(f"Brak pozycji {iid} w magazynie")
 
             items[iid]["stan"] = float(items[iid].get("stan", 0)) + qty
-            print("[WM-DBG] przed zapisem PZ")
+            logger.debug("[WM-DBG][MAG][PZ] saving")
             magazyn_io.append_history(
                 items,
                 iid,
@@ -173,8 +180,9 @@ class MagazynPZDialog:
                 qty=qty,
                 comment=comment,
             )
+            logger.debug("[WM-DBG][MAG][PZ] history updated")
             LM.save_magazyn(data)
-            print("[WM-DBG] po zapisie PZ")
+            logger.debug("[WM-DBG][MAG][PZ] saved")
         except Exception as exc:
             messagebox.showerror("Błąd", str(exc), parent=self.top)
             return


### PR DESCRIPTION
## Summary
- replace print statements with logger.debug in magazyn add, PZ and order dialogs
- add missing debug logs for order saves and PZ save stages using audit format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c136c7a4b08323b405951b37e78df2