### PR TITLE
Expose aliases for tool types and statuses

### DIFF
--- a/logika_zadan.py
+++ b/logika_zadan.py
@@ -27,6 +27,22 @@ logger = logging.getLogger(__name__)
 TOOL_TASKS_PATH = _TASKS_PATH
 HISTORY_PATH = os.path.join("data", "zadania_history.json")
 
+__all__ = [
+    "TOOL_TASKS_PATH",
+    "HISTORY_PATH",
+    "invalidate_cache",
+    "get_collections",
+    "get_default_collection",
+    "get_tool_types",
+    "get_statuses",
+    "get_tasks",
+    "should_autocheck",
+    "get_tool_types_list",
+    "get_statuses_for_type",
+    "register_tasks_state",
+    "consume_for_task",
+]
+
 
 def _safe_load() -> dict:
     try:
@@ -134,6 +150,9 @@ def should_autocheck(
     elif isinstance(cfg, ConfigManager):
         cfg = cfg.merged
     return tools_autocheck.should_autocheck(status_id, collection_id, cfg)
+
+get_tool_types_list = get_tool_types
+get_statuses_for_type = get_statuses
 
 
 def _now():

--- a/tests/test_logika_zadan_api.py
+++ b/tests/test_logika_zadan_api.py
@@ -47,3 +47,8 @@ def test_should_autocheck_respects_global_status():
     cfg = {"tools": {"auto_check_on_status_global": ["S1"]}}
     assert LZ.should_autocheck("S1", "C1", cfg)
     assert not LZ.should_autocheck("S2", "C1", cfg)
+
+
+def test_aliases_exposed():
+    assert LZ.get_tool_types_list is LZ.get_tool_types
+    assert LZ.get_statuses_for_type is LZ.get_statuses


### PR DESCRIPTION
## Summary
- add `get_tool_types_list` and `get_statuses_for_type` aliases to task logic
- export aliases via `__all__`
- test alias availability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c14c74ffd88323ba79b653c1fea9a3