### PR TITLE
Use configured paths in tools GUI

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -94,6 +94,30 @@ _cmb_user_var: tk.StringVar | None = None
 _var_filter_mine: tk.BooleanVar | None = None
 
 
+def _resolve_path_candidate(path: str | None, default: str) -> str:
+    """Return an absolute filesystem path for *path* with *default* fallback."""
+
+    candidate = str(path or "").strip()
+    if not candidate:
+        candidate = default
+    if not os.path.isabs(candidate):
+        try:
+            candidate = cfg_path(candidate)
+        except Exception:
+            candidate = default
+    return candidate
+
+
+def _default_tools_tasks_file() -> str:
+    """Return the default path to ``zadania_narzedzia.json`` using settings."""
+
+    default = cfg_path("data/zadania_narzedzia.json")
+    return _resolve_path_candidate(
+        get_path("tools.definitions_path", default),
+        default,
+    )
+
+
 def _profiles_usernames(cmb_user=None) -> list[str]:
     """Return list of all usernames from profiles.
 
@@ -150,8 +174,18 @@ def _tools_editor_user_choices() -> list[str]:
     except Exception:
         pass
 
-    # 2) profiles.json (prefer data/ subdir, fallback to repo root)
-    for path in ("data/profiles.json", "profiles.json"):
+    # 2) profiles.json (prefer ścieżkę z konfiguracji, następnie fallbacki)
+    profile_candidates: list[str] = []
+    for candidate in (
+        get_path("profiles.file", cfg_path("data/profiles.json")),
+        cfg_path("profiles.json"),
+        "profiles.json",
+    ):
+        candidate = str(candidate or "").strip()
+        if candidate and candidate not in profile_candidates:
+            profile_candidates.append(candidate)
+
+    for path in profile_candidates:
         if not os.path.exists(path):
             continue
         try:
@@ -187,14 +221,25 @@ def _tools_editor_user_choices() -> list[str]:
                 else:
                     add(str(value))
 
-    # 3) data/uzytkownicy.json
-    path_users = os.path.join("data", "uzytkownicy.json")
-    if os.path.exists(path_users):
+    # 3) uzytkownicy.json (prefer ścieżkę z konfiguracji + fallbacki)
+    users_candidates: list[str] = []
+    for candidate in (
+        get_path("profiles.users_file", cfg_path("data/uzytkownicy.json")),
+        cfg_path("uzytkownicy.json"),
+        "uzytkownicy.json",
+    ):
+        candidate = str(candidate or "").strip()
+        if candidate and candidate not in users_candidates:
+            users_candidates.append(candidate)
+
+    for path_users in users_candidates:
+        if not os.path.exists(path_users):
+            continue
         try:
             with open(path_users, "r", encoding="utf-8") as handle:
                 data = json.load(handle)
         except Exception:
-            data = None
+            continue
 
         if isinstance(data, list):
             for value in data:
@@ -207,6 +252,7 @@ def _tools_editor_user_choices() -> list[str]:
                     )
                 else:
                     add(str(value))
+            break
         elif isinstance(data, dict):
             for key, value in data.items():
                 if isinstance(value, dict):
@@ -218,6 +264,7 @@ def _tools_editor_user_choices() -> list[str]:
                     )
                 else:
                     add(str(key))
+            break
 
     # 4) Legacy fallback – ensure previous behaviour still works
     if not users:
@@ -561,11 +608,10 @@ def _definitions_path_for_collection(collection_id: str) -> str:
     except Exception:
         candidate = None
 
-    fallback = getattr(LZ, "TOOL_TASKS_PATH", "data/zadania_narzedzia.json")
-    candidate = str(candidate or fallback or "data/zadania_narzedzia.json").strip()
-    if not candidate:
-        candidate = "data/zadania_narzedzia.json"
-    return cfg_path(candidate)
+    default_path = _default_tools_tasks_file()
+    fallback = getattr(LZ, "TOOL_TASKS_PATH", None)
+    chosen = candidate or fallback
+    return _resolve_path_candidate(chosen, default_path)
 
 
 def _invalidate_tools_definitions_cache() -> None:
@@ -1516,23 +1562,16 @@ def panel_narzedzia(root, frame, login=None, rola=None):
         except Exception:
             candidate = None
         if not candidate:
-            candidate = getattr(LZ, "TOOL_TASKS_PATH", os.path.join("data", "zadania_narzedzia.json"))
-        candidate = str(candidate or "").strip()
-        if not candidate:
-            return None
-        if not os.path.isabs(candidate):
-            try:
-                candidate = cfg_path(candidate)
-            except Exception:
-                candidate = os.path.join("data", "zadania_narzedzia.json")
-        return candidate
+            candidate = getattr(LZ, "TOOL_TASKS_PATH", None)
+        resolved = _resolve_path_candidate(candidate, _default_tools_tasks_file())
+        return resolved or None
 
     def _definitions_mtime(path: str | None) -> float | None:
         if not path:
             return None
         try:
             return os.path.getmtime(path)
-        except OSError:
+        except (OSError, AttributeError):
             return None
 
     def _reload_definitions_from_disk(path: str | None) -> None:
@@ -2362,7 +2401,10 @@ def panel_narzedzia(root, frame, login=None, rola=None):
             self_ref = locals().get("self")
             if self_ref is not None and getattr(self_ref, "global_tasks", None) is None:
                 self_ref.global_tasks = []
-            path = os.path.join("data", "zadania_narzedzia.json")
+            path = _resolve_path_candidate(
+                getattr(LZ, "TOOL_TASKS_PATH", None),
+                _default_tools_tasks_file(),
+            )
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     data = json.load(f)


### PR DESCRIPTION
## Summary
- normalize tool configuration file lookups by resolving paths through the centralized get_path helper
- update profile and user list discovery to respect configured file locations with fallbacks
- reuse the shared resolution helper when watching and updating tool definitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d654fedd608323abed55821a99bfad