### PR TITLE
Normalize None comments in history entries

### DIFF
--- a/magazyn_io.py
+++ b/magazyn_io.py
@@ -104,7 +104,7 @@ def append_history(
     user: str,
     op: str,
     qty: float,
-    comment: str = "",
+    comment: str | None = "",
     ts: str | None = None,
     *,
     komentarz: str | None = None,
@@ -117,7 +117,8 @@ def append_history(
         user: Name of the user performing the operation.
         op: Operation type. Must be one of :data:`ALLOWED_OPS`.
         qty: Positive quantity of the operation.
-        comment: Optional comment stored with the entry.
+        comment: Optional comment stored with the entry. ``None`` is normalized
+            to an empty string.
         ts: Optional timestamp (ISO 8601). Generated when missing.
         komentarz: Polish alias for ``comment``. Overrides ``comment`` when
             provided.
@@ -141,6 +142,8 @@ def append_history(
 
     if komentarz is not None:
         comment = komentarz
+
+    comment = "" if comment is None else str(comment)
 
     entry = {
         "ts": ts,

--- a/tests/test_magazyn_io_comment_alias.py
+++ b/tests/test_magazyn_io_comment_alias.py
@@ -21,3 +21,23 @@ def test_append_history_accepts_komentarz(tmp_path, monkeypatch):
     assert items["A"]["historia"][0]["comment"] == "uwaga"
     data = json.loads(hist_path.read_text(encoding="utf-8"))
     assert data[0]["comment"] == "uwaga"
+
+
+def test_append_history_normalizes_none_comment(tmp_path, monkeypatch):
+    hist_path = tmp_path / "hist.json"
+    monkeypatch.setattr(magazyn_io, "HISTORY_PATH", str(hist_path))
+
+    items = {}
+    entry = magazyn_io.append_history(
+        items,
+        "A",
+        "user",
+        "CREATE",
+        1,
+        comment=None,
+    )
+
+    assert entry["comment"] == ""
+    assert items["A"]["historia"][0]["comment"] == ""
+    data = json.loads(hist_path.read_text(encoding="utf-8"))
+    assert data[0]["comment"] == ""


### PR DESCRIPTION
## Summary
- allow passing None as the comment when appending warehouse history entries and normalize it to an empty string
- document the normalization behaviour and cover it with a regression test

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4307ac2dc8323b653b4bdee6a7593