### PR TITLE
Add room configuration settings for machines tab

### DIFF
--- a/settings_schema.json
+++ b/settings_schema.json
@@ -338,6 +338,39 @@
               "default": true
             }
           ]
+        },
+        {
+          "title": "Pomieszczenia i ściany (ustawienia)",
+          "fields": [
+            {
+              "type": "boolean",
+              "key": "hall.rooms_enabled",
+              "label": "Włącz warstwę pomieszczeń",
+              "default": true
+            },
+            {
+              "type": "number",
+              "key": "hall.rooms_limit",
+              "label": "Maks. liczba pomieszczeń",
+              "default": 10,
+              "min": 1,
+              "max": 50
+            },
+            {
+              "type": "array",
+              "key": "hall.room_types",
+              "label": "Typy pomieszczeń",
+              "default": ["Biuro","Magazyn","Produkcja","Kontrola","Komunikacja"]
+            },
+            {
+              "type": "number",
+              "key": "hall.default_wall_thickness_mm",
+              "label": "Domyślna grubość ściany (mm)",
+              "default": 120,
+              "min": 50,
+              "max": 500
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add a new "Pomieszczenia i ściany" group to the machines settings schema with room and wall configuration options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d39cc1eaf483239c79fb1ae7c17b20