### PR TITLE
Fix topmost helper usage for tools config dialog

### DIFF
--- a/gui_settings.py
+++ b/gui_settings.py
@@ -512,7 +512,7 @@ class SettingsPanel:
         try:
             # master=None, żeby uniknąć błędu
             # "SettingsWindow object has no attribute 'tk'"
-            win = ToolsConfigDialog(
+            dlg = ToolsConfigDialog(
                 master=None, path=path, on_save=self._on_tools_config_saved
             )
         except Exception as exc:
@@ -526,9 +526,22 @@ class SettingsPanel:
             )
             return
 
-        _ensure_topmost(win)
+        # A-2g: preferujemy nowe API helpera, ale obsłuż oba warianty.
         try:
-            self.wait_window(win)
+            _ensure_topmost(dlg, self)
+        except TypeError:
+            try:
+                _ensure_topmost(dlg)
+            except Exception:
+                try:
+                    dlg.transient(self)
+                    dlg.grab_set()
+                    dlg.lift()
+                except Exception:
+                    pass
+
+        try:
+            self.wait_window(dlg)
         except Exception as exc:  # pragma: no cover - wait_window error handling
             log_akcja(f"[SETTINGS] ToolsConfigDialog wait failed: {exc}")
 


### PR DESCRIPTION
## Summary
- call `_ensure_topmost` with the settings window as parent when opening the tools editor
a- fall back to the legacy helper signature and manual transient handling if needed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c948651d8c8323a4997dfb0cf2ee1f