### PR TITLE
Use advanced tools config dialog with safe fallback

### DIFF
--- a/gui_tools_config.py
+++ b/gui_tools_config.py
@@ -1,59 +1,97 @@
-"""Prosty edytor konfiguracji zadań narzędzi."""
+"""Prosty edytor konfiguracji zadań narzędzi (alias do wersji zaawansowanej)."""
 
 from __future__ import annotations
 
-import json
-import tkinter as tk
-from tkinter import messagebox, ttk
+
+def _can_use_advanced_dialog() -> bool:
+    """Sprawdź, czy środowisko pozwala na użycie wersji zaawansowanej."""
+
+    try:
+        import tkinter as _tk  # lokalny import: zależy od środowiska testowego
+    except Exception:
+        return False
+
+    # Jeśli istnieje domyślne okno główne, zakładamy, że Tk działa.
+    default_root = getattr(_tk, "_default_root", None)
+    if default_root is not None:
+        return True
+
+    try:
+        root = _tk.Tk()
+    except Exception:
+        return False
+
+    try:
+        root.withdraw()
+        root.destroy()
+    except Exception:
+        return False
+    return True
 
 
-class ToolsConfigDialog(tk.Toplevel):
-    """Minimalne okno do edycji pliku ``zadania_narzedzia.json``."""
+_AdvancedDialog: type | None = None
+try:
+    from gui_tools_config_advanced import ToolsConfigDialog as _AdvancedDialog  # type: ignore
+except Exception:
+    _AdvancedDialog = None
+else:
+    if not _can_use_advanced_dialog():
+        _AdvancedDialog = None
+if _AdvancedDialog is not None:
+    ToolsConfigDialog = _AdvancedDialog
+else:
+    # Fallback: zachowaj minimalny, tekstowy edytor JSON (stara wersja)
+    import json
+    import tkinter as tk
+    from tkinter import messagebox, ttk
 
-    def __init__(self, master: tk.Widget | None = None, *, path: str, on_save=None) -> None:
-        super().__init__(master)
-        self.title("Konfiguracja zadań narzędzi")
-        self.resizable(True, True)
-        self.path = path
-        self.on_save = on_save
+    class ToolsConfigDialog(tk.Toplevel):  # type: ignore[no-redef]
+        """Minimalne okno do edycji pliku ``zadania_narzedzia.json``."""
 
-        self.text = tk.Text(self, width=80, height=25)
-        self.text.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+        def __init__(self, master: tk.Widget | None = None, *, path: str, on_save=None) -> None:
+            super().__init__(master)
+            self.title("Konfiguracja zadań narzędzi")
+            self.resizable(True, True)
+            self.path = path
+            self.on_save = on_save
 
-        buttons = ttk.Frame(self)
-        buttons.pack(fill=tk.X, padx=4, pady=(0, 4))
-        ttk.Button(buttons, text="Zapisz", command=self._save).pack(side=tk.LEFT)
-        ttk.Button(buttons, text="Anuluj", command=self.destroy).pack(side=tk.LEFT)
+            self.text = tk.Text(self, width=80, height=25)
+            self.text.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
 
-        try:
-            with open(self.path, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        except FileNotFoundError:
-            data = {"collections": {}}
-        self.text.insert("1.0", json.dumps(data, ensure_ascii=False, indent=2))
+            buttons = ttk.Frame(self)
+            buttons.pack(fill=tk.X, padx=4, pady=(0, 4))
+            ttk.Button(buttons, text="Zapisz", command=self._save).pack(side=tk.LEFT)
+            ttk.Button(buttons, text="Anuluj", command=self.destroy).pack(side=tk.LEFT)
 
-    def _save(self) -> None:
-        """Zapisz plik i wywołaj ``on_save`` po sukcesie."""
+            try:
+                with open(self.path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except FileNotFoundError:
+                data = {"collections": {}}
+            self.text.insert("1.0", json.dumps(data, ensure_ascii=False, indent=2))
 
-        raw = self.text.get("1.0", tk.END).strip()
-        try:
-            data = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            messagebox.showerror("Błąd", f"Niepoprawny JSON: {exc}")
-            return
+        def _save(self) -> None:
+            """Zapisz plik i wywołaj ``on_save`` po sukcesie."""
 
-        with open(self.path, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False, indent=2)
-            fh.write("\n")
+            raw = self.text.get("1.0", tk.END).strip()
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                messagebox.showerror("Błąd", f"Niepoprawny JSON: {exc}")
+                return
 
-        try:
-            from logika_zadan import invalidate_cache
-        except Exception:  # pragma: no cover - optional import
-            invalidate_cache = None
-        if callable(invalidate_cache):
-            invalidate_cache()
+            with open(self.path, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False, indent=2)
+                fh.write("\n")
 
-        if callable(self.on_save):
-            self.on_save()
-        self.destroy()
+            try:
+                from logika_zadan import invalidate_cache
+            except Exception:
+                invalidate_cache = None  # pragma: no cover
+            if callable(invalidate_cache):
+                invalidate_cache()
+
+            if callable(self.on_save):
+                self.on_save()
+            self.destroy()
 


### PR DESCRIPTION
## Summary
- load the advanced tools configuration dialog by default when the advanced implementation can work in the current environment
- keep the original text-based JSON editor as a fallback and continue to invalidate the cache on save

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9170c83808323adbfcae49078b67c