### PR TITLE
feat: allow komentarz alias in append_history

### DIFF
--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -62,6 +62,8 @@ def append_history(
     qty: float,
     comment: str = "",
     ts: str | None = None,
+    *,
+    komentarz: str | None = None,
 ) -> Dict[str, Any]:
     """Append a history entry for ``item_id``.
 
@@ -73,6 +75,8 @@ def append_history(
         qty: Positive quantity of the operation.
         comment: Optional comment stored with the entry.
         ts: Optional timestamp (ISO 8601). Generated when missing.
+        komentarz: Polish alias for ``comment``. Overrides ``comment`` when
+            provided.
 
     The entry is appended to ``items[item_id]['historia']``. For ``op == 'PZ'``
     an additional record is stored in :data:`PRZYJECIA_PATH`.
@@ -90,6 +94,9 @@ def append_history(
 
     if not ts:
         ts = datetime.now(timezone.utc).isoformat()
+
+    if komentarz is not None:
+        comment = komentarz
 
     entry = {
         "ts": ts,

--- a/tests/test_magazyn_io_comment_alias.py
+++ b/tests/test_magazyn_io_comment_alias.py
@@ -1,0 +1,23 @@
+import json
+
+import magazyn_io
+
+
+def test_append_history_accepts_komentarz(tmp_path, monkeypatch):
+    hist_path = tmp_path / "hist.json"
+    monkeypatch.setattr(magazyn_io, "HISTORY_PATH", str(hist_path))
+
+    items = {}
+    entry = magazyn_io.append_history(
+        items,
+        "A",
+        "user",
+        "CREATE",
+        1,
+        komentarz="uwaga",
+    )
+
+    assert entry["comment"] == "uwaga"
+    assert items["A"]["historia"][0]["comment"] == "uwaga"
+    data = json.loads(hist_path.read_text(encoding="utf-8"))
+    assert data[0]["comment"] == "uwaga"


### PR DESCRIPTION
## Summary
- add a `komentarz` keyword alias to `append_history`
- cover `append_history` alias handling with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7ce9fa9a48323bc0904e03b4e5b95