### PR TITLE
Clarify Panel Dyspozycji docstring to include former name

### DIFF
--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -1,5 +1,5 @@
 # version: 1.0
-"""Panel Dyspozycji – lista oparta o wspólny store Dyspozycji."""
+"""Panel Dyspozycji (dawniej: Zlecenia) – lista oparta o wspólny store Dyspozycji."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
### Motivation
- Uporządkowanie dokumentacji modułu poprzez doprecyzowanie docstringa `gui_zlecenia.py`, aby zawrzeć informację, że panel wcześniej nazywał się "Zlecenia".

### Description
- Zmieniono modułowy docstring w `gui_zlecenia.py` z `"""Panel Dyspozycji – lista oparta o wspólny store Dyspozycji."""` na `"""Panel Dyspozycji (dawniej: Zlecenia) – lista oparta o wspólny store Dyspozycji."""`.

### Testing
- Uruchomiono `pytest`, wynik: `5 failed, 222 passed, 46 skipped`, z niepowiązanymi z tą kosmetyczną zmianą porażkami w testach: `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive[Edwin]`, `test_gui_logowanie.py::test_logowanie_case_insensitive[EDWIN]`, `test_gui_logowanie.py::test_logowanie_callback_error`, oraz `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a5c9a2a4832397ea98fa4c64b833)