### PR TITLE
Add logging configuration options to system interface settings

### DIFF
--- a/settings_schema.json
+++ b/settings_schema.json
@@ -560,6 +560,25 @@
                 },
                 {
                   "type": "boolean",
+                  "key": "system.debug_enabled",
+                  "label": "Włącz logi debug (WM)",
+                  "default": true,
+                  "tooltip": "Gęstsze logi w konsoli: kliknięcia, parametry, wejścia/wyjścia."
+                },
+                {
+                  "type": "select",
+                  "key": "system.log_level",
+                  "label": "Poziom logów (WM)",
+                  "default": "debug",
+                  "options": [
+                    { "label": "debug", "value": "debug" },
+                    { "label": "info", "value": "info" },
+                    { "label": "error", "value": "error" }
+                  ],
+                  "tooltip": "Minimalny poziom emitowanych logów."
+                },
+                {
+                  "type": "boolean",
                   "key": "auth.require_login",
                   "label": "Wymagaj logowania",
                   "tooltip": "Włącz ekran logowania przy starcie.",


### PR DESCRIPTION
## Summary
- add debug toggle and log level selection to the System > Interfejs > Wygląd i logowanie settings group

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63a6b294c8323a674f04374197607