### PR TITLE
Normalize JSON handling and keep empty tool/order panels

### DIFF
--- a/backend/bootstrap_root.py
+++ b/backend/bootstrap_root.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 from config_manager import ConfigManager, resolve_rel, try_migrate_if_missing
-from utils_json import ensure_dir_json
+from utils_json import ensure_dir_json, safe_read_json
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +51,16 @@ def _migrate_legacy(cfg: dict) -> None:
 
     for src, dst in moved:
         log.info("[MIGRACJA] %s -> %s", src, dst)
+
+
+def ensure_root_min_files(cfg: dict) -> None:
+    """Ensure minimal JSON files exist under configured root."""
+
+    safe_read_json(resolve_rel(cfg, "machines"), default=[])
+    safe_read_json(resolve_rel(cfg, "tools"), default=[])
+    safe_read_json(resolve_rel(cfg, "orders"), default=[])
+    safe_read_json(resolve_rel(cfg, "warehouse_stock"), default={"pozycje": []})
+    safe_read_json(resolve_rel(cfg, "bom"), default={"pozycje": []})
 
 
 def ensure_root_ready(config_path: str = "config.json") -> bool:


### PR DESCRIPTION
## Summary
- extend `resolve_rel` with a central `RESOLVE_MAP` to normalize lookups under the data root
- add shared JSON helpers and use them in the tools/orders panels to tolerate empty or missing data files without dialogs
- provide a bootstrap helper that materializes minimal root JSON files when they are absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00f8db86483239c484d70d1fffa33