### PR TITLE
Harden JSON loaders for machines, tools, and orders

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -152,7 +152,18 @@ def _open_machines_panel(root, container, config_manager=None, Renderer=None):
 
     if tree is None:
         tree = _build_tree(container, rows)
-    logger.info("[Maszyny] Panel otwarty; rekordów: %d; plik=%s", len(rows), primary_path)
+    import os as _os
+
+    _display_path = (
+        primary_path
+        if not _os.path.isdir(primary_path)
+        else _os.path.join(primary_path, r"maszyny\maszyny.json")
+    )
+    logger.info(
+        "[Maszyny] Panel otwarty; rekordów: %d; plik=%s",
+        len(rows),
+        _display_path,
+    )
     return tree
 
 

--- a/utils_orders.py
+++ b/utils_orders.py
@@ -1,33 +1,26 @@
 import os
 from datetime import date
 
-from utils_json import (
-    normalize_rows,
-    safe_read_json as _safe_read_json,
-    safe_write_json as _safe_write_json,
-)
+from utils_json import normalize_rows, safe_read_json as _r, safe_write_json as _w
+
+
+def _fix_if_dir(path: str, expected_rel: str) -> str:
+    if not path or os.path.isdir(path):
+        return os.path.normpath(os.path.join(path or "", expected_rel))
+    return path
 
 
 def load_orders_rows_with_fallback(cfg: dict, resolve_rel):
-    r"""
-    1) <root>\zlecenia\zlecenia.json  (dict{'zlecenia':list} lub list)
-    2) fallback: <root>\zlecenia.json (legacy: list)
-    """
-
     primary = resolve_rel(cfg, r"zlecenia\zlecenia.json")
-    if not primary:
-        primary = resolve_rel({}, r"zlecenia\zlecenia.json")
-    data = _safe_read_json(primary, default={"zlecenia": []})
-    rows = normalize_rows(data, "zlecenia")
-    if not rows and isinstance(data, list):
-        rows = normalize_rows(data, None)
+    primary = _fix_if_dir(primary, r"zlecenia\zlecenia.json")
+    data = _r(primary, default={"zlecenia": []})
+    rows = normalize_rows(data, "zlecenia") or normalize_rows(data, None)
     if rows:
         return rows, primary
 
     legacy = resolve_rel(cfg, r"zlecenia.json")
-    if not legacy:
-        legacy = resolve_rel({}, r"zlecenia.json")
-    data2 = _safe_read_json(legacy, default=[])
+    legacy = _fix_if_dir(legacy, r"zlecenia\zlecenia.json")
+    data2 = _r(legacy, default=[])
     rows2 = normalize_rows(data2, None)
     if rows2:
         return rows2, primary
@@ -41,6 +34,5 @@ def ensure_orders_sample_if_empty(rows: list[dict], primary_path: str):
         {"id": "Z-2025-001", "klient": "ACME", "status": "otwarte", "data": str(date.today())},
         {"id": "Z-2025-002", "klient": "BRAVO", "status": "w toku", "data": str(date.today())},
     ]
-    os.makedirs(os.path.dirname(primary_path) or ".", exist_ok=True)
-    _safe_write_json(primary_path, {"zlecenia": sample})
+    _w(primary_path, {"zlecenia": sample})
     return sample

--- a/utils_tools.py
+++ b/utils_tools.py
@@ -1,32 +1,25 @@
 import os
 
-from utils_json import (
-    normalize_rows,
-    safe_read_json as _safe_read_json,
-    safe_write_json as _safe_write_json,
-)
+from utils_json import normalize_rows, safe_read_json as _r, safe_write_json as _w
+
+
+def _fix_if_dir(path: str, expected_rel: str) -> str:
+    if not path or os.path.isdir(path):
+        return os.path.normpath(os.path.join(path or "", expected_rel))
+    return path
 
 
 def load_tools_rows_with_fallback(cfg: dict, resolve_rel):
-    r"""
-    1) <root>\narzedzia\narzedzia.json  (dict{'narzedzia':list} lub list)
-    2) fallback: <root>\narzedzia.json (legacy: list)
-    """
-
     primary = resolve_rel(cfg, r"narzedzia\narzedzia.json")
-    if not primary:
-        primary = resolve_rel({}, r"narzedzia\narzedzia.json")
-    data = _safe_read_json(primary, default={"narzedzia": []})
-    rows = normalize_rows(data, "narzedzia")
-    if not rows and isinstance(data, list):
-        rows = normalize_rows(data, None)
+    primary = _fix_if_dir(primary, r"narzedzia\narzedzia.json")
+    data = _r(primary, default={"narzedzia": []})
+    rows = normalize_rows(data, "narzedzia") or normalize_rows(data, None)
     if rows:
         return rows, primary
 
     legacy = resolve_rel(cfg, r"narzedzia.json")
-    if not legacy:
-        legacy = resolve_rel({}, r"narzedzia.json")
-    data2 = _safe_read_json(legacy, default=[])
+    legacy = _fix_if_dir(legacy, r"narzedzia\narzedzia.json")
+    data2 = _r(legacy, default=[])
     rows2 = normalize_rows(data2, None)
     if rows2:
         return rows2, primary
@@ -41,6 +34,5 @@ def ensure_tools_sample_if_empty(rows: list[dict], primary_path: str):
         {"id": "T-002", "nazwa": "Suwmiarka 150 mm", "status": "OK"},
         {"id": "T-003", "nazwa": "Wiertło Ø8 HSS", "status": "zużyte"},
     ]
-    os.makedirs(os.path.dirname(primary_path) or ".", exist_ok=True)
-    _safe_write_json(primary_path, {"narzedzia": sample})
+    _w(primary_path, {"narzedzia": sample})
     return sample


### PR DESCRIPTION
## Summary
- guard the shared JSON helpers against directory paths and keep writes safe
- update machine, tool, and order loaders to normalise directories before reading or seeding sample data
- adjust GUI panels to handle directory paths in logs and skip consume_for_task when the backend is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e026e7a2488323bbc13c3fe3f0ba81