### PR TITLE
Add RC1 stabilization documentation templates

### DIFF
--- a/docs/ROADMAP_RC1.md
+++ b/docs/ROADMAP_RC1.md
@@ -1,0 +1,39 @@
+# RC1 Stabilization Roadmap
+
+## Cel
+Zabezpieczenie wydania RC1 poprzez kontrolę jakości, monitoring oraz komunikację z interesariuszami.
+
+## Fazy Stabilizacji
+1. **Przegląd otwartych zgłoszeń**
+   - Priorytetyzacja krytycznych błędów.
+   - Weryfikacja regresji.
+2. **Implementacja poprawek**
+   - Przydzielenie właścicieli do zgłoszeń.
+   - Śledzenie statusów wdrożeń poprawek.
+3. **Testy regresyjne**
+   - Smoke tests dla funkcji krytycznych.
+   - Testy automatyczne i manualne według planu QA.
+4. **Przygotowanie do releasu**
+   - Finalna walidacja kryteriów wyjścia.
+   - Przygotowanie notatek releasowych.
+
+## Harmonogram (przykład)
+| Tydzień | Kluczowe aktywności |
+|---------|---------------------|
+| T1      | Zbiórka zgłoszeń, priorytetyzacja, plan testów |
+| T2      | Implementacja poprawek, testy smoke |
+| T3      | Testy regresyjne, analiza ryzyk |
+| T4      | Finalizacja dokumentacji, zgoda na releas |
+
+## Monitorowanie Ryzyk
+- Lista ryzyk wraz z planami mitigacji.
+- Sygnały alarmowe i metryki jakości.
+
+## Komunikacja
+- Cotygodniowe statusy do zarządu.
+- Kanał incident-response dla krytycznych zgłoszeń.
+
+## Materiały uzupełniające
+- Link do TICKETS_RC1.md.
+- Plan testów QA.
+- Lista właścicieli modułów.

--- a/docs/TICKETS_RC1.md
+++ b/docs/TICKETS_RC1.md
@@ -1,0 +1,30 @@
+# RC1 Stabilization Ticket Log
+
+## Overview
+- **Release Candidate:** RC1
+- **Stabilization Window:** _<wprowadź daty>_
+- **Release Owner:** _<imię i nazwisko>_
+
+## Ticket Intake Checklist
+1. Zgłoszenie posiada opis problemu oraz kroki reprodukcji.
+2. Priorytet został nadany (P0/P1/P2/P3).
+3. Dodano wymagane załączniki (logi, zrzuty ekranu).
+4. Potwierdzono wersję aplikacji, w której wystąpił błąd.
+
+## Ticket Register
+| ID | Priorytet | Moduł | Opis | Status | Właściciel | Uwagi |
+|----|-----------|-------|------|--------|------------|-------|
+|    |           |       |      |        |            |       |
+
+## Decision Log
+- _<data>_: _<krótkie podsumowanie decyzji>_
+
+## Stabilization Exit Criteria
+- [ ] Brak otwartych zgłoszeń o priorytecie P0/P1.
+- [ ] Zakończone testy regresyjne dla krytycznych modułów.
+- [ ] Wszystkie poprawki posiadają plan wdrożenia i rollbacku.
+
+## Retro Notes
+- Co zadziałało dobrze?
+- Co wymaga poprawy przed kolejną RC?
+- Propozycje usprawnień procesu.


### PR DESCRIPTION
## Summary
- add RC1 ticket logging template to capture intake details and exit criteria
- add RC1 stabilization roadmap covering phases, schedule, and communication assets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d66ae8653483239e4eed4eabf7feb4