### PR TITLE
Fix schema default nesting and missing import

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -107,22 +107,31 @@ class ConfigManager:
 
         return default
 
-    @classmethod
     def _ensure_defaults_from_schema(
-        cls, cfg: Dict[str, Any], schema: Dict[str, Any]
+        self, cfg: Dict[str, Any], schema: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Uzupełnia brakujące klucze domyślnymi wartościami ze schematu."""
 
-        def apply_default(field: Dict[str, Any]) -> None:
+        sentinel = object()
+
+        for field in self._iter_schema_fields(schema):
             key = field.get("key")
             default = field.get("default")
-            if key and default is not None and key not in cfg:
-                value = cls._coerce_default_for_field(field)
-                print(f"[WM-DBG] [SETTINGS] default injected: {key}={value}")
-                cfg[key] = value
+            if not key or default is None:
+                continue
+            existing = get_by_key(cfg, key, sentinel)
+            if existing is not sentinel:
+                continue
+            if key in cfg:
+                value = cfg.pop(key)
+                set_by_key(cfg, key, value)
+                continue
+            value = self._coerce_default_for_field(field)
+            print(f"[WM-DBG] [SETTINGS] default injected: {key}={value}")
+            set_by_key(cfg, key, value)
+            self._schema_defaults_injected.add(key)
 
-        for field in cls._iter_schema_fields(schema):
-            apply_default(field)
+        migrate_dotted_keys(cfg)
         return cfg
     # >>> WM PATCH END
 
@@ -222,6 +231,7 @@ class ConfigManager:
                 self._audit_change(key, before_val=None, after_val=val, who="auto-heal")
         # >>> WM PATCH END
 
+        self._schema_defaults_injected: set[str] = set()
         self.global_cfg = self._ensure_defaults_from_schema(
             self.global_cfg, self.schema
         )
@@ -383,6 +393,11 @@ class ConfigManager:
     def get(self, key: str, default: Any = None) -> Any:
         return get_by_key(self.merged, key, default)
 
+    def is_schema_default(self, key: str) -> bool:
+        """Zwraca True, jeśli wartość została wstrzyknięta z domyślnego schematu."""
+
+        return key in self._schema_defaults_injected
+
     def set(self, key: str, value: Any, who: str = "system"):
         idx = self._schema_idx
         opt = idx.get(key)
@@ -398,6 +413,7 @@ class ConfigManager:
             # klucz spoza schematu → zapis do global
             target = self.global_cfg
         before_val = get_by_key(self.merged, key)
+        self._schema_defaults_injected.discard(key)
         set_by_key(target, key, value)
         self.merged = self._merge_all()
         self._audit_change(key, before_val=before_val, after_val=value, who=who)
@@ -440,6 +456,7 @@ class ConfigManager:
         self._perform_save_all()
 
     def _perform_save_all(self) -> None:
+        migrate_dotted_keys(self.global_cfg)
         stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_dir = Path(BACKUP_DIR)
         backup_dir.mkdir(parents=True, exist_ok=True)
@@ -561,3 +578,19 @@ def set_by_key(d: Dict[str, Any], dotted: str, value: Any):
             cur[p] = {}
         cur = cur[p]
     cur[parts[-1]] = value
+
+
+def migrate_dotted_keys(d: Dict[str, Any]) -> None:
+    """Przenieś klucze z kropkami do struktury zagnieżdżonej."""
+
+    if not isinstance(d, dict):
+        return
+
+    sentinel = object()
+    dotted_keys = [
+        key for key in list(d.keys()) if isinstance(key, str) and "." in key
+    ]
+    for dotted in dotted_keys:
+        value = d.pop(dotted)
+        if get_by_key(d, dotted, sentinel) is sentinel:
+            set_by_key(d, dotted, value)

--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -540,7 +540,11 @@ def _types_from_config():
     try:
         cfg_mgr = ConfigManager()
         types = cfg_mgr.get("tools.types", None)
-        if isinstance(types, list) and types:
+        if (
+            isinstance(types, list)
+            and types
+            and not cfg_mgr.is_schema_default("tools.types")
+        ):
             clean = [str(x).strip() for x in types if str(x).strip()]
             return clean
     except Exception:

--- a/utils_maszyny.py
+++ b/utils_maszyny.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import time
+import unicodedata
 from typing import Any, Dict, Iterable, List, Tuple
 
 PRIMARY_DATA = os.path.join("data", "maszyny.json")


### PR DESCRIPTION
## Summary
- ensure ConfigManager writes schema defaults through nested setters, tracks injected defaults, and cleans dotted keys before saving
- expose `ConfigManager.is_schema_default` so legacy tool type overrides continue to work despite schema defaults
- import the missing `unicodedata` dependency in `utils_maszyny`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da53b719048323b413ebd8f4c0f4ca