### PR TITLE
Add ZZ purchase order integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2025-09-18 — Zlecenie Zakupu (ZZ)
+- Dodano nowy typ zlecenia: ZZ (Zlecenie zakupu).
+- Kreator ZZ: wybór materiału z katalogu magazynu albo wpisanie nowego materiału ręcznie.
+- Obsługa pól: materiał, ilość, dostawca, termin.
+- Przy zapisie ZZ tworzony jest draft w `data/zamowienia_oczekujace.json`.
+- Nowe materiały (spoza magazynu) oznaczane są flagą `"nowy": true`.
+
 # Changelog
 
 ## [Unreleased]

--- a/config.json
+++ b/config.json
@@ -59,6 +59,12 @@
           "niski": "green"
         },
         "statuses": ["awaria zgłoszona","diagnoza","w naprawie","test","sprawdzona","zakończone","anulowane"]
+      },
+      "ZZ": {
+        "enabled": true,
+        "label": "Zlecenie zakupu",
+        "prefix": "ZZ-",
+        "statuses": ["nowe","oczekuje na dostawę","zrealizowane","anulowane"]
       }
     }
   }

--- a/gui_zlecenia_detail.py
+++ b/gui_zlecenia_detail.py
@@ -47,6 +47,15 @@ def open_order_detail(master: tk.Widget, order: dict[str, Any]) -> tk.Toplevel:
         ttk.Label(frame, text=f"Maszyna: {order.get('maszyna_id', '–')}").pack(anchor="w")
         ttk.Label(frame, text=f"Awaria: {order.get('awaria', '')}").pack(anchor="w")
         ttk.Label(frame, text=f"Pilność: {order.get('pilnosc', '')}").pack(anchor="w")
+    elif order.get("rodzaj") == "ZZ":
+        ttk.Label(frame, text=f"Materiał: {order.get('material')}").pack(anchor="w")
+        ttk.Label(frame, text=f"Ilość: {order.get('ilosc')}").pack(anchor="w")
+        if order.get("dostawca"):
+            ttk.Label(frame, text=f"Dostawca: {order.get('dostawca')}").pack(anchor="w")
+        if order.get("termin"):
+            ttk.Label(frame, text=f"Termin: {order.get('termin')}").pack(anchor="w")
+        if order.get("nowy"):
+            ttk.Label(frame, text="(Nowy materiał spoza magazynu)").pack(anchor="w")
 
     ttk.Label(frame, text="Historia:").pack(anchor="w", pady=(12, 0))
     historia = order.get("historia", []) or []


### PR DESCRIPTION
## Summary
- add the ZZ purchase order type to the configuration and document the change in the changelog
- extend the order creator and detail views to handle ZZ orders with material, quantity, supplier, and due date fields
- update order utilities to support ZZ IDs and write pending purchase drafts to `data/zamowienia_oczekujace.json`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb2c343288323ae96294b05efff11