### PR TITLE
Use configurable orders directory

### DIFF
--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -8,6 +8,7 @@ import tkinter as tk
 from tkinter import ttk
 from typing import Any
 
+from config.paths import join_path
 from zlecenia_utils import load_orders
 
 try:  # pragma: no cover - środowiska testowe nie wymagają motywu
@@ -62,7 +63,7 @@ def panel_zlecenia(parent: tk.Widget) -> ttk.Frame:
         if not selection:
             return
         order_id = selection[0]
-        path = os.path.join("data", "zlecenia", f"{order_id}.json")
+        path = join_path("paths.orders_dir", f"{order_id}.json")
         if not os.path.exists(path):
             return
         try:


### PR DESCRIPTION
## Summary
- read order detail files via the configured orders directory
- route order persistence utilities through `config.paths` helpers to honor settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4fe0017d48323af855fedee8570f5