### PR TITLE
Add helper for saving warehouse reservations

### DIFF
--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -1,3 +1,3 @@
 """Pakiet warstwy domenowej aplikacji Warsztat Menager."""
 
-__all__ = ["orders"]
+__all__ = ["orders", "magazyn"]

--- a/domain/magazyn.py
+++ b/domain/magazyn.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+import os
+
+from config.paths import get_path
+from wm_log import dbg as wm_dbg, err as wm_err
+
+
+def save_reservations(rezerwacje: list[dict]) -> bool:
+    path = get_path("warehouse.reservations_file")
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(rezerwacje, f, ensure_ascii=False, indent=2)
+        wm_dbg("magazyn.res", "saved", path=path, count=len(rezerwacje))
+        return True
+    except Exception as e:  # pragma: no cover - logowanie błędu
+        wm_err("magazyn.res", "save failed", e, path=path)
+        return False


### PR DESCRIPTION
## Summary
- add a domain-level helper that saves reservation data using the configured warehouse path
- expose the new magazyn domain module through the package export list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6551300b883238001bf58a47c9805