### PR TITLE
Use tool definitions for tool dialog selectors

### DIFF
--- a/test_gui_narzedzia_config.py
+++ b/test_gui_narzedzia_config.py
@@ -116,6 +116,7 @@ def test_panel_refreshes_after_config_change(monkeypatch, tmp_path):
     monkeypatch.setattr(gui_narzedzia, "apply_theme", lambda *a, **k: None)
     monkeypatch.setattr(gui_narzedzia, "clear_frame", lambda *a, **k: None)
     monkeypatch.setattr(gui_narzedzia, "_load_all_tools", lambda: [])
+    monkeypatch.setattr(gui_narzedzia, "_type_names_for_collection", lambda *a, **k: [])
 
     gui_narzedzia.panel_narzedzia(DummyWidget(), DummyWidget())
     assert "Specjalny" in gui_narzedzia._types_from_config()

--- a/test_gui_narzedzia_enter.py
+++ b/test_gui_narzedzia_enter.py
@@ -126,6 +126,15 @@ def test_enter_triggers_actions(monkeypatch):
     monkeypatch.setattr(gui_narzedzia, "_next_free_in_range", lambda lo, hi: "001")
     monkeypatch.setattr(gui_narzedzia, "_resolve_tools_dir", lambda: ".")
     monkeypatch.setattr(gui_narzedzia, "_types_from_config", lambda: [])
+    monkeypatch.setattr(
+        gui_narzedzia, "_type_names_for_collection", lambda *a, **k: ["Specjalny"]
+    )
+    monkeypatch.setattr(
+        gui_narzedzia, "_status_names_for_type", lambda *a, **k: ["s"]
+    )
+    monkeypatch.setattr(
+        gui_narzedzia, "_task_names_for_status", lambda *a, **k: []
+    )
     monkeypatch.setattr(gui_narzedzia, "_append_type_to_config", lambda v: True)
     monkeypatch.setattr(gui_narzedzia, "_tasks_for_type", lambda *a, **k: [])
     monkeypatch.setattr(gui_narzedzia, "_task_templates_from_config", lambda: [])


### PR DESCRIPTION
## Summary
- add cached helpers for resolving tool definition files and fetching types, statuses, and tasks
- load tool dialog comboboxes from definition data and drop inline type creation while keeping debug visibility
- adapt GUI narzędzia tests to stub the new helpers when running in isolation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8ac9e55083238b18a3dcd1a1194e