### PR TITLE
Add configuration toggle for brygadzista pinless login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- [LOGOWANIE] Dodano przełącznik w ustawieniach systemu umożliwiający włączenie przycisku "Logowanie bez PIN" dla brygadzisty.
+
 ## 1.5.1 - 2025-09-09
 - [USTAWIENIA] Zapis plików bez znaku BOM.
 - [NARZĘDZIA] Limit typów i statusów do 8 × 8.

--- a/settings_schema.json
+++ b/settings_schema.json
@@ -190,6 +190,18 @@
               ]
             }
           ]
+        },
+        {
+          "key": "login",
+          "label": "Logowanie",
+          "fields": [
+            {
+              "key": "auth.pinless_brygadzista",
+              "type": "bool",
+              "label": "Logowanie brygadzisty bez PIN",
+              "description": "Dodaj przycisk logowania brygadzisty bez wpisywania PIN."
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary
- expose the `auth.pinless_brygadzista` option on the System tab so SettingsPanel renders a checkbox
- ensure GUI settings tests toggle and persist the value, verifying the login screen shows the pinless button
- document the new pinless login capability in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba9eed5048323a6b51fcaef267397