### PR TITLE
Refactor order ID generation

### DIFF
--- a/gui_orders.py
+++ b/gui_orders.py
@@ -91,9 +91,8 @@ class OrdersWindow(tk.Toplevel):
         lbl_info.pack(anchor="w")
 
     def _generate_id(self) -> str:
-        today = dt.datetime.now().strftime("%Y%m%d")
-        seq = int(dt.datetime.now().strftime("%H%M%S"))
-        return f"ORD-{today}-{seq:06d}"
+        now = dt.datetime.now()
+        return now.strftime("ORD-%Y%m%d-%H%M%S")
 
     def _save_draft(self):
         _ensure_orders_dir()


### PR DESCRIPTION
## Summary
- Avoid multiple `datetime.now()` calls when generating order IDs
- Format ID using single `strftime` call to ensure consistent timestamp

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7d4f004548323bd591471e8e3a5f6