### PR TITLE
Handle missing machine list in hall renderer

### DIFF
--- a/widok_hali/renderer.py
+++ b/widok_hali/renderer.py
@@ -281,10 +281,15 @@ class Tooltip:
 class Renderer:
     """Renderer widoku hali."""
 
-    def __init__(self, root: tk.Tk, canvas: tk.Canvas, machines: List[dict]):
+    def __init__(
+        self,
+        root: tk.Tk,
+        canvas: tk.Canvas,
+        machines: Optional[List[dict]] = None,
+    ):
         self.root = root
         self.canvas = canvas
-        self.machines: List[Machine] = [Machine(m) for m in machines]
+        self.machines: List[Machine] = [Machine(m) for m in machines or []]
 
         self._dot_items: Dict[str, int] = {}
         self._blink_state = True
@@ -309,8 +314,8 @@ class Renderer:
         self._start_blink()
 
     # public API -----------------------------------------------------
-    def reload(self, machines: List[dict]) -> None:
-        self.machines = [Machine(m) for m in machines]
+    def reload(self, machines: Optional[List[dict]]) -> None:
+        self.machines = [Machine(m) for m in machines or []]
         self._preview_cache.clear()
         self.draw_all()
 


### PR DESCRIPTION
## Summary
- allow instantiating the hall renderer without preloaded machine data
- guard reload so it tolerates `None` and clears cached previews safely

## Testing
- `pytest` *(fails: missing optional test fixture module `test_config_manager` required by several GUI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e13a407483239d307e9766e4de91