### PR TITLE
Prevent duplicate Magazyn orders toolbar button

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -21,6 +21,8 @@ import re
 import tkinter as tk
 from tkinter import messagebox, ttk
 
+from rc1_magazyn_fix import ensure_magazyn_toolbar_once
+
 try:
     from gui_zlecenia_creator import open_order_creator
 except Exception:
@@ -68,6 +70,23 @@ ROLE_PERMS = {
     "unreserve": "brygadzista",
     "to_orders": "brygadzista",
 }
+
+
+@ensure_magazyn_toolbar_once
+def _add_orders_button(toolbar: ttk.Frame, owner):
+    btn_orders = ttk.Button(
+        toolbar,
+        text="Zamówienia",
+        command=lambda: open_orders_window(owner) if open_orders_window else None,
+    )
+    btn_orders.pack(side="left", padx=(6, 0))
+    if open_orders_window is None:
+        try:
+            btn_orders.state(["disabled"])
+        except Exception:
+            pass
+    print("[WM-DBG][MAGAZYN] Dodano przycisk 'Zamówienia' w toolbarze")
+    return btn_orders
 
 
 def _role_rank(role: str) -> int:
@@ -280,18 +299,7 @@ class MagazynFrame(ttk.Frame):
         self.ent_q.pack(side="left", padx=(0, 6))
         self.ent_q.bind("<KeyRelease>", lambda _e: self._apply_filters())
 
-        btn_orders = ttk.Button(
-            toolbar,
-            text="Zamówienia",
-            command=lambda: open_orders_window(self) if open_orders_window else None,
-        )
-        btn_orders.pack(side="left", padx=(6, 0))
-        if open_orders_window is None:
-            try:
-                btn_orders.state(["disabled"])
-            except Exception:
-                pass
-        print("[WM-DBG][MAGAZYN] Dodano przycisk 'Zamówienia' w toolbarze")
+        btn_orders = _add_orders_button(toolbar, self)
 
         btn_orders_prefill = ttk.Button(
             toolbar,

--- a/rc1_magazyn_fix.py
+++ b/rc1_magazyn_fix.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Ograniczenia RC1 dla modułu Magazyn."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar, cast
+
+_MAG_TOOLBAR_INIT = False
+_MAG_TOOLBAR_IDS: set[int] = set()
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def ensure_magazyn_toolbar_once(build_fn: _F) -> _F:
+    """Zwraca dekorator chroniący przed duplikacją przycisku w toolbarze.
+
+    Funkcja ``build_fn`` zostanie wykonana maksymalnie raz dla danego widgetu
+    paska narzędzi.  Jeżeli nie uda się ustalić widgetu (np. dekorator użyty
+    bez argumentów), chroni globalnie – wywoła ``build_fn`` tylko przy pierwszym
+    wywołaniu.
+    """
+
+    marker = "_wm_magazyn_toolbar_orders"
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        global _MAG_TOOLBAR_INIT
+
+        toolbar = args[0] if args else None
+        if toolbar is not None:
+            toolbar_id = id(toolbar)
+            if toolbar_id in _MAG_TOOLBAR_IDS:
+                return None
+
+            _MAG_TOOLBAR_IDS.add(toolbar_id)
+
+            try:
+                if getattr(toolbar, marker):
+                    return None
+            except AttributeError:
+                pass
+
+            try:
+                setattr(toolbar, marker, True)
+            except Exception:
+                pass
+
+            return build_fn(*args, **kwargs)
+
+        if _MAG_TOOLBAR_INIT:
+            return None
+        _MAG_TOOLBAR_INIT = True
+        return build_fn(*args, **kwargs)
+
+    return cast(_F, wrapper)


### PR DESCRIPTION
## Summary
- add rc1_magazyn_fix.ensure_magazyn_toolbar_once helper to guard toolbar injections
- reuse the helper in gui_magazyn to avoid adding the "Zamówienia" button twice per toolbar

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6af04cddc8323a79c312b9cbdfbc9