### PR TITLE
Handle JSON decode errors in magazyn_io.load

### DIFF
--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -54,6 +54,35 @@ def _load_json(path: str, default):
         return default
 
 
+def load(path: str = MAGAZYN_PATH) -> Dict[str, Any]:
+    """Load warehouse data from ``path``.
+
+    Returns a structure with ``items`` and ``meta`` keys. When the file is
+    missing or contains invalid JSON the default ``{"items": {},
+    "meta": {}}`` structure is returned.  A JSON decoding problem is logged to
+    aid debugging.
+    """
+
+    default = {"items": {}, "meta": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return default
+    except json.JSONDecodeError as exc:
+        logging.error("Niepoprawny format JSON w %s: %s", path, exc)
+        return default
+    except Exception as exc:  # unexpected issues
+        logging.error("Błąd podczas odczytu %s: %s", path, exc)
+        return default
+
+    if not isinstance(data, dict):
+        return default
+    items = data.get("items") if isinstance(data.get("items"), dict) else {}
+    meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
+    return {"items": items, "meta": meta}
+
+
 def append_history(
     items: Dict[str, Any],
     item_id: str,

--- a/tests/test_magazyn_io_core.py
+++ b/tests/test_magazyn_io_core.py
@@ -28,7 +28,9 @@ def test_generate_pz_id_resets_each_year(tmp_path, monkeypatch):
 def test_ensure_in_katalog_unit_conflict(tmp_path, monkeypatch):
     katalog_path = tmp_path / "katalog.json"
     monkeypatch.setattr(magazyn_io, "KATALOG_PATH", str(katalog_path))
-    magazyn_io.ensure_in_katalog({"item_id": "A", "nazwa": "A", "jednostka": "szt"})
+    magazyn_io.ensure_in_katalog(
+        {"item_id": "A", "nazwa": "A", "jednostka": "szt"}
+    )
     warning = magazyn_io.ensure_in_katalog({"item_id": "A", "jednostka": "kg"})
     assert warning == {"warning": "Jednostka różni się: katalog=szt, PZ=kg"}
 
@@ -45,3 +47,12 @@ def test_logging_messages(tmp_path, monkeypatch, caplog):
     magazyn_io.update_stany_after_pz({"item_id": "X", "qty": 1, "nazwa": "X"})
     assert f"[INFO] Zapisano PZ {pz_id}" in caplog.text
     assert "[INFO] Zaktualizowano stan X: 1.0" in caplog.text
+
+
+def test_load_bad_json(tmp_path, caplog):
+    bad_file = tmp_path / "magazyn.json"
+    bad_file.write_text("{bad json", encoding="utf-8")
+    caplog.set_level(logging.ERROR)
+    data = magazyn_io.load(str(bad_file))
+    assert data == {"items": {}, "meta": {}}
+    assert "Niepoprawny format JSON" in caplog.text


### PR DESCRIPTION
## Summary
- guard `magazyn_io.load` against malformed JSON and log decode errors
- cover bad JSON case with a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7cea1f3e88323ba2044bfbc02be36