### PR TITLE
RC1: hotfix dispatcher (BOM/Audyt) + poprawa kontrastu + guard Zamówienia

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -39,6 +39,11 @@ from wm_log import dbg as wm_dbg, err as wm_err
 
 from ui_theme import apply_theme_safe as apply_theme
 
+from rc1_magazyn_fix import (
+    build_orders_command,
+    should_disable_orders_button,
+)
+
 import logika_magazyn as LM
 from gui_magazyn_edit import open_edit_dialog
 from gui_magazyn_rezerwacje import (
@@ -283,10 +288,10 @@ class MagazynFrame(ttk.Frame):
         btn_orders = ttk.Button(
             toolbar,
             text="Zamówienia",
-            command=lambda: open_orders_window(self) if open_orders_window else None,
+            command=build_orders_command(self, open_orders_window, _can),
         )
         btn_orders.pack(side="left", padx=(6, 0))
-        if open_orders_window is None:
+        if should_disable_orders_button(self, open_orders_window, _can):
             try:
                 btn_orders.state(["disabled"])
             except Exception:

--- a/rc1_hotfix_actions.py
+++ b/rc1_hotfix_actions.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import traceback
+from pathlib import Path
 from typing import Any, Dict
 
 # -- Pomocnicze: lekkie logowanie
@@ -18,7 +19,20 @@ def _log(msg: str) -> None:
     print(f"WM|RC1|hotfix|{msg}")
 
 # -- Bezpieczny dostęp do configu (czytamy i zapisujemy config.json)
-CONFIG_PATH = os.path.join(os.getcwd(), "config.json")
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_DEFAULT_CONFIG_PATH = _SCRIPT_DIR / "config.json"
+
+
+def _resolve_config_path() -> Path:
+    """Zwraca możliwie najbardziej prawdopodobną ścieżkę do config.json."""
+
+    if _DEFAULT_CONFIG_PATH.exists():
+        return _DEFAULT_CONFIG_PATH
+    cwd_path = Path(os.getcwd()) / "config.json"
+    return cwd_path if cwd_path.exists() else _DEFAULT_CONFIG_PATH
+
+
+CONFIG_PATH = _resolve_config_path()
 
 
 def _config_load() -> Dict[str, Any]:

--- a/rc1_magazyn_fix.py
+++ b/rc1_magazyn_fix.py
@@ -1,0 +1,68 @@
+"""RC1 hotfix dla widoku magazynu – pilnowanie przycisku "Zamówienia"."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from tkinter import messagebox
+
+CanCheck = Callable[[Any, str], bool]
+OrdersHandler = Callable[[Any], Any]
+
+
+def _can_access_orders(owner: Any, can_check: CanCheck) -> bool:
+    try:
+        return bool(can_check(owner, "to_orders"))
+    except Exception:
+        return False
+
+
+def build_orders_command(
+    owner: Any,
+    handler: OrdersHandler | None,
+    can_check: CanCheck,
+) -> Callable[[], None]:
+    """Tworzy komendę dla przycisku Zamówienia z dodatkowymi komunikatami."""
+
+    def _cmd() -> None:
+        if not _can_access_orders(owner, can_check):
+            messagebox.showwarning(
+                "Uprawnienia",
+                "Brak uprawnień do modułu Zamówienia.",
+            )
+            return
+        if not callable(handler):
+            messagebox.showinfo(
+                "Zamówienia",
+                "Moduł Zamówienia jest chwilowo niedostępny.",
+            )
+            return
+        try:
+            handler(owner)
+        except Exception as exc:  # pragma: no cover - defensywne okno
+            messagebox.showerror(
+                "Zamówienia",
+                f"Nie udało się otworzyć modułu Zamówienia: {exc}",
+            )
+
+    return _cmd
+
+
+def should_disable_orders_button(
+    owner: Any,
+    handler: OrdersHandler | None,
+    can_check: CanCheck,
+) -> bool:
+    """Zwraca True jeśli przycisk Zamówienia powinien być wyłączony."""
+
+    if not _can_access_orders(owner, can_check):
+        return True
+    if not callable(handler):
+        return True
+    return False
+
+
+__all__ = [
+    "build_orders_command",
+    "should_disable_orders_button",
+]

--- a/rc1_theme_fix.py
+++ b/rc1_theme_fix.py
@@ -1,0 +1,154 @@
+"""RC1 hotfix dla motywu WM – poprawa kontrastu przycisków akcentowych."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from tkinter import ttk
+
+import ui_theme
+
+LOGGER = logging.getLogger(__name__)
+
+_ORIG_APPLY_THEME_SAFE: Callable[..., None] | None = None
+_ORIG_APPLY_THEME: Callable[..., None] | None = None
+_INSTALLED = False
+
+
+def _parse_hex_color(value: str) -> tuple[float, float, float]:
+    value = value.strip()
+    if value.startswith("#"):
+        value = value[1:]
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    if len(value) != 6:
+        raise ValueError(f"Nieprawidłowy kolor HEX: {value!r}")
+    r = int(value[0:2], 16) / 255.0
+    g = int(value[2:4], 16) / 255.0
+    b = int(value[4:6], 16) / 255.0
+    return r, g, b
+
+
+def _relative_luminance(rgb: tuple[float, float, float]) -> float:
+    def _channel(c: float) -> float:
+        if c <= 0.03928:
+            return c / 12.92
+        return ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (_channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _preferred_foreground(color: str) -> str:
+    try:
+        luminance = _relative_luminance(_parse_hex_color(color))
+    except Exception:
+        return "#ffffff"
+    return "#111111" if luminance >= 0.5 else "#f7f7f7"
+
+
+def _apply_button_contrast(style: ttk.Style, palette: Mapping[str, Any]) -> None:
+    accent = palette.get("accent")
+    if not isinstance(accent, str):
+        return
+    accent_hover = palette.get("accent_hover", accent)
+    muted = palette.get("muted", "#888888")
+
+    normal_fg = _preferred_foreground(accent)
+    hover_fg = _preferred_foreground(accent_hover if isinstance(accent_hover, str) else accent)
+
+    style.configure("WM.Button.TButton", foreground=normal_fg)
+    style.map(
+        "WM.Button.TButton",
+        background=[("active", accent_hover), ("pressed", accent)],
+        foreground=[
+            ("disabled", muted),
+            ("active", hover_fg),
+            ("pressed", normal_fg),
+        ],
+    )
+
+    style.map(
+        "TButton",
+        background=[("active", accent_hover), ("pressed", accent)],
+        foreground=[
+            ("disabled", muted),
+            ("active", hover_fg),
+            ("pressed", normal_fg),
+        ],
+    )
+
+    style.map(
+        "WM.Outline.TButton",
+        background=[("active", accent_hover), ("pressed", accent)],
+        bordercolor=[("active", accent_hover), ("pressed", accent)],
+        foreground=[
+            ("disabled", muted),
+            ("active", hover_fg),
+            ("pressed", normal_fg),
+        ],
+    )
+
+
+def _post_apply_theme(style: ttk.Style, name: str | None) -> None:
+    resolved = ui_theme.resolve_theme_name(name or ui_theme.DEFAULT_THEME)
+    palette = ui_theme.THEMES.get(resolved)
+    if palette is None:
+        return
+    _apply_button_contrast(style, palette)
+
+
+def _wrap_apply_theme_safe() -> None:
+    global _ORIG_APPLY_THEME_SAFE
+    if _ORIG_APPLY_THEME_SAFE is None:
+        _ORIG_APPLY_THEME_SAFE = ui_theme.apply_theme_safe
+
+    def patched(
+        target: Any | None = None,
+        name: str | None = None,
+        *,
+        config_path: Path | None = None,
+    ) -> None:
+        assert _ORIG_APPLY_THEME_SAFE is not None
+        _ORIG_APPLY_THEME_SAFE(target, name=name, config_path=config_path)
+        try:
+            style = target if isinstance(target, ttk.Style) else ttk.Style(target)
+            if name is None:
+                path = config_path or ui_theme.CONFIG_FILE
+                name = ui_theme.load_theme_name(path)
+            _post_apply_theme(style, name)
+        except Exception:  # pragma: no cover - defensywne logowanie
+            LOGGER.exception("rc1_theme_fix.apply_theme_safe failed")
+
+    ui_theme.apply_theme_safe = patched  # type: ignore[assignment]
+
+
+def _wrap_apply_theme() -> None:
+    global _ORIG_APPLY_THEME
+    if _ORIG_APPLY_THEME is None:
+        _ORIG_APPLY_THEME = ui_theme.apply_theme
+
+    def patched(style: ttk.Style, name: str = ui_theme.DEFAULT_THEME) -> None:
+        assert _ORIG_APPLY_THEME is not None
+        _ORIG_APPLY_THEME(style, name)
+        try:
+            _post_apply_theme(style, name)
+        except Exception:  # pragma: no cover - defensywne logowanie
+            LOGGER.exception("rc1_theme_fix.apply_theme failed")
+
+    ui_theme.apply_theme = patched  # type: ignore[assignment]
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _wrap_apply_theme()
+    _wrap_apply_theme_safe()
+    _INSTALLED = True
+    LOGGER.info("[RC1][THEME] Hotfix motywu zainstalowany")
+
+
+install()

--- a/start.py
+++ b/start.py
@@ -22,6 +22,9 @@ import tkinter as tk
 from tkinter import messagebox, Toplevel
 from utils import error_dialogs
 
+import rc1_theme_fix  # noqa: F401 - instalacja hotfixa motywu przy imporcie
+
+rc1_theme_fix.install()
 from ui_theme import apply_theme_safe as apply_theme
 from gui_settings import SettingsWindow
 from config_manager import ConfigManager
@@ -32,6 +35,7 @@ from pathlib import Path
 try:
     CONFIG_MANAGER = ConfigManager()
     import rc1_hotfix_actions  # RC1: rejestracja brakujących akcji BOM/audytu
+    import rc1_magazyn_fix  # noqa: F401 - zapewnia dostępność strażnika Zamówień
 except Exception:  # pragma: no cover - fallback if config init fails
     CONFIG_MANAGER = None
 


### PR DESCRIPTION
## Summary
- resolve the RC1 dispatcher hotfix config path relative to the script to ensure BOM/audit actions always read the intended config
- install a theme hotfix that patches `ui_theme` button styling to automatically pick a high-contrast foreground for accent buttons
- guard the warehouse "Zamówienia" entry point with dedicated helpers so it disables for missing permissions or modules and surfaces clear user messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6af1a6f308323945de2e23180b571