### PR TITLE
Update machines sample fallback path handling

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -70,7 +70,7 @@ def _open_machines_panel(root, container, Renderer=None):
         cfg = {}
 
     rows, primary_path = load_machines_rows_with_fallback(cfg, resolve_rel)
-    rows = ensure_machines_sample_if_empty(rows, primary_path)
+    rows, primary_path = ensure_machines_sample_if_empty(rows, primary_path)
 
     if not rows:
         info.set("Brak maszyn w konfiguracji. Lista jest pusta – możesz dodać pozycje.")

--- a/utils_maszyny.py
+++ b/utils_maszyny.py
@@ -364,11 +364,13 @@ def load_machines_rows_with_fallback(
     return rows, primary_path
 
 
-def ensure_machines_sample_if_empty(rows: List[dict], primary_path: str | None) -> List[dict]:
+def ensure_machines_sample_if_empty(
+    rows: List[dict], primary_path: str | None
+) -> Tuple[List[dict], str | None]:
     """Provide sample data when ``rows`` are empty for preview purposes."""
 
     if rows:
-        return rows
+        return rows, primary_path
 
     candidates: List[str] = []
     if primary_path:
@@ -393,6 +395,6 @@ def ensure_machines_sample_if_empty(rows: List[dict], primary_path: str | None) 
         sample_rows = _load_json_file(abs_path)
         if sample_rows:
             print(f"[WM][Maszyny] użyto danych przykładowych z pliku: {abs_path}")
-            return sample_rows
+            return sample_rows, abs_path
 
-    return rows
+    return rows, primary_path


### PR DESCRIPTION
## Summary
- return both rows and the active data path when machines sample data is used
- update the machines panel loader to log the resolved sample file path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e023fed7a88323bb52c6052dde43b1