### PR TITLE
Refine updater logging payloads

### DIFF
--- a/wm_log.py
+++ b/wm_log.py
@@ -1,8 +1,10 @@
 """Minimal logging helpers used by backend utilities during tests.
 
 The real application defines richer logging facilities under the same
-module name.  For test purposes we emulate the API that the updater module
-expects so that imports succeed without pulling the full logging stack.
+module name. For test purposes we emulate the ``wm_log`` API that the
+updater module expects so that imports succeed without pulling the full
+logging stack. The helpers mirror the ``wm_log`` contract of accepting a
+single ``extra`` payload (typically a dict with structured data).
 """
 
 from __future__ import annotations
@@ -10,23 +12,24 @@ from __future__ import annotations
 from typing import Any
 
 
-def _log(level: str, area: str, event: str, extra: Any | None = None, **kwargs: Any) -> None:
+def _log(level: str, area: str, event: str, extra: Any | None = None) -> None:
     parts = [f"[{level}]", f"[{area}]", event]
     if extra is not None:
-        parts.append(repr(extra))
-    if kwargs:
-        details = " ".join(f"{key}={value!r}" for key, value in kwargs.items())
-        parts.append(details)
+        if isinstance(extra, dict):
+            details = " ".join(f"{key}={value!r}" for key, value in extra.items())
+            parts.append(details)
+        else:
+            parts.append(repr(extra))
     print(" ".join(parts))
 
 
-def dbg(area: str, event: str, extra: Any | None = None, **kwargs: Any) -> None:
-    _log("DBG", area, event, extra, **kwargs)
+def dbg(area: str, event: str, extra: Any | None = None) -> None:
+    _log("DBG", area, event, extra)
 
 
-def info(area: str, event: str, extra: Any | None = None, **kwargs: Any) -> None:
-    _log("INFO", area, event, extra, **kwargs)
+def info(area: str, event: str, extra: Any | None = None) -> None:
+    _log("INFO", area, event, extra)
 
 
-def err(area: str, event: str, extra: Any | None = None, **kwargs: Any) -> None:
-    _log("ERR", area, event, extra, **kwargs)
+def err(area: str, event: str, extra: Any | None = None) -> None:
+    _log("ERR", area, event, extra)


### PR DESCRIPTION
## Summary
- update backend updater logging to provide structured `extra` payloads compatible with `wm_log`
- align the lightweight `wm_log` stub with the production signature and documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63c2aa7288323bc3ab8d9bb53a3a9