### PR TITLE
Use suspend-ui flag when rebuilding task comboboxes

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -382,15 +382,16 @@ class _TaskTemplateUI:
         return self.status_map.get(self.var_status.get())
 
     def _fill_collections(self):
+        cur = self._collection_id_from_combo()
         with self._suspend_ui():
             collections = LZ.get_collections()
             self.coll_map = {c["name"]: c["id"] for c in collections}
             self.cb_collection.config(values=list(self.coll_map.keys()))
-            default = LZ.get_default_collection()
-            name = next((n for n, cid in self.coll_map.items() if cid == default), "")
+            name = next((n for n, cid in self.coll_map.items() if cid == cur), "")
+            if not name:
+                default = LZ.get_default_collection()
+                name = next((n for n, cid in self.coll_map.items() if cid == default), "")
             self.var_collection.set(name)
-        self._cur_type_id = ""
-        self._cur_status_id = ""
         self._fill_types()
 
     def _fill_types(self):


### PR DESCRIPTION
## Summary
- Track combobox state with `_ui_updating` to prevent feedback loops
- Preserve the current collection/type/status IDs when repopulating task lists

## Testing
- `pytest -q` *(fails: test_gui_profile_roles.py::test_read_tasks_foreman_role_case_insensitive, test_priority_order.py::test_deadline_sorting_and_default)*
- `pytest test_gui_narzedzia_tasks.py tests/test_gui_narzedzia_missing_data.py tests/test_gui_narzedzia_tasks_mixed.py -q`
- `python -m pycodestyle gui_narzedzia.py` *(fails: No module named pycodestyle)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d062033883239e6a945bb83dc0d3