### PR TITLE
Add textual audit runner helper

### DIFF
--- a/tests/test_backend_audit_runtime.py
+++ b/tests/test_backend_audit_runtime.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.audit import wm_audit_runtime
+from config import paths as config_paths
+
+
+def _fake_getter_factory(root: Path):
+    mapping = {"paths.data_root": str(root)}
+
+    def _fake_getter(key: str):
+        return mapping.get(key)
+
+    return _fake_getter
+
+
+def test_run_audit_returns_report_text(tmp_path, monkeypatch):
+    root = tmp_path / "data"
+    getter = _fake_getter_factory(root)
+    monkeypatch.setattr(config_paths, "_SETTINGS_STATE", None)
+    monkeypatch.setattr(config_paths, "_SETTINGS_GETTER", getter)
+
+    report = wm_audit_runtime.run_audit()
+
+    logs_dir = root / "logs"
+    report_files = list(logs_dir.glob("audyt_wm-*.txt"))
+
+    assert report
+    assert "Audyt WM" in report
+    assert report_files
+    assert report == report_files[0].read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- expose a `run_audit` helper in the backend audit runtime module that returns the rendered report text
- cover the helper with a regression test that ensures the saved report is returned to callers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d654f6827c83238cf0d68c87671057