### PR TITLE
Nasłuchiwanie eventu `<<DyspozycjeUpdated>>` w liście dyspozycji

### DIFF
--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -247,7 +247,8 @@ class ZleceniaView(ttk.Frame):
             root = None
         if not root:
             return
-        root.bind("<<OrdersUpdated>>", lambda _event: self._reload_orders(), add=True)
+        # nowy event dla Dyspozycji
+        root.bind("<<DyspozycjeUpdated>>", lambda _event: self._reload_orders(), add=True)
 
     def _fill_orders_table(self, rows: list[dict]) -> None:
         for item in self.tree.get_children():


### PR DESCRIPTION
### Motivation
- Kreator dyspozycji emituje event `<<DyspozycjeUpdated>>`, więc widok listy zleceń powinien nasłuchiwać tego eventu, aby poprawnie odświeżać listę po zapisaniu dyspozycji.

### Description
- W `gui_zlecenia.py` w metodzie `_bind_orders_event` zmieniono bindowanie z `<<OrdersUpdated>>` na `<<DyspozycjeUpdated>>` oraz dodano komentarz wyjaśniający zmianę.

### Testing
- Uruchomiono `pytest -q`; wynik: 222 passed, 46 skipped, 5 failed, przy czym wykryte niepowodzenia wydają się nie być związane z tą zmianą.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a5bb33948323921e3f89aa9bbc53)