### PR TITLE
Handle machine list configs

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -95,7 +95,13 @@ def _open_machines_panel(root, container, config_manager=None, Renderer=None):
     machines_path = resolve_rel(cfg, "machines") if cfg else resolve_rel({}, "machines")
     default_doc = {"maszyny": []}
     rows_data = _safe_read_json(machines_path, default_doc)
-    rows = [row for row in rows_data.get("maszyny") or [] if isinstance(row, dict)]
+    if isinstance(rows_data, dict):
+        rows = rows_data.get("maszyny") or []
+    elif isinstance(rows_data, list):
+        rows = rows_data
+    else:
+        rows = []
+    rows = [row for row in rows if isinstance(row, dict)]
 
     if not rows:
         info.set("Brak maszyn w konfiguracji. Lista jest pusta – możesz dodać pozycje.")


### PR DESCRIPTION
## Summary
- allow the machines panel to read machine definitions from either a dict with a `maszyny` key or a plain list
- filter out any malformed machine entries before rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e009d8f3248323a0077711f418055d