### PR TITLE
RC1: resolve conflicts — dispatcher + theme + magazyn toolbar (canonical)

### DIFF
--- a/rc1_hotfix_actions.py
+++ b/rc1_hotfix_actions.py
@@ -2,19 +2,13 @@
 # RC1: hotfix dispatcher (BOM export/import + Audyt)
 
 from __future__ import annotations
-
-import json
-import os
-import shutil
+import os, json, shutil
 from typing import Any, Dict
-
 
 def _log(msg: str) -> None:
     print(f"[RC1][hotfix] {msg}")
 
-
 CONFIG_PATH = os.path.join(os.getcwd(), "config.json")
-
 
 def _config_load() -> Dict[str, Any]:
     try:
@@ -23,7 +17,6 @@ def _config_load() -> Dict[str, Any]:
     except Exception:
         return {}
 
-
 def _config_save(cfg: Dict[str, Any]) -> None:
     try:
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
@@ -31,14 +24,11 @@ def _config_save(cfg: Dict[str, Any]) -> None:
     except Exception as e:
         _log(f"config.save.error: {e}")
 
-
 def _ask_open_file(filters=None) -> str | None:
     try:
         import tkinter as tk
         from tkinter import filedialog
-
-        root = tk.Tk()
-        root.withdraw()
+        root = tk.Tk(); root.withdraw()
         types = [(f, f) for f in (filters or ["*.json", "*.csv", "*.xlsx"])]
         path = filedialog.askopenfilename(filetypes=types)
         root.destroy()
@@ -47,62 +37,41 @@ def _ask_open_file(filters=None) -> str | None:
         _log(f"filedialog.open.error: {e}")
         return None
 
-
 def _ask_save_file(default_name="bom.json") -> str | None:
     try:
         import tkinter as tk
         from tkinter import filedialog
-
-        root = tk.Tk()
-        root.withdraw()
-        path = filedialog.asksaveasfilename(
-            defaultextension=".json", initialfile=default_name
-        )
+        root = tk.Tk(); root.withdraw()
+        path = filedialog.asksaveasfilename(defaultextension=".json", initialfile=default_name)
         root.destroy()
         return path or None
     except Exception as e:
         _log(f"filedialog.save.error: {e}")
         return None
 
-
 def _info(title: str, msg: str) -> None:
     try:
         import tkinter as tk
         from tkinter import messagebox
-
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showinfo(title, msg)
-        root.destroy()
+        root = tk.Tk(); root.withdraw(); messagebox.showinfo(title, msg); root.destroy()
     except Exception:
         _log(f"INFO: {title}: {msg}")
-
 
 def _warn(title: str, msg: str) -> None:
     try:
         import tkinter as tk
         from tkinter import messagebox
-
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showwarning(title, msg)
-        root.destroy()
+        root = tk.Tk(); root.withdraw(); messagebox.showwarning(title, msg); root.destroy()
     except Exception:
         _log(f"WARN: {title}: {msg}")
-
 
 def _error(title: str, msg: str) -> None:
     try:
         import tkinter as tk
         from tkinter import messagebox
-
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showerror(title, msg)
-        root.destroy()
+        root = tk.Tk(); root.withdraw(); messagebox.showerror(title, msg); root.destroy()
     except Exception:
         _log(f"ERROR: {title}: {msg}")
-
 
 def action_bom_export_current(params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     cfg = _config_load()
@@ -121,7 +90,6 @@ def action_bom_export_current(params: Dict[str, Any] | None = None) -> Dict[str,
         _error("Eksport BOM", f"Błąd zapisu:\n{e}")
         return {"ok": False, "msg": str(e)}
 
-
 def action_bom_import_dialog(params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     sel = _ask_open_file((params or {}).get("filters"))
     if not sel:
@@ -133,7 +101,6 @@ def action_bom_import_dialog(params: Dict[str, Any] | None = None) -> Dict[str, 
     _config_save(cfg)
     _info("Import BOM", f"Ustawiono plik BOM:\n{sel}")
     return {"ok": True, "path": sel}
-
 
 def action_wm_audit_run(params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     try:
@@ -148,42 +115,37 @@ def action_wm_audit_run(params: Dict[str, Any] | None = None) -> Dict[str, Any]:
             ok = bool(out.get("ok")) if isinstance(out, dict) else True
             msg = out.get("msg", "") if isinstance(out, dict) else str(out)
             path = out.get("path") if isinstance(out, dict) else None
-            (_info if ok else _warn)(
-                "Audyt WM", msg or ("OK" if ok else "Problemy wykryte")
-            )
+            (_info if ok else _warn)("Audyt WM", msg or ("OK" if ok else "Problemy wykryte"))
             return {"ok": ok, "msg": msg, "path": path}
-        _error("Audyt WM", "Brak funkcji audit.run()")
-        return {"ok": False, "msg": "audit.run missing"}
+        else:
+            _error("Audyt WM", "Brak funkcji audit.run()")
+            return {"ok": False, "msg": "audit.run missing"}
     except Exception as e:
         _error("Audyt WM", f"Błąd audytu:\n{e}")
         return {"ok": False, "msg": str(e)}
 
-
 _HOTFIX_ACTIONS: Dict[str, Any] = {
     "bom.export_current": action_bom_export_current,
-    "bom.import_dialog": action_bom_import_dialog,
-    "wm_audit.run": action_wm_audit_run,
+    "bom.import_dialog":  action_bom_import_dialog,
+    "wm_audit.run":       action_wm_audit_run,
 }
 
-
-def _install_into_dispatch() -> None:
+def _install_into_dispatch():
     try:
         import dispatch
     except Exception as e:
         _log(f"dispatch.import.error: {e}")
         return
-    # A) globalny słownik akcji
     try:
         actions = getattr(dispatch, "ACTIONS", None)
         if isinstance(actions, dict):
-            for key, handler in _HOTFIX_ACTIONS.items():
-                if key not in actions:
-                    actions[key] = handler
+            for k, v in _HOTFIX_ACTIONS.items():
+                if k not in actions:
+                    actions[k] = v
             _log("registered via ACTIONS")
             return
     except Exception:
         pass
-    # B) wrap execute (fallback)
     try:
         orig = getattr(dispatch, "execute", None)
         if callable(orig):
@@ -191,12 +153,10 @@ def _install_into_dispatch() -> None:
                 if action in _HOTFIX_ACTIONS:
                     return _HOTFIX_ACTIONS[action](params or {})
                 return orig(action, params)
-
             setattr(dispatch, "execute", wrapped)
             _log("wrapped execute")
     except Exception as e:
         _log(f"execute.wrap.error: {e}")
-
 
 _install_into_dispatch()
 _log("ready")

--- a/rc1_magazyn_fix.py
+++ b/rc1_magazyn_fix.py
@@ -1,19 +1,11 @@
 # -*- coding: utf-8 -*-
 # RC1: guard przed podwójnym przyciskiem 'Zamówienia' w Magazynie
-
-from __future__ import annotations
-
 _MAG_TOOLBAR_INIT = False
-
-
 def ensure_magazyn_toolbar_once(build_fn):
-    """Dekorator: wywoła build_fn tylko raz (chroni przed duplikatami przycisków)."""
-
     def wrapper(*args, **kwargs):
         global _MAG_TOOLBAR_INIT
         if _MAG_TOOLBAR_INIT:
-            return None
+            return
         _MAG_TOOLBAR_INIT = True
         return build_fn(*args, **kwargs)
-
     return wrapper

--- a/rc1_theme_fix.py
+++ b/rc1_theme_fix.py
@@ -1,32 +1,22 @@
 # -*- coding: utf-8 -*-
 # RC1: poprawa kontrastu napisów w przyciskach (motyw default)
-
 from __future__ import annotations
 
-
-def apply_theme_fixes() -> None:
+def apply_theme_fixes():
     try:
         import tkinter as tk
         from tkinter import ttk
-
-        _root = tk._get_default_root() or tk.Tk()
+        root = tk._get_default_root() or tk.Tk()
         style = ttk.Style()
         style.configure("TButton", foreground="#FFFFFF")
-        style.map(
-            "TButton",
-            foreground=[("active", "#FFFFFF"), ("disabled", "#AAAAAA")],
-        )
-        for style_name in ("WM.Side.TButton", "WM.Toolbar.TButton"):
+        style.map("TButton", foreground=[("active", "#FFFFFF"), ("disabled", "#AAAAAA")])
+        for s in ("WM.Side.TButton", "WM.Toolbar.TButton"):
             try:
-                style.configure(style_name, foreground="#FFFFFF")
-                style.map(
-                    style_name,
-                    foreground=[("active", "#FFFFFF"), ("disabled", "#AAAAAA")],
-                )
+                style.configure(s, foreground="#FFFFFF")
+                style.map(s, foreground=[("active", "#FFFFFF"), ("disabled", "#AAAAAA")])
             except Exception:
                 pass
     except Exception:
         pass
-
 
 apply_theme_fixes()

--- a/start.py
+++ b/start.py
@@ -528,8 +528,15 @@ def main():
         # [NOWE] Theme od wejścia — dokładnie to, o co prosiłeś:
         apply_theme(root)
         # RC1 hotfixy: rejestracja akcji i poprawa motywu po załadowaniu configu/motywu
-        import rc1_hotfix_actions  # noqa: F401  # RC1: akcje BOM + Audyt
-        import rc1_theme_fix  # noqa: F401  # RC1: kontrast napisów
+        try:
+            import rc1_hotfix_actions  # RC1: akcje BOM + Audyt
+        except Exception:
+            pass
+
+        try:
+            import rc1_theme_fix  # RC1: kontrast napisów
+        except Exception:
+            pass
 
         _show_tutorial_if_first_run(root)
 


### PR DESCRIPTION
## Summary
- wrap RC1 hotfix imports in `start.py` with try/except guards to match canonical RC1 loading expectations
- restore the canonical RC1 dispatcher, theme contrast fix, and magazyn toolbar guard implementations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d6cc87597c8323ade8e735b5c9dc4d