### PR TITLE
Validate positive quantities in reservation dialogs

### DIFF
--- a/gui_magazyn_rezerwacje.py
+++ b/gui_magazyn_rezerwacje.py
@@ -41,6 +41,11 @@ def open_rezerwuj_dialog(master, item_id):
         except ValueError:
             messagebox.showerror("Błąd", "Ilość musi być liczbą.", parent=win)
             return
+        if qty <= 0:
+            messagebox.showerror(
+                "Błąd", "Ilość musi być większa od zera.", parent=win
+            )
+            return
         data = magazyn_io.load()
         items = data.get("items", {})
         if item_id not in items:
@@ -88,6 +93,11 @@ def open_zwolnij_rezerwacje_dialog(master, item_id):
             qty = float(var_qty.get())
         except ValueError:
             messagebox.showerror("Błąd", "Ilość musi być liczbą.", parent=win)
+            return
+        if qty <= 0:
+            messagebox.showerror(
+                "Błąd", "Ilość musi być większa od zera.", parent=win
+            )
             return
         data = magazyn_io.load()
         items = data.get("items", {})


### PR DESCRIPTION
## Summary
- Ensure reservation dialog rejects non-positive quantities
- Apply same validation for releasing reservations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7cea0e128832382af92fbc8a1bab2