### PR TITLE
Add devOnly flag to tests tab

### DIFF
--- a/settings_schema.json
+++ b/settings_schema.json
@@ -288,6 +288,7 @@
       "title": "[DEV] Testy",
       "description": "Zakładka testowa – tylko do użytku deweloperskiego.",
       "tooltip": "Opcje techniczne używane tylko podczas prac deweloperskich.",
+      "devOnly": true,
       "icon": "beaker",
       "sections": []
     }


### PR DESCRIPTION
## Summary
- mark the developer-only Tests tab with a `devOnly` flag so it can be hidden outside DEV builds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd748c45048323a74644542d0767e9