### PR TITLE
Revamp NN/SN tools config and extend auto-close logging

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -1481,6 +1481,32 @@ def panel_narzedzia(root, frame, login=None, rola=None):
                             "auto ✔ przy statusie końcowym",
                         ),
                     )
+                else:
+                    try:
+                        comment = simpledialog.askstring(
+                            "Brak odhaczeń",
+                            "Nie odhaczono żadnych zadań dla ostatniego statusu.\n"
+                            "Podaj komentarz (dlaczego):",
+                            parent=dlg,
+                        )
+                    except Exception:
+                        comment = ""
+                    msg = f"Ostatni status '{new_st}': brak zadań do odhaczenia."
+                    if comment:
+                        msg += f" Komentarz: {comment}"
+                    hist_items.append(
+                        {
+                            "ts": now_ts,
+                            "by": (login or "system"),
+                            "z": "[zadania]",
+                            "na": msg,
+                        }
+                    )
+                    hist_view.insert(
+                        "",
+                        0,
+                        values=(now_ts, login or "system", "[zadania]", msg),
+                    )
             last_status[0] = new_st
             last_applied_status[0] = new_st
 


### PR DESCRIPTION
## Summary
- rebuild the advanced tools configuration dialog so NN and SN share type definitions while keeping per-collection statuses/tasks, with search, limits, backups, and brygadzista authentication
- prompt for a comment when automatic task closure on the last status has nothing to tick off and record the note in history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92b27a42c83238147e1acdc28a180