### PR TITLE
Add default order types fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-09-18 — Fallback typów ZW/ZN/ZM/ZZ w zleceniach
+- Dodano domyślne typy zleceń (ZW/ZN/ZM/ZZ) z prefixami i statusami w `zlecenia_utils.py`.
+- `_orders_types()` teraz **scala** wartości z `config.json` z domyślnymi i loguje wynik (`[WM-DBG][ZLECENIA] types=...`).
+- Dzięki temu błąd „Nieznany rodzaj: ZW” nie wystąpi nawet przy brakującym/niepełnym configu.
+
 ## 2025-09-18 — Stabilizacja kreatora zleceń (ZW/ZN/ZM/ZZ)
 - Ujednolicono przekazywanie danych z kreatora: teraz trafiają **proste pola**
   (`produkt`, `narzedzie_id`, `maszyna_id`, `material`, `ilosc`, itp.), bez


### PR DESCRIPTION
## Summary
- add default order type definitions and merge them with configuration with additional diagnostics
- update the changelog to document the fallback order types behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc094ff408323a087b9f23fae4a2a