### PR TITLE
Fix docstring escaping in kreator_sprawdzenia

### DIFF
--- a/kreator_sprawdzenia.py
+++ b/kreator_sprawdzenia.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
+r"""
 Kreator sprawdzania plikow i wersji – Warsztat Menager
 Wersja narzedzia: 1.3.0 (ASCII-only output)
 


### PR DESCRIPTION
## Summary
- switch the introductory docstring in `kreator_sprawdzenia.py` to a raw string literal to keep Windows-style paths from triggering `SyntaxWarning`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4efc9d6b08323aa675603199c2671