### PR TITLE
Use hall configuration keys in machine GUI

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1,77 +1,57 @@
 from __future__ import annotations
 
 import json
-import os
 import traceback
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-# ---------- Config ----------
-try:
-    from config_manager import ConfigManager
-except Exception:
-    class _DummyCfg(dict):
-        def get(self, key, default=None):
-            return default
+from config.paths import get_path
+from wm_log import dbg as wm_dbg, err as wm_err
 
-    def ConfigManager():  # type: ignore[override]
-        return _DummyCfg()
 
-_CFG = ConfigManager()
-
-# Relatywna lokalizacja pliku z maszynami w obrębie katalogu danych:
-MACHINES_REL_PATH = os.path.join("maszyny", "maszyny.json")
-
-# ---------- Helpers ----------
-def _read_json_list(path: str) -> list:
-    """Bezpiecznie czyta listę z JSON. W razie błędu zwraca [] i loguje powód."""
+def _read_machines_from_file(path: str) -> list:
+    """Bezpiecznie czyta listę maszyn z pliku JSON."""
+    if not path:
+        wm_err("gui.maszyny", "machines file missing", path=path)
+        return []
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        if isinstance(data, list):
-            return data
-        print(f"[ERROR][Maszyny] {path} nie zawiera listy (typ={type(data).__name__}).")
+    except FileNotFoundError as err:
+        wm_err("gui.maszyny", "machines file not found", err, path=path)
         return []
-    except FileNotFoundError:
-        print(f"[ERROR][Maszyny] Brak pliku: {path}")
-        return []
-    except Exception as e:
-        print(f"[ERROR][Maszyny] Nie można wczytać {path}: {e}")
+    except Exception as err:  # pragma: no cover - log + fallback
+        wm_err("gui.maszyny", "machines load failed", err, path=path)
         traceback.print_exc()
         return []
+    if isinstance(data, list):
+        wm_dbg(
+            "gui.maszyny",
+            "machines loaded",
+            path=path,
+            count=len(data),
+        )
+        return data
+    wm_err(
+        "gui.maszyny",
+        "machines json not a list",
+        path=path,
+        type=type(data).__name__,
+    )
+    return []
 
-def _get_data_root() -> tuple[str, str]:
-    """
-    Priorytet klucza:
-      1) paths.data_root   ← docelowy, jeden klucz (ustawienia/System już go mają)
-      2) system.data_dir   ← kompatybilność wsteczna
-      3) system.data_path  ← kompatybilność wsteczna
-      4) system.data_root  ← kompatybilność wsteczna
-      5) ./data            ← fallback (repo)
-    Zwraca (root, picked_key).
-    """
-    for key in ("paths.data_root", "system.data_dir", "system.data_path", "system.data_root"):
-        v = _CFG.get(key, None)
-        if v:
-            return str(v), key
-    return os.path.join(os.getcwd(), "data"), "fallback:cwd/data"
 
-def _machines_path() -> tuple[str, dict]:
-    root, picked = _get_data_root()
-    path = os.path.join(root, MACHINES_REL_PATH)
-    return path, {"root": root, "picked_key": picked, "rel": MACHINES_REL_PATH}
+def _load_machines_from_config() -> tuple[list, str]:
+    machines_file = get_path("hall.machines_file", "").strip()
+    machines = _read_machines_from_file(machines_file)
+    return machines, machines_file
 
 # ---------- GUI ----------
 class MaszynyGUI:
     def __init__(self, parent: tk.Misc):
         self.parent = parent
-        self._path, self._meta = _machines_path()
-        self._machines = _read_json_list(self._path)
-
-        print(
-            f"[WM][Maszyny] źródło: {self._path} "
-            f"(root={self._meta['root']} via {self._meta['picked_key']}) | rekordy: {len(self._machines)}"
-        )
+        self._machines, self._path = _load_machines_from_config()
+        wm_dbg("gui.maszyny", "init", path=self._path, count=len(self._machines))
 
         # Layout główny
         self._build_left_list(parent)
@@ -90,7 +70,7 @@ class MaszynyGUI:
         top.pack(fill="x", padx=12, pady=(10, 6))
         lbl = tk.Label(
             top,
-            text=f"Źródło maszyn: {self._path}  •  ({self._meta['picked_key']})",
+            text=f"Źródło maszyn: {self._path or 'brak'}  •  (hall.machines_file)",
             anchor="w",
             fg="#cbd5e1",
             bg=bg,
@@ -100,7 +80,7 @@ class MaszynyGUI:
         if not self._machines:
             tk.Label(
                 top,
-                text="Brak danych — sprawdź Ustawienia ➝ System ➝ paths.data_root",
+                text="Brak danych — sprawdź Ustawienia ➝ Hala ➝ hall.machines_file",
                 fg="#fca5a5",
                 bg=bg,
             ).pack(side="right")
@@ -141,9 +121,8 @@ class MaszynyGUI:
             self.tree.insert("", "end", values=(mid, nazwa, typ, nastepne))
 
     def _refresh_all(self):
-        self._path, self._meta = _machines_path()
-        self._machines = _read_json_list(self._path)
-        print(f"[WM][Maszyny] REFRESH: {self._path} (via {self._meta['picked_key']}) → {len(self._machines)} szt.")
+        self._machines, self._path = _load_machines_from_config()
+        wm_dbg("gui.maszyny", "refresh", path=self._path, count=len(self._machines))
         self._reload_tree()
         # odśwież prawy panel, jeśli renderer jest dostępny
         if hasattr(self, "_renderer") and hasattr(self._renderer, "reload"):


### PR DESCRIPTION
## Summary
- load machines in `gui_maszyny.py` using `config.paths.get_path` with the new `hall.machines_file` key
- add structured logging for machine data loading and refresh actions
- update UI hints to reference the hall configuration section

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d65521e1e8832390bdfa126cef32ba