### PR TITLE
Make settings window scrollable with fixed footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-09-18 — Ustawienia: przewijanie i stała stopka
+- Dodano przewijanie (scroll) dla zawartości zakładek w module **Ustawienia**.
+- Stopka z przyciskami (Zapisz/Anuluj) jest teraz przypięta do dołu okna i zawsze widoczna.
+- Okno Ustawień startuje dopasowane do ekranu (max ~80% wysokości) i nie wymaga ręcznego powiększania.
+
 ## 2025-09-18 — Rozbudowa ustawień zleceń
 - Zakładka „Zlecenia” w ustawieniach rozbudowana o sekcje:
   - Definicje typów zleceń (ZW/ZN/ZM/ZZ),

--- a/start.py
+++ b/start.py
@@ -325,7 +325,15 @@ def open_settings_window(root):
     print("[WM-DBG] open_settings_window()")
     win = Toplevel(root)
     win.title("Ustawienia – Warsztat Menager")
-    win.geometry("1000x680")
+    try:
+        screen_h = win.winfo_screenheight()
+        screen_w = win.winfo_screenwidth()
+        height = int(screen_h * 0.8)
+        width = min(1100, int(screen_w * 0.85))
+        win.geometry(f"{width}x{height}")
+        win.minsize(900, 600)
+    except Exception:
+        win.geometry("1000x680")
     apply_theme(win)
     SettingsWindow(
         win,


### PR DESCRIPTION
## Summary
- document the scrollable settings window and fixed footer in the changelog
- wrap the settings notebook in a reusable ScrollableFrame and pin the action buttons to a footer with a cancel option
- size the settings window to ~80% of the screen with a sensible minimum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbdfe3fe1c8323bc8e112f8ab18703