### PR TITLE
Fix order configuration access and machine selection fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-09-18 — Poprawki modułu Zleceń
+- Naprawiono obsługę ConfigManager w `zlecenia_utils.py` (użycie instancji zamiast metody klasy).
+- Naprawiono błąd w `gui_zlecenia_creator.py` przy wczytywaniu `data/maszyny.json` (obsługa listy i dict).
+- Zabezpieczono kreator ZM przed awarią przy nietypowej strukturze pliku maszyn.
+
 ## [Unreleased]
 - [LOGOWANIE] Dodano przełącznik w ustawieniach systemu umożliwiający włączenie przycisku "Logowanie bez PIN" dla brygadzisty.
 

--- a/gui_zlecenia_creator.py
+++ b/gui_zlecenia_creator.py
@@ -147,15 +147,28 @@ def open_order_creator(master: tk.Widget | None = None, autor: str = "system") -
                 with open(machines_path, "r", encoding="utf-8") as handle:
                     machines_data = json.load(handle)
             except Exception:
-                machines_data = {}
+                machines_data = []
+
+            if isinstance(machines_data, dict):
+                machines_raw = machines_data.get("maszyny", []) or []
+            elif isinstance(machines_data, list):
+                machines_raw = machines_data
+            else:
+                machines_raw = []
+
             machines = [
-                f"{machine.get('id')} - {machine.get('nazwa')}"
-                for machine in machines_data.get("maszyny", [])
-                if machine.get("id")
+                f"{machine.get('id')} - {machine.get('nazwa', '')}".strip()
+                for machine in machines_raw
+                if machine.get("id") is not None
             ]
 
             ttk.Label(container, text="Maszyna:").pack(anchor="w")
-            cb_machine = ttk.Combobox(container, values=machines, state="readonly")
+            cb_machine = ttk.Combobox(
+                container,
+                values=machines,
+                state="readonly",
+                width=40,
+            )
             cb_machine.pack(anchor="w")
             state["widgets"]["maszyna"] = cb_machine
 
@@ -165,12 +178,17 @@ def open_order_creator(master: tk.Widget | None = None, autor: str = "system") -
             state["widgets"]["opis"] = entry_desc
 
             ttk.Label(container, text="Pilność:").pack(anchor="w")
+            priority_values = ["niski", "normalny", "wysoki"]
             cb_priority = ttk.Combobox(
                 container,
-                values=["niski", "normalny", "wysoki"],
+                values=priority_values,
                 state="readonly",
+                width=12,
             )
             cb_priority.pack(anchor="w")
+            if priority_values:
+                default_idx = 1 if len(priority_values) > 1 else 0
+                cb_priority.current(default_idx)
             state["widgets"]["pilnosc"] = cb_priority
 
         else:

--- a/zlecenia_utils.py
+++ b/zlecenia_utils.py
@@ -15,15 +15,22 @@ try:
 except Exception:  # pragma: no cover - fallback dla środowisk testowych
     ConfigManager = None  # type: ignore
 
+try:
+    _CONFIG_MANAGER = ConfigManager() if ConfigManager else None
+except Exception:  # pragma: no cover - zabezpieczenie dla wyjątków inicjalizacji
+    _CONFIG_MANAGER = None
+
 DATA_DIR = os.path.join("data", "zlecenia")
 
 
 def _orders_cfg() -> Dict[str, object]:
     """Zwraca sekcję konfiguracyjną modułu zleceń."""
 
-    if ConfigManager:
-        cfg = ConfigManager.get()
-        return (cfg or {}).get("orders", {}) or {}
+    if _CONFIG_MANAGER:
+        try:
+            return _CONFIG_MANAGER.get("orders") or {}
+        except Exception:  # pragma: no cover - zabezpieczenie na wypadek błędnej konfiguracji
+            return {}
     return {}
 
 


### PR DESCRIPTION
## Summary
- initialize and reuse a ConfigManager instance when reading order settings
- harden the machine order creator against alternative maszyny.json structures
- document the fixes in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb1cf3f448323a12c020b99f22aef