### PR TITLE
Refine machines panel loading flow

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1,60 +1,38 @@
 from __future__ import annotations
 
-import json
 import os
 import tkinter as tk
 from logging import getLogger
 from tkinter import messagebox, ttk
 
 try:
-    from config_manager import ConfigManager, resolve_rel
-except Exception:  # pragma: no cover - fallback gdy moduł nieosiągalny
-    ConfigManager = None  # type: ignore[assignment]
+    from config_manager import get_config, resolve_rel  # type: ignore
+except Exception:  # pragma: no cover - fallback dla starszych wersji
+    try:
+        from config_manager import resolve_rel  # type: ignore
+    except Exception:  # pragma: no cover - fallback gdy moduł nieosiągalny
 
-    def resolve_rel(cfg: dict, what: str) -> str:
-        root = (cfg.get("paths", {}) or {}).get("data_root") or "C:/wm/data"
-        mapping = {"machines": os.path.join("maszyny", "maszyny.json")}
-        return os.path.normpath(os.path.join(root, mapping.get(what, "")))
+        def resolve_rel(cfg: dict, what: str) -> str:
+            root = (cfg.get("paths", {}) or {}).get("data_root") or "C:/wm/data"
+            mapping = {"machines": os.path.join("maszyny", "maszyny.json")}
+            return os.path.normpath(os.path.join(root, mapping.get(what, "")))
+
+    def get_config() -> dict:
+        try:
+            from config_manager import ConfigManager  # type: ignore
+
+            return ConfigManager().load()
+        except Exception:
+            return {}
 
 from ui_theme import ensure_theme_applied
+from utils_maszyny import (
+    ensure_machines_sample_if_empty,
+    load_machines_rows_with_fallback,
+)
 
 logger = getLogger(__name__)
 _ = messagebox  # pragma: no cover - import utrzymany dla kompatybilności
-
-try:  # pragma: no cover - CONFIG_MANAGER jest opcjonalny
-    from start import CONFIG_MANAGER
-except Exception:  # pragma: no cover - środowiska testowe
-    CONFIG_MANAGER = None
-
-
-def _safe_read_json(path: str, default: dict) -> dict:
-    try:
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        if not os.path.exists(path):
-            with open(path, "w", encoding="utf-8") as handle:
-                json.dump(default, handle, ensure_ascii=False, indent=2)
-            logger.warning("[AUTOJSON] Brak pliku %s – utworzono szablon", path)
-            return default.copy()
-        with open(path, "r", encoding="utf-8") as handle:
-            return json.load(handle)
-    except Exception as exc:  # pragma: no cover - ochrona przed błędami IO
-        logger.error("[Maszyny] Błąd JSON (%s): %s", path, exc)
-        return default.copy()
-
-
-def _resolve_manager(explicit: ConfigManager | None) -> ConfigManager | None:
-    if explicit is not None:
-        return explicit
-    if CONFIG_MANAGER is not None:
-        return CONFIG_MANAGER
-    if ConfigManager is None:
-        return None
-    try:
-        return ConfigManager()
-    except Exception:  # pragma: no cover - ConfigManager opcjonalny
-        logger.exception("[Maszyny] Nie udało się zainicjalizować ConfigManagera.")
-        return None
-
 
 def _build_tree(parent: tk.Misc, rows: list[dict]) -> ttk.Treeview:
     tree = ttk.Treeview(parent, columns=("id", "nazwa", "typ"), show="headings", height=18)
@@ -77,7 +55,7 @@ def _build_tree(parent: tk.Misc, rows: list[dict]) -> ttk.Treeview:
 Renderer = None
 
 
-def _open_machines_panel(root, container, config_manager=None, Renderer=None):
+def _open_machines_panel(root, container, Renderer=None):
     for child in container.winfo_children():
         child.destroy()
 
@@ -85,23 +63,14 @@ def _open_machines_panel(root, container, config_manager=None, Renderer=None):
     info_label = ttk.Label(container, textvariable=info)
     info_label.pack(fill="x", padx=8, pady=8)
 
-    manager = _resolve_manager(config_manager)
     try:
-        cfg = manager.load() if manager is not None else {}
+        cfg = get_config()
     except Exception:
         logger.exception("[Maszyny] Nie udało się wczytać konfiguracji.")
         cfg = {}
 
-    machines_path = resolve_rel(cfg, "machines") if cfg else resolve_rel({}, "machines")
-    default_doc = {"maszyny": []}
-    rows_data = _safe_read_json(machines_path, default_doc)
-    if isinstance(rows_data, dict):
-        rows = rows_data.get("maszyny") or []
-    elif isinstance(rows_data, list):
-        rows = rows_data
-    else:
-        rows = []
-    rows = [row for row in rows if isinstance(row, dict)]
+    rows, primary_path = load_machines_rows_with_fallback(cfg, resolve_rel)
+    rows = ensure_machines_sample_if_empty(rows, primary_path)
 
     if not rows:
         info.set("Brak maszyn w konfiguracji. Lista jest pusta – możesz dodać pozycje.")
@@ -145,7 +114,7 @@ def _open_machines_panel(root, container, config_manager=None, Renderer=None):
 
     if tree is None:
         tree = _build_tree(container, rows)
-    logger.info("[Maszyny] Panel otwarty; rekordów: %d", len(rows))
+    logger.info("[Maszyny] Panel otwarty; rekordów: %d; plik=%s", len(rows), primary_path)
     return tree
 
 
@@ -177,7 +146,6 @@ class MaszynyGUI:
         self.tree = _open_machines_panel(
             self.root,
             self.container,
-            CONFIG_MANAGER,
             Renderer=Renderer,
         )
 
@@ -185,7 +153,7 @@ class MaszynyGUI:
 def panel_maszyny(root, frame, login=None, rola=None):
     """Adapter używany przez główny panel aplikacji."""
 
-    _open_machines_panel(root, frame, CONFIG_MANAGER, Renderer=Renderer)
+    _open_machines_panel(root, frame, Renderer=Renderer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load machines panel configuration via `get_config` with safe fallbacks
- add utility helpers to resolve machine data with sample data fallback
- refresh the machines UI loader to reuse the shared helpers and log the active file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e022191a3c8323bf2e825ac913e0c6