### PR TITLE
Handle missing notebook tab retrieval

### DIFF
--- a/ustawienia_uzytkownicy.py
+++ b/ustawienia_uzytkownicy.py
@@ -245,14 +245,22 @@ def make_tab(parent, rola):
         btn_del = ttk.Button(btns, text="Usuń")
         btn_del.pack(side="left", padx=2)
 
-    notebook = parent.nametowidget(parent.winfo_parent())
-    base_title = notebook.tab(parent, "text")
+    try:
+        notebook = parent.nametowidget(parent.winfo_parent())
+        if hasattr(notebook, "tab"):
+            base_title = notebook.tab(parent, "text")
+        else:
+            base_title = "Profile"
+    except Exception:
+        notebook = parent
+        base_title = "Profile"
     guard = DirtyGuard(
         "Użytkownicy",
         on_save=lambda: (save_user(), guard.reset()),
         on_reset=lambda: (load_selected(), guard.reset()),
-        on_dirty_change=lambda d: notebook.tab(
-            parent, text=base_title + (" •" if d else "")
+        on_dirty_change=lambda d: (
+            hasattr(notebook, "tab")
+            and notebook.tab(parent, text=base_title + (" •" if d else ""))
         ),
     )
     guard.watch(frame)


### PR DESCRIPTION
## Summary
- Safely resolve parent notebook and tab title in `ustawienia_uzytkownicy.make_tab`
- Guard dirty-tab text updates when notebook lacks a `tab` method

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1cbd1a3dc83238dc916b768e84425