### PR TITLE
Integrate logging configuration and theme fallbacks

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from logging import StreamHandler
+
+_LOG_CREATED = False
+
+
+def setup_logging(log_dir: str = "logs", filename: str = "wm.log") -> None:
+    global _LOG_CREATED
+    if _LOG_CREATED:
+        return
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, filename)
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    ch = StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(fmt)
+    root.addHandler(ch)
+    fh = RotatingFileHandler(
+        log_path, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8"
+    )
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(fmt)
+    root.addHandler(fh)
+    logging.getLogger(__name__).info("[LOGCFG] Logging initialized → %s", log_path)
+    _LOG_CREATED = True

--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -34,6 +34,8 @@ import gui_panel  # używamy: _shift_bounds, _shift_progress, uruchom_panel
 # Motyw
 from ui_theme import apply_theme_tree
 
+logger = logging.getLogger(__name__)
+
 BASE_DIR = Path(__file__).resolve().parent
 
 # Alias zachowany dla kompatybilności testów

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -22,6 +22,7 @@ from services.profile_service import get_user, save_user
 
 from ui_theme import apply_theme_safe as apply_theme
 from utils.gui_helpers import clear_frame
+# [PR-1165-MERGE-FIX] unikajmy zbyt szerokiego importu z start (ryzyko cyklu)
 from start import CONFIG_MANAGER, open_settings_window
 import gui_changelog
 from logger import log_akcja

--- a/start.py
+++ b/start.py
@@ -22,18 +22,16 @@ import tkinter as tk
 from tkinter import messagebox, Toplevel
 from utils import error_dialogs
 
+# [PR-1165-MERGE-FIX] import motywu z fallbackiem
 try:
-    from ui_theme import apply_theme_safe as apply_theme  # alias zgodnie z dotychczasowym użyciem
+    from ui_theme import apply_theme_safe as apply_theme
 except Exception:
-    # Łagodny fallback – jeśli z jakiegoś powodu zabraknie funkcji, nie blokuj startu
-    def apply_theme(*_args, **_kwargs):
+    def apply_theme(*_a, **_k):  # no-op
         return None
-
 try:
     from ui_theme import ensure_theme_applied
 except Exception:
-    # Fallback: no-op – by start nie wysypał się przy braku tej funkcji
-    def ensure_theme_applied(_win):
+    def ensure_theme_applied(_win):  # no-op
         return False
 from gui_settings import SettingsWindow
 from config_manager import ConfigManager
@@ -48,26 +46,16 @@ except Exception:  # pragma: no cover - fallback if config init fails
 
 # ====== LOGGING ======
 
-def _ensure_log_dir():
-    os.makedirs("logi", exist_ok=True)
+# [PR-1165-MERGE-FIX] integracja logowania
+try:
+    from core.logging_config import setup_logging
+    setup_logging()  # konsola + logs/wm.log (rotacja)
+except Exception:
+    pass
 
 
 def _log_path():
-    return os.path.join(
-        "logi", f"warsztat_{datetime.now().strftime('%Y-%m-%d')}.log"
-    )
-
-
-DEBUG_MODE = bool(os.getenv("WM_DEBUG"))
-_ensure_log_dir()
-logging.basicConfig(
-    level=logging.DEBUG if DEBUG_MODE else logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler(_log_path(), encoding="utf-8"),
-        logging.StreamHandler(),
-    ],
-)
+    return os.path.join("logs", "wm.log")
 
 
 def _info(msg):


### PR DESCRIPTION
## Summary
- add a `core.logging_config` module with rotating file logging setup and package marker
- update `start.py` to use the new logging initializer and resilient theme imports
- tidy GUI modules by defining a module logger and documenting narrow imports

## Testing
- pytest *(fails: test_gui_narzedzia_config::test_panel_refreshes_after_config_change)*

------
https://chatgpt.com/codex/tasks/task_e_68db740b41e883238fb96fd283f9e47b