### PR TITLE
Add ProfileView dark layout skeleton

### DIFF
--- a/gui_profile.py
+++ b/gui_profile.py
@@ -693,3 +693,389 @@ def uruchom_panel(root, frame, login=None, rola=None):
 
 # API zgodne z wcześniejszymi wersjami:
 panel_profil = uruchom_panel
+
+
+# ========================
+#  Ciemny widok PROFILU  
+# ========================
+
+# --- Kolory motywu (dopasowane do widoku WM) ---
+WM_BG = "#121415"  # tło główne
+WM_BG_ELEV = "#1A1D1F"  # karty/panele
+WM_BG_ELEV_2 = "#212529"  # akcentowane panele
+WM_TEXT = "#E6E7E8"  # tekst jasny
+WM_TEXT_MUTED = "#A7A9AB"  # tekst przygaszony
+WM_ACCENT = "#FF6B1A"  # pomarańczowy akcent
+WM_ACCENT_DARK = "#2B2F31"  # ciemny hover/obramowanie
+WM_DIVIDER = "#2A2E31"
+
+
+class ProfileView(ttk.Frame):
+    """Widok profilu użytkownika w układzie cover + kolumny.
+
+    Layout inspirowany makietą WM. Nie wykorzystuje danych z modułów
+    produkcyjnych – prezentuje statyczny szkielet do dalszej rozbudowy.
+    """
+
+    def __init__(
+        self,
+        master,
+        login="edwin",
+        display_name="Edwin Karolczyk",
+        rola="brygadzista",
+        zatrudniony_od="2022-04-01",
+        staz_lata=3,
+        **kwargs,
+    ):
+        super().__init__(master, **kwargs)
+        self.configure(style="WM.Container.TFrame")
+        self.login = login
+        self.display_name = display_name
+        self.rola = rola
+        self.zatrudniony_od = zatrudniony_od
+        self.staz_lata = staz_lata
+        self.active_tab = tk.StringVar(value="Oś")
+
+        self._init_styles()
+        self._build_cover_header()
+        self._build_tabs()
+        self._build_columns()
+        print("[WM-DBG][PROFILE] Widok profilu zainicjalizowany.")
+
+    # ---------- STYLES ----------
+    def _init_styles(self) -> None:
+        style = ttk.Style(self)
+        try:
+            style.theme_use("clam")
+        except tk.TclError:
+            # Gdy motyw "clam" nie istnieje, pozostaw bieżący motyw.
+            pass
+
+        style.configure("WM.Container.TFrame", background=WM_BG)
+        style.configure("WM.Card.TFrame", background=WM_BG_ELEV, relief="flat")
+        style.configure("WM.Header.TFrame", background=WM_BG, relief="flat")
+        style.configure("WM.Cover.TFrame", background=WM_ACCENT_DARK)
+        style.configure("WM.Label", background=WM_BG, foreground=WM_TEXT)
+        style.configure(
+            "WM.Muted.TLabel",
+            background=WM_BG,
+            foreground=WM_TEXT_MUTED,
+        )
+        style.configure(
+            "WM.CardLabel.TLabel",
+            background=WM_BG_ELEV,
+            foreground=WM_TEXT,
+        )
+        style.configure(
+            "WM.CardMuted.TLabel",
+            background=WM_BG_ELEV,
+            foreground=WM_TEXT_MUTED,
+        )
+        style.configure(
+            "WM.Button.TButton",
+            background=WM_BG_ELEV_2,
+            foreground=WM_TEXT,
+            borderwidth=0,
+            padding=(14, 8),
+        )
+        style.map("WM.Button.TButton", background=[("active", WM_ACCENT_DARK)])
+        style.configure(
+            "WM.Outline.TButton",
+            background=WM_BG,
+            foreground=WM_TEXT,
+            borderwidth=1,
+        )
+        style.configure(
+            "WM.Tag.TLabel",
+            background=WM_BG_ELEV_2,
+            foreground=WM_TEXT,
+            padding=(6, 2),
+        )
+        style.configure(
+            "WM.Section.TLabelframe",
+            background=WM_BG_ELEV,
+            foreground=WM_TEXT,
+        )
+        style.configure(
+            "WM.Section.TLabelframe.Label",
+            background=WM_BG_ELEV,
+            foreground=WM_TEXT_MUTED,
+        )
+
+    # ---------- COVER + AVATAR + INFO + PRZYCISKI ----------
+    def _build_cover_header(self) -> None:
+        cover = ttk.Frame(self, style="WM.Cover.TFrame")
+        cover.pack(fill="x", padx=16, pady=(16, 8))
+        cover.configure(height=180)
+        cover.grid_propagate(False)
+
+        inner = ttk.Frame(cover, style="WM.Header.TFrame")
+        inner.place(
+            relx=0,
+            rely=1.0,
+            x=0,
+            y=-20,
+            relwidth=1.0,
+            anchor="sw",
+        )
+
+        avatar = tk.Canvas(inner, width=96, height=96, highlightthickness=0, bg=WM_BG)
+        avatar.create_oval(2, 2, 94, 94, fill="#2E3236", outline=WM_DIVIDER, width=2)
+        avatar.create_text(
+            48,
+            48,
+            text=str(self.login or "?").upper()[:2],
+            fill=WM_TEXT,
+            font=("Segoe UI", 20, "bold"),
+        )
+        avatar.grid(row=0, column=0, rowspan=2, padx=(16, 12), pady=6, sticky="w")
+
+        info = ttk.Frame(inner, style="WM.Header.TFrame")
+        info.grid(row=0, column=1, sticky="w")
+        ttk.Label(
+            info,
+            text=self.display_name,
+            style="WM.Label",
+            font=("Segoe UI", 18, "bold"),
+        ).pack(anchor="w")
+        ttk.Label(info, text=f"@{self.login}", style="WM.Muted.TLabel").pack(
+            anchor="w",
+            pady=(2, 6),
+        )
+        ttk.Label(
+            info,
+            text=(
+                f"Rola: {self.rola}    Staż: {self.staz_lata} lata "
+                f"(od {self.zatrudniony_od})"
+            ),
+            style="WM.Muted.TLabel",
+        ).pack(anchor="w")
+
+        actions = ttk.Frame(inner, style="WM.Header.TFrame")
+        actions.grid(row=0, column=2, rowspan=2, sticky="e", padx=16)
+        buttons = [
+            ("Wyślij PW", self._on_send_pw),
+            ("Kto ma najmniej zadań?", self._on_least_tasks),
+            ("Przejdź do Ustawienia", self._on_open_settings),
+        ]
+        for i, (txt, cmd) in enumerate(buttons):
+            btn = ttk.Button(actions, text=txt, style="WM.Button.TButton", command=cmd)
+            btn.grid(row=0, column=i, padx=6)
+
+        sep = tk.Frame(self, height=1, bg=WM_DIVIDER)
+        sep.pack(fill="x", padx=16, pady=(8, 0))
+
+    # ---------- ZAKŁADKI ----------
+    def _build_tabs(self) -> None:
+        tabs = ttk.Frame(self, style="WM.Header.TFrame")
+        tabs.pack(fill="x", padx=16)
+
+        def make_tab(text: str) -> ttk.Frame:
+            frm = ttk.Frame(tabs, style="WM.Header.TFrame")
+            lbl = ttk.Label(frm, text=text, style="WM.Label")
+            lbl.pack(padx=8, pady=10)
+            underline = tk.Frame(
+                frm,
+                height=3,
+                bg=WM_ACCENT if self.active_tab.get() == text else WM_BG,
+            )
+            underline.pack(fill="x")
+            frm.bind("<Button-1>", lambda _e, tab=text: self._activate_tab(tab))
+            lbl.bind("<Button-1>", lambda _e, tab=text: self._activate_tab(tab))
+            return frm
+
+        self._tab_widgets: dict[str, ttk.Frame] = {}
+        for name in ("Oś", "O mnie", "Zadania", "Narzędzia", "PW"):
+            widget = make_tab(name)
+            widget.pack(side="left")
+            self._tab_widgets[name] = widget
+
+        sep = tk.Frame(self, height=1, bg=WM_DIVIDER)
+        sep.pack(fill="x", padx=16, pady=(0, 8))
+
+    def _activate_tab(self, name: str) -> None:
+        self.active_tab.set(name)
+        for tab_name, widget in self._tab_widgets.items():
+            underline = widget.winfo_children()[1]
+            underline.configure(
+                bg=WM_ACCENT if tab_name == name else WM_BG,
+            )
+        print(f"[WM-DBG][PROFILE] Aktywowano zakładkę: {name}")
+
+    # ---------- TRZY KOLUMNY ----------
+    def _build_columns(self) -> None:
+        content = ttk.Frame(self, style="WM.Container.TFrame")
+        content.pack(fill="both", expand=True, padx=16, pady=(4, 16))
+
+        content.columnconfigure(0, weight=1)
+        content.columnconfigure(1, weight=2)
+        content.columnconfigure(2, weight=1)
+        content.rowconfigure(0, weight=1)
+
+        left = ttk.Frame(content, style="WM.Card.TFrame")
+        left.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        self._build_about(left)
+
+        center = ttk.Frame(content, style="WM.Card.TFrame")
+        center.grid(row=0, column=1, sticky="nsew", padx=8)
+        self._build_timeline(center)
+
+        right = ttk.Frame(content, style="WM.Card.TFrame")
+        right.grid(row=0, column=2, sticky="nsew", padx=(8, 0))
+        self._build_shortcuts(right)
+
+    def _build_about(self, parent: ttk.Frame) -> None:
+        parent.pack_propagate(False)
+        wrap = ttk.Frame(parent, style="WM.Card.TFrame", padding=12)
+        wrap.pack(fill="both", expand=True)
+
+        ttk.Label(
+            wrap,
+            text="O MNIE",
+            style="WM.CardMuted.TLabel",
+            font=("Segoe UI", 10, "bold"),
+        ).pack(anchor="w", pady=(0, 8))
+
+        def row(label: str, value: str) -> None:
+            container = ttk.Frame(wrap, style="WM.Card.TFrame")
+            container.pack(fill="x", pady=4)
+            ttk.Label(container, text=label, style="WM.CardMuted.TLabel").pack(
+                side="left",
+            )
+            ttk.Label(container, text=value, style="WM.CardLabel.TLabel").pack(
+                side="right",
+            )
+
+        row("Login:", self.login)
+        row("Rola:", self.rola)
+        row("Zatrudniony od:", self.zatrudniony_od or "—")
+        row("Status:", "aktywny")
+        row("Kontakt:", "—")
+        row("Umiejętności:", "spawanie")
+
+    def _build_timeline(self, parent: ttk.Frame) -> None:
+        parent.pack_propagate(False)
+        wrap = ttk.Frame(parent, style="WM.Card.TFrame", padding=12)
+        wrap.pack(fill="both", expand=True)
+
+        ttk.Label(
+            wrap,
+            text="OŚ AKTYWNOŚCI",
+            style="WM.CardMuted.TLabel",
+            font=("Segoe UI", 10, "bold"),
+        ).pack(anchor="w", pady=(0, 8))
+
+        self._timeline_item(
+            wrap,
+            "12:41 — Otrzymano PW od Dawid",
+            refs=[("Zadanie", "ZAD-0148"), ("Narzędzie", "NN-508")],
+        )
+        self._timeline_item(
+            wrap,
+            "10:05 — Przegląd NN-508   Status: W TOKU",
+        )
+        self._timeline_item(
+            wrap,
+            "09:10 — Narzędzie NN-508 przypisane do @edwin",
+        )
+
+    def _timeline_item(
+        self,
+        parent: ttk.Frame,
+        text: str,
+        refs: list[tuple[str, str]] | None = None,
+    ) -> None:
+        box = ttk.Frame(parent, style="WM.Card.TFrame")
+        box.pack(fill="x", pady=6)
+
+        dot = tk.Canvas(box, width=10, height=10, bg=WM_BG_ELEV, highlightthickness=0)
+        dot.create_oval(2, 2, 8, 8, fill=WM_ACCENT, outline=WM_ACCENT)
+        dot.pack(side="left", padx=(0, 8), pady=4)
+
+        body = ttk.Frame(box, style="WM.Card.TFrame")
+        body.pack(side="left", fill="x", expand=True)
+
+        ttk.Label(body, text=text, style="WM.CardLabel.TLabel").pack(anchor="w")
+
+        if refs:
+            pillbar = ttk.Frame(body, style="WM.Card.TFrame")
+            pillbar.pack(anchor="w", pady=4)
+            for label, ref_id in refs:
+                ttk.Label(pillbar, text=label, style="WM.Tag.TLabel").pack(
+                    side="left",
+                    padx=(0, 6),
+                )
+                ttk.Label(pillbar, text=ref_id, style="WM.Tag.TLabel").pack(
+                    side="left",
+                    padx=(0, 12),
+                )
+
+    def _build_shortcuts(self, parent: ttk.Frame) -> None:
+        parent.pack_propagate(False)
+        wrap = ttk.Frame(parent, style="WM.Card.TFrame", padding=12)
+        wrap.pack(fill="both", expand=True)
+
+        ttk.Label(
+            wrap,
+            text="SKRÓTY",
+            style="WM.CardMuted.TLabel",
+            font=("Segoe UI", 10, "bold"),
+        ).pack(anchor="w", pady=(0, 8))
+
+        for text in (
+            "Dzisiejsze zadania (3)",
+            "Narzędzia przypisane (2)",
+            "Ostatnie PW (5)",
+        ):
+            row = ttk.Frame(wrap, style="WM.Card.TFrame")
+            row.pack(fill="x", pady=4)
+            ttk.Label(row, text=text, style="WM.CardLabel.TLabel").pack(anchor="w")
+
+        sep = tk.Frame(wrap, height=1, bg=WM_DIVIDER)
+        sep.pack(fill="x", pady=8)
+
+        ttk.Label(
+            wrap,
+            text="SZYBKIE AKCJE",
+            style="WM.CardMuted.TLabel",
+            font=("Segoe UI", 10, "bold"),
+        ).pack(anchor="w", pady=(0, 8))
+
+        actions = [
+            ("Nowa wiadomość (PW)", self._on_send_pw),
+            ("Symuluj zdarzenie awarii", self._on_sim_event),
+            ("Podgląd mojego grafiku", self._on_open_schedule),
+        ]
+        for text, cmd in actions:
+            btn = ttk.Button(wrap, text=text, style="WM.Button.TButton", command=cmd)
+            btn.pack(fill="x", pady=4)
+
+    # ---------- Handlery (szkielet) ----------
+    def _on_send_pw(self) -> None:
+        print("[WM-DBG][PROFILE] Klik: Wyślij PW (do spięcia z modułem PW).")
+
+    def _on_least_tasks(self) -> None:
+        print("[WM-DBG][PROFILE] Klik: Kto ma najmniej zadań? (ranking placeholder).")
+
+    def _on_open_settings(self) -> None:
+        print(
+            "[WM-DBG][PROFILE] Klik: Przejdź do Ustawienia → Profile (placeholder)."
+        )
+
+    def _on_sim_event(self) -> None:
+        print("[WM-DBG][PROFILE] Klik: Symuluj zdarzenie awarii (placeholder).")
+
+    def _on_open_schedule(self) -> None:
+        print("[WM-DBG][PROFILE] Klik: Podgląd grafiku (placeholder).")
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    root.title("WM – PROFIL (podgląd)")
+    root.configure(bg=WM_BG)
+    container = ttk.Frame(root, style="WM.Container.TFrame")
+    container.pack(fill="both", expand=True)
+    view = ProfileView(container)
+    view.pack(fill="both", expand=True)
+    root.geometry("1100x720")
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add a dark-themed `ProfileView` widget that mirrors the cover, tab, and column layout from the WM profile mockup
- define reusable WM color constants and component styles used by the new view
- provide placeholder handlers and a local `__main__` preview for manual inspection of the skeleton UI

## Testing
- `pytest test_gui_profile_smoke.py test_gui_profile_roles.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'test_config_manager' in several settings-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d557e18483239e3c9d0d73a6c52e