### PR TITLE
Register RC1 hotfix actions during startup

### DIFF
--- a/start.py
+++ b/start.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 try:
     CONFIG_MANAGER = ConfigManager()
+    import rc1_hotfix_actions  # RC1: rejestracja brakujących akcji BOM/audytu
 except Exception:  # pragma: no cover - fallback if config init fails
     CONFIG_MANAGER = None
 


### PR DESCRIPTION
## Summary
- ensure the RC1 hotfix actions module is imported immediately after configuration initialization so BOM and audit actions are registered during startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d66e16bf3c8323a4674e517dd45ac4