### PR TITLE
Adjust machines GUI messaging and update sample data

### DIFF
--- a/data/maszyny/maszyny.sample.json
+++ b/data/maszyny/maszyny.sample.json
@@ -2,7 +2,7 @@
   {
     "id": "M-001",
     "kod": "PRASA-01",
-    "nazwa": "Prasa hydrauliczna 100T",
+    "nazwa": "Prasa 100T",
     "lokacja": "H1-A3",
     "status": "OK"
   },
@@ -16,7 +16,7 @@
   {
     "id": "M-003",
     "kod": "FREZ-03",
-    "nazwa": "Frezarka 3-osiowa F300",
+    "nazwa": "Frezarka F300",
     "lokacja": "H2-C2",
     "status": "OK"
   }

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -69,7 +69,7 @@ def load_machines_from_config(config_manager) -> list[dict]:
     if not abs_path:
         messagebox.showwarning(
             "Maszyny",
-            "Nie ustawiono relatywnej ścieżki 'maszyny/…' względem Folderu WM (root).",
+            "Nie ustawiono 'Relatywna ścieżka pliku maszyn' względem Folderu WM (root).",
         )
         logger.warning("[Maszyny] Brak machines.rel_path albo paths.data_root")
         return []
@@ -138,9 +138,7 @@ def _open_machines_panel(root, container, config_manager) -> ttk.Treeview | None
     machines = load_machines_from_config(config_manager)
 
     if not Renderer:
-        logger.warning(
-            "[Maszyny] Renderer hali niedostępny – pokażę listę tekstową zamiast podglądu."
-        )
+        logger.warning("[Maszyny] Renderer niedostępny – używam widoku listy.")
     else:  # pragma: no cover - renderer opcjonalny
         try:
             Renderer.draw(machines)


### PR DESCRIPTION
## Summary
- align the missing-path warning and renderer fallback message in the machines GUI
- refresh the sample machines data file with the simplified names used by the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd08a506648323bda638ee6e4574ab