### PR TITLE
Add backward-compatible <<OrdersUpdated>> binding in ZleceniaView

### DIFF
--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -241,6 +241,8 @@ class ZleceniaView(ttk.Frame):
     # endregion ---------------------------------------------------------
 
     def _bind_orders_event(self) -> None:
+        # kompatybilność wsteczna – jeśli gdzieś jeszcze leci OrdersUpdated
+        self.bind("<<OrdersUpdated>>", lambda _event: self._reload_orders(), add=True)
         try:
             root = self.winfo_toplevel()
         except Exception:


### PR DESCRIPTION
### Motivation
- Zachować kompatybilność wsteczną dla miejsc, które emitują event `<<OrdersUpdated>>` bezpośrednio na widoku, aby widok nadal reagował na takie emisje nawet gdy główny toplevel też emituje event.

### Description
- Dodano lokalne powiązanie eventu w `ZleceniaView._bind_orders_event` poprzez `self.bind("<<OrdersUpdated>>", lambda _event: self._reload_orders(), add=True)` i pozostawiono istniejące powiązanie na toplevel bez zmian.

### Testing
- Uruchomiono `pytest -q`; testy uruchomiły się, ale całość zakończyła się niepowodzeniem z `5` błędami (222 passed, 46 skipped) z powodu istniejących, niepowiązanych problemów związanych z headless Tkinter (`$DISPLAY`) oraz jednym `KeyError` w logice zleceń.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a5d41f6c83239048d2633a565bc2)