### PR TITLE
Add optional merging of warehouse lists

### DIFF
--- a/logika_magazyn.py
+++ b/logika_magazyn.py
@@ -128,7 +128,7 @@ def _default_magazyn():
 
 
 def _merge_list_into(mag: dict, path: str, item_type: str) -> None:
-    """Scal listę/dictę z ``path`` do magazynu ``mag``.
+    """Scal listę lub słownik z ``path`` do magazynu ``mag``.
 
     Parametry:
         mag: docelowa struktura magazynu.


### PR DESCRIPTION
## Summary
- add helper to merge surowce/półprodukty JSON lists into warehouse data
- expand `load_magazyn` to merge optional lists with `[WM-DBG][MAG]` debug prints
- clarify merge helper docstring wording

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15afe7a0483239ec36511b581093c