### PR TITLE
Expose aliases for tool types and statuses

### DIFF
--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -136,6 +136,10 @@ def should_autocheck(
     return tools_autocheck.should_autocheck(status_id, collection_id, cfg)
 
 
+get_tool_types_list = get_tool_types
+get_statuses_for_type = get_statuses
+
+
 def _now():
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
## Summary
- add exported aliases `get_tool_types_list` and `get_statuses_for_type` in `logika_zadan`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c148483f80832391e8c57d24c946ca