### PR TITLE
Add auto-check hint to tools rules settings

### DIFF
--- a/settings_schema.json
+++ b/settings_schema.json
@@ -459,6 +459,11 @@
                   "key": "tools.auto_check_on_last_status",
                   "label": "Odhaczaj zadania przy ostatnim statusie",
                   "default": true
+                },
+                {
+                  "type": "info",
+                  "key": "tools.auto_check_hint",
+                  "text": "Jeśli włączone: po ustawieniu ostatniego statusu z listy 'Statusy narzędzi' wszystkie zadania zostaną oznaczone jako wykonane."
                 }
               ]
             },


### PR DESCRIPTION
## Summary
- add an informational hint to the Narzędzia → Reguły auto-check group describing the completed tasks behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3af28a2cc8323967c2567c347498b