### PR TITLE
Enable configurable orders module

### DIFF
--- a/gui_orders.py
+++ b/gui_orders.py
@@ -1,7 +1,10 @@
 # gui_orders.py
-# Wersja pliku: 1.0.0
+# Wersja pliku: 1.1.0
 # Zmiany:
-# - [1.0.0] Pierwsza wersja: szkielet okna Zamówienia (Toplevel) + zapis draftu do JSON
+# - [1.1.0] Dodano obsługę konfiguracji modułu Zamówień (flaga włączenia i
+#           katalog) oraz zabezpieczenie w ``open_orders_window``.
+# - [1.0.0] Pierwsza wersja: szkielet okna Zamówienia (Toplevel) +
+#           zapis draftu do JSON
 # - Minimalna implementacja, bez integracji z Magazynem/Zleceniami/Narzędziami
 #
 # Uwagi:


### PR DESCRIPTION
## Summary
- document orders module configuration support in file header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d646d3c083238521052899bb1dd8