### PR TITLE
Dodaj konfigurację tła hali w ustawieniach maszyn

### DIFF
--- a/settings_schema.json
+++ b/settings_schema.json
@@ -267,6 +267,36 @@
               "placeholder": "np. C:\\\\wm\\\\data\\\\hala_bg.jpg"
             },
             {
+              "type": "button",
+              "key": "hall.background_image_pick",
+              "label": "Wybierz z dysku…",
+              "action": "dialog.open_file",
+              "params": {
+                "filters": ["*.png","*.jpg","*.jpeg"],
+                "write_to_key": "hall.background_image"
+              }
+            },
+            {
+              "type": "select",
+              "key": "hall.background_fit",
+              "label": "Dopasowanie tła",
+              "options": [
+                {"label":"Dopasuj (contain)","value":"contain"},
+                {"label":"Wypełnij (cover)","value":"cover"},
+                {"label":"Rozciągnij","value":"stretch"},
+                {"label":"Oryginalny rozmiar","value":"none"}
+              ],
+              "default": "contain"
+            },
+            {
+              "type": "number",
+              "key": "hall.background_opacity",
+              "label": "Przezroczystość tła (%)",
+              "default": 100,
+              "min": 0,
+              "max": 100
+            },
+            {
               "type": "boolean",
               "key": "hall.show_numbers",
               "label": "Pokaż numery hal na maszynach",


### PR DESCRIPTION
## Summary
- dodano przycisk wyboru pliku tła hali oraz ustawienia dopasowania i przezroczystości
- rozszerzono sekcję "Widok i siatka" o nowe parametry konfiguracji

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38e4ece8c8323bc00bcc8c4098062