### PR TITLE
Emit <<DyspozycjeUpdated>> event after saving disposition

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -222,7 +222,8 @@ def open_dyspozycje_creator(
         )
         add_dyspozycja(item)
         try:
-            win.winfo_toplevel().event_generate("<<OrdersUpdated>>", when="tail")
+            # NOWY event dla Dyspozycji (zamiast OrdersUpdated)
+            win.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
         except Exception:
             pass
         messagebox.showinfo("Dyspozycje", "Dyspozycja została zapisana.", parent=win)


### PR DESCRIPTION
### Motivation
- Replace the generic `<<OrdersUpdated>>` post-save event with a dedicated `<<DyspozycjeUpdated>>` event so saving a dyspozycja (disposition) triggers the correct refresh flow.

### Description
- In `gui_dyspozycje_creator.py` changed the event generated after `add_dyspozycja(item)` from `win.winfo_toplevel().event_generate("<<OrdersUpdated>>", when="tail")` to `win.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")` and added an inline comment explaining the new event.

### Testing
- Ran `pytest`; the test run completed but with failures: 5 failed, 222 passed, 46 skipped, where the failing tests were `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive[Edwin]`, `test_gui_logowanie.py::test_logowanie_case_insensitive[EDWIN]`, `test_gui_logowanie.py::test_logowanie_callback_error`, and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`, which appear unrelated to this small event rename.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4a1619883238102a323424ee401)