### PR TITLE
Remove legacy hala/serwis modules from manifest handling

### DIFF
--- a/core/modules_manifest.py
+++ b/core/modules_manifest.py
@@ -1,0 +1,15 @@
+"""Definicja listy modułów aplikacji wykorzystywana w testach i narzędziach."""
+
+from __future__ import annotations
+
+modules: list[str] = [
+    "ustawienia",
+    "profile",
+    "panel_glowny",
+    "narzedzia",
+    "magazyn",
+    "zlecenia",
+    "maszyny",
+]
+
+__all__ = ["modules"]

--- a/profile_utils.py
+++ b/profile_utils.py
@@ -6,6 +6,7 @@
 from datetime import date, datetime, timezone
 import re
 from pathlib import Path
+from collections.abc import Iterable
 
 from io_utils import read_json, write_json
 from utils.path_utils import cfg_path
@@ -76,7 +77,12 @@ def _ensure_users_file_path() -> None:
     if legacy.exists() and not Path(USERS_FILE).exists():
         legacy.replace(USERS_FILE)
 
-SIDEBAR_MODULES: list[tuple[str, str]] = [
+try:
+    from utils.moduly import lista_modulow as _lista_modulow
+except Exception:  # pragma: no cover - fallback na brak manifestu
+    _lista_modulow = None
+
+_SIDEBAR_BASE: list[tuple[str, str]] = [
     ("zlecenia", "Zlecenia"),
     ("narzedzia", "Narzędzia"),
     ("maszyny", "Maszyny"),
@@ -86,6 +92,38 @@ SIDEBAR_MODULES: list[tuple[str, str]] = [
     ("ustawienia", "Ustawienia"),
     ("profil", "Profil"),
 ]
+
+_SIDEBAR_ALWAYS = {"feedback", "uzytkownicy", "ustawienia", "profil"}
+
+
+def _load_manifest_modules() -> set[str]:
+    """Zwróć zestaw ID modułów zdefiniowanych w manifeście."""
+
+    if _lista_modulow is None:
+        return set()
+    try:
+        modules: Iterable[str] = _lista_modulow()
+    except Exception:
+        return set()
+    return {str(module).strip() for module in modules if module}
+
+
+def _compute_sidebar_modules() -> list[tuple[str, str]]:
+    """Zbuduj listę modułów bocznego panelu w oparciu o manifest."""
+
+    manifest_modules = _load_manifest_modules()
+    if not manifest_modules:
+        manifest_modules = {
+            key for key, _ in _SIDEBAR_BASE if key not in _SIDEBAR_ALWAYS
+        }
+    modules: list[tuple[str, str]] = []
+    for key, label in _SIDEBAR_BASE:
+        if key in manifest_modules or key in _SIDEBAR_ALWAYS:
+            modules.append((key, label))
+    return modules
+
+
+SIDEBAR_MODULES: list[tuple[str, str]] = _compute_sidebar_modules()
 
 # Domyślny profil użytkownika z rozszerzonymi polami
 DEFAULT_USER = {


### PR DESCRIPTION
## Summary
- add a Python manifest listing current modules without the retired `maszyny_hala`
- derive sidebar modules from the manifest so obsolete Hala/Serwis tabs are filtered out

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db823c69e083238c7904d9563136e4