### PR TITLE
Add message rotation and search utilities

### DIFF
--- a/services/messages_service.py
+++ b/services/messages_service.py
@@ -1,30 +1,57 @@
 # -*- coding: utf-8 -*-
-# services/messages_service.py
 from __future__ import annotations
 
-import os
 import json
+import os
 import uuid
 from datetime import datetime, timezone
-from typing import List, Dict, Optional, Any
+from typing import Optional
 
 BASE_DIR = os.path.join("data", "messages")
 os.makedirs(BASE_DIR, exist_ok=True)
+MAX_LINES = 10_000  # rotacja po 10k lini
+
 
 def _path(login: str) -> str:
     return os.path.join(BASE_DIR, f"{login}.jsonl")
 
-def _append(login: str, rec: Dict[str, Any]) -> None:
-    p = _path(login)
-    with open(p, "a", encoding="utf-8") as fh:
+
+def _count_lines(path: str) -> int:
+    if not os.path.exists(path):
+        return 0
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return sum(1 for _ in fh)
+    except Exception:
+        return 0
+
+
+def _rotate_if_needed(path: str) -> None:
+    if not os.path.exists(path):
+        return
+    if _count_lines(path) < MAX_LINES:
+        return
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    archive = path.replace(".jsonl", f".{timestamp}.jsonl")
+    try:
+        os.replace(path, archive)
+    except Exception:
+        pass
+
+
+def _append(login: str, rec: dict) -> None:
+    path = _path(login)
+    _rotate_if_needed(path)
+    with open(path, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
-def _read_all(login: str) -> List[Dict[str, Any]]:
-    p = _path(login)
-    if not os.path.exists(p):
+
+def _read_all(login: str) -> list[dict]:
+    path = _path(login)
+    if not os.path.exists(path):
         return []
-    out: List[Dict[str, Any]] = []
-    with open(p, "r", encoding="utf-8") as fh:
+    out: list[dict] = []
+    with open(path, "r", encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if not line:
@@ -35,17 +62,23 @@ def _read_all(login: str) -> List[Dict[str, Any]]:
                 continue
     return out
 
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def send_message(
     sender: str,
     to: str,
     subject: str,
     body: str,
-    refs: Optional[List[Dict[str, Any]]] = None,
-) -> Dict[str, Any]:
-    """Zapisuje wiadomość do skrzynki nadawcy i odbiorcy."""
-    msg: Dict[str, Any] = {
+    refs: Optional[list[dict]] = None,
+) -> dict:
+    """Zapisuje wiadomość do skrzynki nadawcy i odbiorcy (obie kopie)."""
+
+    msg = {
         "id": str(uuid.uuid4()),
-        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "ts": _now_iso(),
         "from": sender,
         "to": to,
         "subject": subject or "",
@@ -55,26 +88,76 @@ def send_message(
     }
     _append(sender, dict(msg, folder="sent"))
     _append(to, dict(msg, folder="inbox"))
+    _append(to, {"folder": "_last_marker", "ts": msg["ts"]})
     return msg
 
-def list_inbox(login: str) -> List[Dict[str, Any]]:
-    return [m for m in _read_all(login) if m.get("folder") == "inbox"]
 
-def list_sent(login: str) -> List[Dict[str, Any]]:
-    return [m for m in _read_all(login) if m.get("folder") == "sent"]
+def list_inbox(login: str, *, q: Optional[str] = None) -> list[dict]:
+    rows = [m for m in _read_all(login) if m.get("folder") == "inbox"]
+    if q:
+        query = q.lower()
+        rows = [
+            m
+            for m in rows
+            if query in (
+                (m.get("subject", "") + m.get("from", "") + m.get("body", ""))
+            ).lower()
+        ]
+    rows.sort(key=lambda m: m.get("ts", ""), reverse=True)
+    return rows
+
+
+def list_sent(login: str, *, q: Optional[str] = None) -> list[dict]:
+    rows = [m for m in _read_all(login) if m.get("folder") == "sent"]
+    if q:
+        query = q.lower()
+        rows = [
+            m
+            for m in rows
+            if query in (
+                (m.get("subject", "") + m.get("to", "") + m.get("body", ""))
+            ).lower()
+        ]
+    rows.sort(key=lambda m: m.get("ts", ""), reverse=True)
+    return rows
+
+
+def last_inbox_ts(login: str) -> str | None:
+    """Zwraca timestamp ostatniego markera _last_marker (na końcu pliku)."""
+
+    path = _path(login)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            back = min(size, 8192)
+            fh.seek(-back, os.SEEK_END)
+            tail = fh.read().decode("utf-8", errors="ignore").splitlines()
+            for line in reversed(tail):
+                try:
+                    record = json.loads(line)
+                except Exception:
+                    continue
+                if record.get("folder") == "_last_marker":
+                    return record.get("ts")
+    except Exception:
+        return None
+    return None
+
 
 def mark_read(login: str, msg_id: str, read: bool = True) -> bool:
-    """Prosta implementacja: przepisuje plik ustawiając 'read' dla danego id w Inbox."""
-    p = _path(login)
+    path = _path(login)
     arr = _read_all(login)
     changed = False
-    for m in arr:
-        if m.get("id") == msg_id and m.get("folder") == "inbox":
-            m["read"] = bool(read)
+    for message in arr:
+        if message.get("id") == msg_id and message.get("folder") == "inbox":
+            message["read"] = bool(read)
             changed = True
-    tmp = p + ".tmp"
+    tmp = path + ".tmp"
     with open(tmp, "w", encoding="utf-8") as fh:
-        for m in arr:
-            fh.write(json.dumps(m, ensure_ascii=False) + "\n")
-    os.replace(tmp, p)
+        for message in arr:
+            fh.write(json.dumps(message, ensure_ascii=False) + "\n")
+    os.replace(tmp, path)
     return changed


### PR DESCRIPTION
## Summary
- rotate per-user message logs after 10k entries and append _last_marker records when new inbox messages arrive
- add timestamp helper and per-folder filtering with optional search across subject/sender/body
- implement last_inbox_ts helper for quick checks and maintain mark_read rewrite logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f3241d0c8323885751f3eda1a7af