### PR TITLE
Fix statuses_for configuration handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2025-09-18 — Poprawka funkcji statuses_for
+- Naprawiono błąd w `zlecenia_utils.py`, który powodował wyjątek
+  (`'str' object has no attribute 'get'`) przy odczycie statusów z configa.
+- Funkcja `statuses_for` teraz sprawdza typ danych i bezpiecznie zwraca listę statusów
+  lub pustą listę, gdy struktura jest niepoprawna.
+
 ## 2025-09-18 — Cleanup Magazynu
 - Usunięto plik `gui_magazyn_order.py` (stary kreator zamówień).
 - W `gui_magazyn.py` podłączono wyłącznie nowy kreator zleceń (`open_order_creator`).

--- a/zlecenia_utils.py
+++ b/zlecenia_utils.py
@@ -1,9 +1,10 @@
 """Narzędzia pomocnicze dla modułu zleceń."""
 
-# Wersja pliku: 1.3.0
+# Wersja pliku: 1.3.1
 # Zmiany:
 # - skeleton dla ZZ
 # - zapis draftu do zamowienia_oczekujace.json
+# - poprawiona funkcja statuses_for (bezpieczne sprawdzanie typu)
 
 from __future__ import annotations
 
@@ -115,7 +116,16 @@ def next_order_id(kind: str) -> str:
 
 
 def statuses_for(kind: str) -> List[str]:
-    return _orders_types().get(kind, {}).get("statuses", []) or []
+    types = _orders_types()
+    if not isinstance(types, dict):
+        return []
+    kind_cfg = types.get(kind)
+    if not isinstance(kind_cfg, dict):
+        return []
+    statuses = kind_cfg.get("statuses", [])
+    if not isinstance(statuses, list):
+        return []
+    return statuses or []
 
 
 def is_valid_status(kind: str, status: str) -> bool:


### PR DESCRIPTION
## Summary
- document the statuses_for regression fix in the changelog
- guard statuses_for against malformed order type configuration data to avoid runtime errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb9fcc6c08323950c58b4e78d22ac