### PR TITLE
Add ProfileView dark layout skeleton

### DIFF
--- a/gui_profile.py
+++ b/gui_profile.py
@@ -27,6 +27,7 @@ import json
 import glob
 import re
 import tkinter as tk
+from contextlib import suppress
 from pathlib import Path
 from tkinter import ttk, messagebox
 from datetime import datetime as _dt
@@ -107,6 +108,17 @@ def _load_assign_tools():
 
 def _save_assign_tool(task_id, login):
     save_assign_tool(task_id, login)
+
+
+def _disable_geometry_propagation(widget: tk.Misc) -> None:
+    """Prevent geometry managers from shrinking the widget unexpectedly."""
+
+    for method_name in ("pack_propagate", "grid_propagate"):
+        method = getattr(widget, method_name, None)
+        if method is None:
+            continue
+        with suppress(tk.TclError):
+            method(False)
 
 def _login_list():
     """Zbiera loginy z profili, avatarów i plików zadań."""
@@ -807,7 +819,7 @@ class ProfileView(ttk.Frame):
         cover = ttk.Frame(self, style="WM.Cover.TFrame")
         cover.pack(fill="x", padx=16, pady=(16, 8))
         cover.configure(height=180)
-        cover.pack_propagate(False)
+        _disable_geometry_propagation(cover)
 
         inner = ttk.Frame(cover, style="WM.Header.TFrame")
         inner.place(


### PR DESCRIPTION
## Summary
- add a dark-themed `ProfileView` widget that mirrors the cover, tab, and column layout from the WM profile mockup
- define reusable WM color constants and component styles used by the new view
- provide placeholder handlers and a local `__main__` preview for manual inspection of the skeleton UI
- guard the `ProfileView` cover frame height by disabling geometry propagation for both pack/grid managers

## Testing
- `pytest test_gui_profile_smoke.py test_gui_profile_roles.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'test_config_manager' in several settings-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d0df3872208323b916cc8a5ca9d138