### PR TITLE
Add bootstrap data helpers and seed core GUI modules

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -36,8 +36,10 @@ except Exception:  # pragma: no cover - optional dependency
     magazyn_io = None
     HAVE_MAG_IO = False
 
-from config.paths import get_path
+from config.paths import get_path, prefer_config_file
 from wm_log import dbg as wm_dbg, err as wm_err
+from utils.io_json import load_or_seed_json
+from seeds import SEEDS
 
 from ui_theme import apply_theme_safe as apply_theme
 
@@ -59,6 +61,9 @@ except Exception as _e:
 from logika_zakupy import auto_order_missing
 
 COLUMNS = ("id", "typ", "rozmiar", "nazwa", "stan", "zadania")
+
+STOCK_FILE = prefer_config_file("warehouse.file", "magazyn/magazyn.json")
+load_or_seed_json(STOCK_FILE, SEEDS["magazyn"])
 
 
 ROLE_PERMS = {
@@ -192,7 +197,7 @@ def _resolve_order_author(widget) -> str:
 
 
 def load_stock():
-    path = get_path("warehouse.stock_source")
+    path = get_path("warehouse.stock_source") or STOCK_FILE
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -205,7 +210,7 @@ def load_stock():
 
 def _load_data():
     """Czyta magazyn; preferuje ``magazyn_io`` z fallbackiem na plik."""
-    path = get_path("warehouse.stock_source")
+    path = get_path("warehouse.stock_source") or STOCK_FILE
     data = {}
     if HAVE_MAG_IO and hasattr(magazyn_io, "load"):
         try:

--- a/gui_profile.py
+++ b/gui_profile.py
@@ -32,6 +32,13 @@ from tkinter import ttk, messagebox
 from datetime import datetime as _dt, datetime
 from typing import Optional
 from config_manager import ConfigManager
+from config.paths import prefer_config_file
+from utils.io_json import load_or_seed_json
+from seeds import SEEDS
+
+
+PROFILES_FILE = prefer_config_file("profiles.file", "profiles.json")
+load_or_seed_json(PROFILES_FILE, SEEDS["profiles"])
 try:
     from PIL import Image, ImageTk, UnidentifiedImageError
 except ImportError:  # Pillow missing

--- a/seeds.py
+++ b/seeds.py
@@ -1,0 +1,49 @@
+"""Minimalne dane startowe dla podstawowych modułów GUI."""
+
+from __future__ import annotations
+
+SEEDS = {
+    "maszyny": [
+        {
+            "id": "M001",
+            "name": "Maszyna testowa",
+            "nr": "MX-001",
+            "status": "OK",
+            "lokalizacja": "Hala A",
+        }
+    ],
+    "narzedzia": [
+        {
+            "id": "T001",
+            "name": "Młotek testowy",
+            "typ": "NN",
+            "status": "sprawne",
+            "SN": False,
+            "NN": True,
+        }
+    ],
+    "zlecenia": [
+        {
+            "id": "Z001",
+            "nazwa": "Zlecenie testowe",
+            "opis": "Pierwsze zlecenie demo",
+            "status": "nowe",
+        }
+    ],
+    "magazyn": [
+        {
+            "id": "MAT001",
+            "nazwa": "Materiał testowy",
+            "jm": "szt",
+            "qty": 10,
+        }
+    ],
+    "profiles": [
+        {
+            "login": "admin",
+            "rola": "admin",
+            "imie": "Admin",
+            "aktywne": True,
+        }
+    ],
+}

--- a/utils/io_json.py
+++ b/utils/io_json.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+def load_or_seed_json(path: str, seed_data: Any, *, indent: int = 2):
+    """
+    Jeśli plik istnieje → wczytaj JSON.
+    Jeśli nie istnieje lub jest uszkodzony → utwórz z ``seed_data`` i zwróć seed.
+    """
+
+    try:
+        if not os.path.exists(path):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(seed_data, handle, indent=indent, ensure_ascii=False)
+            return seed_data
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except Exception:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(seed_data, handle, indent=indent, ensure_ascii=False)
+        return seed_data


### PR DESCRIPTION
## Summary
- add path resolution helpers to derive application data directories automatically
- introduce reusable JSON seeding utility with bundled starter datasets
- ensure machines, tools, warehouse, orders, and profile GUIs seed required data on load

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa0e97bec832384adb703108845c9