### PR TITLE
Add WM root folder controls to system settings

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -540,6 +540,22 @@ class ConfigManager:
 # ========== Helpers ==========
 
 
+def get_path(key: str, default: Any = None) -> Any:
+    """Shortcut for ``ConfigManager().get``."""
+
+    mgr = ConfigManager()
+    return mgr.get(key, default)
+
+
+def set_path(key: str, value: Any, *, who: str = "system", save: bool = True) -> None:
+    """Shortcut for setting a config path and optionally saving immediately."""
+
+    mgr = ConfigManager()
+    mgr.set(key, value, who=who)
+    if save:
+        mgr.save_all()
+
+
 def deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
     out = dict(a)
     for k, v in b.items():


### PR DESCRIPTION
## Summary
- add helpers in `config.paths` for resolving the WM base directory
- expose convenience `get_path`/`set_path` wrappers from the configuration manager
- render a new "Folder WM" section in the System tab and skip legacy file overrides in the UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa10613948323be62be6bc7535b95