### PR TITLE
Add module manifest loader and integration

### DIFF
--- a/data/moduly_manifest.json
+++ b/data/moduly_manifest.json
@@ -1,0 +1,66 @@
+{
+  "wersja": "2025-09-15.1",
+  "rdzen": {
+    "id": "rdzen",
+    "nazwa": "Rdzeń (Konfiguracja / Logger / Motyw / Utils)",
+    "pliki": ["config_manager.py", "logger.py", "ui_theme.py", "utils/**"],
+    "dostarcza": ["konfiguracja", "logi", "motyw", "io", "sciezki"],
+    "korzysta_z": []
+  },
+  "moduly": [
+    {
+      "id": "ustawienia",
+      "nazwa": "Ustawienia",
+      "pliki": ["gui_settings.py", "settings_schema.json", "updater.py", "updates_utils.py"],
+      "dostarcza": ["ustawienia_aplikacji", "aktualizacje", "schema_ui"],
+      "korzysta_z": ["rdzen"]
+    },
+    {
+      "id": "profile",
+      "nazwa": "Profile / Obecność",
+      "pliki": ["services/profile_service.py", "presence.py", "presence_watcher.py", "data/profiles.json"],
+      "dostarcza": ["autoryzacja", "role", "obecnosc"],
+      "korzysta_z": ["rdzen", "ustawienia"]
+    },
+    {
+      "id": "panel_glowny",
+      "nazwa": "Panel główny",
+      "pliki": ["gui_panel.py", "gui_dashboard.py"],
+      "dostarcza": ["nawigacja", "start"],
+      "korzysta_z": ["rdzen", "ustawienia", "profile"]
+    },
+    {
+      "id": "narzedzia",
+      "nazwa": "Narzędzia",
+      "pliki": ["gui_narzedzia.py", "tools_*.py", "data/narzedzia/**"],
+      "dostarcza": ["baza_narzedzi", "szablony", "historia", "qr"],
+      "korzysta_z": ["rdzen", "ustawienia", "profile"]
+    },
+    {
+      "id": "magazyn",
+      "nazwa": "Magazyn",
+      "pliki": ["gui_magazyn*.py", "logika_magazyn.py", "logika_bom.py", "data/magazyn/**", "data/produkty/**"],
+      "dostarcza": ["stany", "pz", "rezerwacje", "bom"],
+      "korzysta_z": ["rdzen", "ustawienia", "profile"]
+    },
+    {
+      "id": "zlecenia",
+      "nazwa": "Zlecenia / Kreator",
+      "pliki": ["gui_orders.py", "gui_zlecenia.py", "zlecenia_*.py", "data/zlecenia/**"],
+      "dostarcza": ["baza_zlecen", "kreator"],
+      "korzysta_z": ["rdzen", "ustawienia", "profile", "magazyn"]
+    },
+    {
+      "id": "maszyny_hala",
+      "nazwa": "Maszyny / Hala",
+      "pliki": ["gui_hala.py", "widok_hali/**", "data/maszyny.json", "data/sciany.json"],
+      "dostarcza": ["widok_hali", "maszyny"],
+      "korzysta_z": ["rdzen", "ustawienia", "profile"]
+    }
+  ],
+  "reguly": [
+    {"musi_startowac_przed": "panel_glowny", "modul": "ustawienia"},
+    {"musi_startowac_przed": "panel_glowny", "modul": "profile"},
+    {"musi_startowac_przed": "zlecenia", "modul": "magazyn"}
+  ]
+}

--- a/start.py
+++ b/start.py
@@ -549,6 +549,26 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
+    # --- Integracja manifestu modułów (lekka) ---
+    try:
+        from utils.moduly import (
+            zaladuj_manifest,
+            lista_modulow,
+            sprawdz_reguly,
+            tag_logu,
+        )
+
+        _mod_tag = tag_logu("rdzen")
+        print(f"{_mod_tag} Ładuję manifest modułów…")
+        _manifest = zaladuj_manifest()
+        _lista = lista_modulow(_manifest)
+        print(f"{_mod_tag} Moduły zdefiniowane w manifeście: {', '.join(_lista)}")
+        _kom = sprawdz_reguly(_manifest)
+        for k in _kom:
+            print(k)
+    except Exception as e:
+        print(f"[ERROR] Problem z manifestem modułów: {e}")
+    # --- Koniec integracji manifestu ---
     _wm_git_check_on_start()
     main()
 

--- a/tests/test_moduly_manifest.py
+++ b/tests/test_moduly_manifest.py
@@ -1,0 +1,12 @@
+# tests/test_moduly_manifest.py
+# Szybki smoke test manifestu (nie zmienia działania programu).
+from utils.moduly import zaladuj_manifest, lista_modulow, pobierz_modul, zaleznosci
+
+
+def test_manifest_smoke():
+    man = zaladuj_manifest()
+    mods = lista_modulow(man)
+    assert "magazyn" in mods
+    assert "zlecenia" in mods
+    z = pobierz_modul("zlecenia", man)
+    assert "magazyn" in zaleznosci("zlecenia", man)

--- a/utils/moduly.py
+++ b/utils/moduly.py
@@ -1,0 +1,117 @@
+# utils/moduly.py
+# Wersja pliku: 1.0.0 (2025-09-15)
+# Zmiany:
+# - Nowy loader manifestu modułów (PL) + walidacja zależności + tag do logów.
+# - Brak wpływu na istniejącą logikę; wyłącznie funkcje pomocnicze.
+
+from __future__ import annotations
+import json
+import os
+from typing import Dict, List, Any
+
+_MANIFEST_CACHE: Dict[str, Any] | None = None
+
+
+class ManifestBlad(Exception):
+    """Błąd związany z manifestem modułów."""
+
+
+def _wczytaj_json(sciezka: str) -> Dict[str, Any]:
+    if not os.path.exists(sciezka):
+        raise ManifestBlad(f"[ERROR] Brak pliku manifestu modułów: {sciezka}")
+    with open(sciezka, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            raise ManifestBlad(f"[ERROR] Niepoprawny JSON w {sciezka}: {e}") from e
+
+
+def zaladuj_manifest(sciezka: str = "data/moduly_manifest.json") -> Dict[str, Any]:
+    """
+    Ładuje i cache'uje manifest modułów.
+    """
+    global _MANIFEST_CACHE
+    if _MANIFEST_CACHE is not None:
+        return _MANIFEST_CACHE
+    manifest = _wczytaj_json(sciezka)
+    # Walidacja minimalna
+    if "rdzen" not in manifest or "moduly" not in manifest:
+        raise ManifestBlad("[ERROR] Manifest musi zawierać klucze: 'rdzen' i 'moduly'.")
+    if not isinstance(manifest["moduly"], list):
+        raise ManifestBlad("[ERROR] 'moduly' musi być listą.")
+    _MANIFEST_CACHE = manifest
+    return manifest
+
+
+def pobierz_modul(modul_id: str, manifest: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """
+    Zwraca definicję modułu wg 'id'. Specjalny 'rdzen' zwraca sekcję rdzenia.
+    """
+    man = manifest or zaladuj_manifest()
+    if modul_id == "rdzen":
+        return man["rdzen"]
+    for m in man["moduly"]:
+        if m.get("id") == modul_id:
+            return m
+    raise ManifestBlad(f"[ERROR] Nie znaleziono modułu o id='{modul_id}'.")
+
+
+def lista_modulow(manifest: Dict[str, Any] | None = None) -> List[str]:
+    """
+    Zwraca listę ID wszystkich modułów (bez 'rdzen').
+    """
+    man = manifest or zaladuj_manifest()
+    return [m.get("id") for m in man["moduly"]]
+
+
+def zaleznosci(modul_id: str, manifest: Dict[str, Any] | None = None) -> List[str]:
+    """
+    Zwraca listę ID modułów, z których dany moduł korzysta (korzysta_z).
+    """
+    mod = pobierz_modul(modul_id, manifest)
+    return list(mod.get("korzysta_z", []))
+
+
+def sprawdz_reguly(manifest: Dict[str, Any] | None = None) -> List[str]:
+    """
+    Sprawdza sekcję 'reguly' i zwraca listę ostrzeżeń/błędów (stringi).
+    Na dziś: tylko raport tekstowy (bez podnoszenia wyjątków).
+    """
+    man = manifest or zaladuj_manifest()
+    komunikaty: List[str] = []
+    reguly = man.get("reguly", [])
+    # Prosta weryfikacja istnienia modułów wskazanych w regułach
+    znane = set(lista_modulow(man) + ["rdzen"])
+    for r in reguly:
+        a = r.get("modul")
+        b = r.get("musi_startowac_przed")
+        if a not in znane:
+            komunikaty.append(f"[WARN] Reguła odwołuje się do nieznanego modułu: {a}")
+        if b not in znane:
+            komunikaty.append(f"[WARN] Reguła odwołuje się do nieznanego modułu: {b}")
+    return komunikaty
+
+
+def assert_zaleznosci_gotowe(modul_id: str, zainicjowane: List[str], manifest: Dict[str, Any] | None = None) -> None:
+    """
+    Dla danego modułu sprawdza, czy wszystkie 'korzysta_z' znajdują się na liście zainicjowanych.
+    Jeśli nie – rzuca ManifestBlad z czytelnym komunikatem PL.
+    """
+    deps = zaleznosci(modul_id, manifest)
+    brak = [d for d in deps if d not in zainicjowane]
+    if brak:
+        raise ManifestBlad(
+            "[ERROR] Moduł '{0}' wymaga wcześniejszej inicjalizacji: {1}".format(
+                modul_id, ", ".join(brak)
+            )
+        )
+
+
+def tag_logu(modul_id: str) -> str:
+    """
+    Zwraca ujednolicony tag do logów, np. '[WM-DBG][mod:magazyn]'
+    """
+    return f"[WM-DBG][mod:{modul_id}]"
+
+
+# ⏹ KONIEC KODU


### PR DESCRIPTION
## Summary
- add `moduly_manifest.json` describing core and feature modules with startup rules
- provide `utils.moduly` helper for loading, validating and tagging modules
- log manifest contents during startup and add smoke test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f904ca28832386f69ba6bde16cd4