### PR TITLE
Prefer runtime ConfigManager for dyspozycje sources and improve magazyn parsing

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -16,16 +16,31 @@ except Exception:  # pragma: no cover
     resolve_rel = None  # type: ignore
 
 
-def _cfg() -> dict:
+def _runtime_cfg_manager():
     try:
         from start import CONFIG_MANAGER  # type: ignore
 
-        if CONFIG_MANAGER is not None and hasattr(CONFIG_MANAGER, "load"):
-            cfg = CONFIG_MANAGER.load() or {}
-            if isinstance(cfg, dict):
-                return cfg
+        if CONFIG_MANAGER is not None:
+            return CONFIG_MANAGER
     except Exception:
         pass
+    if ConfigManager is not None:
+        try:
+            return ConfigManager()
+        except Exception:
+            pass
+    return None
+
+
+def _cfg() -> dict:
+    mgr = _runtime_cfg_manager()
+    if mgr is not None and hasattr(mgr, "load"):
+        try:
+            cfg = mgr.load() or {}
+            if isinstance(cfg, dict):
+                return cfg
+        except Exception:
+            pass
     if callable(get_config):
         try:
             cfg = get_config() or {}
@@ -44,36 +59,24 @@ def _cfg() -> dict:
 
 
 def _root_path(*parts: str) -> str:
-    try:
-        from start import CONFIG_MANAGER  # type: ignore
-
-        if CONFIG_MANAGER is not None:
-            path_root = getattr(CONFIG_MANAGER, "path_root", None)
+    mgr = _runtime_cfg_manager()
+    if mgr is not None:
+        try:
+            path_root = getattr(mgr, "path_root", None)
             if callable(path_root):
                 return path_root(*parts)
-    except Exception:
-        pass
-    if ConfigManager is not None:
-        try:
-            return ConfigManager().path_root(*parts)
         except Exception:
             pass
     return os.path.join(os.getcwd(), *parts)
 
 
 def _data_path(*parts: str) -> str:
-    try:
-        from start import CONFIG_MANAGER  # type: ignore
-
-        if CONFIG_MANAGER is not None:
-            path_data = getattr(CONFIG_MANAGER, "path_data", None)
+    mgr = _runtime_cfg_manager()
+    if mgr is not None:
+        try:
+            path_data = getattr(mgr, "path_data", None)
             if callable(path_data):
                 return path_data(*parts)
-    except Exception:
-        pass
-    if ConfigManager is not None:
-        try:
-            return ConfigManager().path_data(*parts)
         except Exception:
             pass
     return os.path.join("data", *parts)
@@ -116,7 +119,6 @@ def load_tool_choices() -> List[Tuple[str, str]]:
     tools_dir = _first_existing_path(
         _root_path("narzedzia"),
         _resolve_rel_path("tools.dir"),
-        _resolve_rel_path("tools_item_dir"),
         _resolve_rel_path("tools_dir"),
         _data_path("narzedzia"),
     ) or _root_path("narzedzia")
@@ -205,10 +207,10 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
     seen: set[str] = set()
 
     candidates = [
-        _resolve_rel_path("warehouse_stock"),
-        _resolve_rel_path("warehouse"),
         _root_path("magazyn", "magazyn.json"),
         _root_path("magazyn", "katalog.json"),
+        _resolve_rel_path("warehouse_stock"),
+        _resolve_rel_path("warehouse"),
         _data_path("magazyn", "katalog.json"),
     ]
 
@@ -227,6 +229,10 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
                 rows = data.get("pozycje") or []
             elif isinstance(data.get("magazyn"), list):
                 rows = data.get("magazyn") or []
+            elif isinstance(data.get("produkty"), list):
+                rows = data.get("produkty") or []
+            elif isinstance(data.get("stany"), list):
+                rows = data.get("stany") or []
             else:
                 for key, row in data.items():
                     if isinstance(row, dict):
@@ -234,6 +240,7 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
                             row.get("id")
                             or row.get("kod")
                             or row.get("nr")
+                            or row.get("symbol")
                             or key
                         ).strip()
                         if not code or code.lower() in seen:
@@ -256,6 +263,7 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
                 or row.get("kod")
                 or row.get("nr")
                 or row.get("symbol")
+                or row.get("index")
                 or ""
             ).strip()
             if not code or code.lower() in seen:
@@ -265,6 +273,7 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
                 row.get("nazwa")
                 or row.get("name")
                 or row.get("opis")
+                or row.get("typ")
                 or ""
             ).strip()
             label = f"{code} - {name}" if name else code

--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -43,10 +43,27 @@ def _now_iso() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
-def _data_root() -> Path:
+def _runtime_cfg_manager():
+    try:
+        from start import CONFIG_MANAGER  # type: ignore
+
+        if CONFIG_MANAGER is not None:
+            return CONFIG_MANAGER
+    except Exception:
+        pass
     if ConfigManager is not None:
         try:
-            return Path(ConfigManager().path_data())
+            return ConfigManager()
+        except Exception:
+            pass
+    return None
+
+
+def _data_root() -> Path:
+    mgr = _runtime_cfg_manager()
+    if mgr is not None:
+        try:
+            return Path(mgr.path_data())
         except Exception:
             pass
     return Path("data")


### PR DESCRIPTION
### Motivation
- Prefer using the runtime `start.CONFIG_MANAGER` when available instead of unconditionally instantiating `ConfigManager()` to respect application startup wiring and avoid duplicated lookup logic. 
- Centralize the runtime resolution of the configuration manager to reduce duplicated `start` import/error handling across `dyspozycje` modules. 
- Make magazyn/catalog loading more tolerant to different JSON shapes and field names encountered in real-world data. 

### Description
- Added a shared helper function ` _runtime_cfg_manager()` in `dyspozycje_store.py` and `dyspozycje_sources.py` that returns `start.CONFIG_MANAGER` when present or falls back to `ConfigManager()` safely. 
- Refactored `_data_root()`, `_cfg()`, `_root_path()` and `_data_path()` to use the runtime manager helper and removed duplicated `start` import logic. 
- Adjusted `load_tool_choices()` to remove the obsolete `tools_item_dir` fallback and use the intended tool directory resolution candidates. 
- Improved `load_magazyn_choices()` by reordering path candidates to prefer root `magazyn/*.json`, adding support for `produkty` and `stany` list keys, and expanding field fallbacks with `symbol`, `index` and `typ` to better detect item codes and names. 

### Testing
- Ran `pytest` after the changes by executing `pytest` in the repository root. 
- Test summary: `269` collected, `222` passed, `46` skipped, and `5` failed. 
- Failures were in GUI login tests (`test_gui_logowanie.py`) that hit tkinter display/root constraints in the test environment and one unrelated `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja` which raised a `KeyError: 'status'`; these failures appear unrelated to the runtime `ConfigManager` resolution changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66639aa288323bd40f537fe0f2578)