### PR TITLE
Update order settings schema and config

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,43 +34,31 @@
         "label": "Zlecenie wewnętrzne",
         "prefix": "ZW-",
         "reserve_by_default": false,
-        "requires_approval": false,
-        "wizard": false,
-        "statuses": ["nowe", "w trakcie", "zakończone", "anulowane"]
+        "allow_products": true,
+        "bom_required": true,
+        "statuses": ["nowe","w trakcie","zakończone","anulowane"]
       },
       "ZN": {
         "enabled": true,
         "label": "Zlecenie na narzędzie",
         "prefix": "ZN-",
         "reserve_by_default": true,
-        "requires_approval": false,
-        "wizard": true,
-        "statuses": [
-          "projekt",
-          "w budowie",
-          "1 próba",
-          "2 próba",
-          "odbiór",
-          "na produkcji",
-          "anulowane"
-        ]
+        "allow_old_tools": true,
+        "tools_range": [500,1000],
+        "statuses": ["projekt","w budowie","ostrzenie","naprawa","odbiór","na produkcji","anulowane"]
       },
       "ZM": {
         "enabled": true,
         "label": "Naprawa/awaria maszyny",
         "prefix": "ZM-",
         "reserve_by_default": true,
-        "requires_approval": false,
-        "wizard": true,
-        "statuses": [
-          "awaria zgłoszona",
-          "diagnoza",
-          "w naprawie",
-          "test",
-          "sprawdzona",
-          "zakończone",
-          "anulowane"
-        ]
+        "require_description": true,
+        "urgency_colors": {
+          "wysoki": "blink_red",
+          "normalny": "yellow",
+          "niski": "green"
+        },
+        "statuses": ["awaria zgłoszona","diagnoza","w naprawie","test","sprawdzona","zakończone","anulowane"]
       }
     }
   }

--- a/settings_schema.json
+++ b/settings_schema.json
@@ -97,12 +97,12 @@
               "label": { "type": "string", "default": "Zlecenie wewnętrzne" },
               "prefix": { "type": "string", "default": "ZW-" },
               "reserve_by_default": { "type": "boolean", "default": false },
-              "requires_approval": { "type": "boolean", "default": false },
-              "wizard": { "type": "boolean", "default": false },
+              "allow_products": { "type": "boolean", "default": true },
+              "bom_required": { "type": "boolean", "default": true },
               "statuses": {
                 "type": "array",
                 "items": { "type": "string" },
-                "default": ["nowe", "w trakcie", "zakończone", "anulowane"]
+                "default": ["nowe","w trakcie","zakończone","anulowane"]
               }
             },
             "required": ["enabled", "label", "prefix", "statuses"]
@@ -114,20 +114,16 @@
               "label": { "type": "string", "default": "Zlecenie na narzędzie" },
               "prefix": { "type": "string", "default": "ZN-" },
               "reserve_by_default": { "type": "boolean", "default": true },
-              "requires_approval": { "type": "boolean", "default": false },
-              "wizard": { "type": "boolean", "default": true },
+              "allow_old_tools": { "type": "boolean", "default": true },
+              "tools_range": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "default": [500,1000]
+              },
               "statuses": {
                 "type": "array",
                 "items": { "type": "string" },
-                "default": [
-                  "projekt",
-                  "w budowie",
-                  "1 próba",
-                  "2 próba",
-                  "odbiór",
-                  "na produkcji",
-                  "anulowane"
-                ]
+                "default": ["projekt","w budowie","ostrzenie","naprawa","odbiór","na produkcji","anulowane"]
               }
             },
             "required": ["enabled", "label", "prefix", "statuses"]
@@ -139,20 +135,19 @@
               "label": { "type": "string", "default": "Naprawa/awaria maszyny" },
               "prefix": { "type": "string", "default": "ZM-" },
               "reserve_by_default": { "type": "boolean", "default": true },
-              "requires_approval": { "type": "boolean", "default": false },
-              "wizard": { "type": "boolean", "default": true },
+              "require_description": { "type": "boolean", "default": true },
+              "urgency_colors": {
+                "type": "object",
+                "default": {
+                  "wysoki": "blink_red",
+                  "normalny": "yellow",
+                  "niski": "green"
+                }
+              },
               "statuses": {
                 "type": "array",
                 "items": { "type": "string" },
-                "default": [
-                  "awaria zgłoszona",
-                  "diagnoza",
-                  "w naprawie",
-                  "test",
-                  "sprawdzona",
-                  "zakończone",
-                  "anulowane"
-                ]
+                "default": ["awaria zgłoszona","diagnoza","w naprawie","test","sprawdzona","zakończone","anulowane"]
               }
             },
             "required": ["enabled", "label", "prefix", "statuses"]


### PR DESCRIPTION
## Summary
- extend the orders schema with new flags for internal, tooling, and machine orders, including urgency color defaults
- align the default config with the updated schema for ZW/ZN/ZM order types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba6ef913c8323a5384e42d59ab16a