### PR TITLE
Add dyspozycje debug logging for config/path resolution

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -21,12 +21,27 @@ def _runtime_cfg_manager():
         from start import CONFIG_MANAGER  # type: ignore
 
         if CONFIG_MANAGER is not None:
+            try:
+                print(
+                    "[WM-DBG][DYSP][SRC] runtime manager=start.CONFIG_MANAGER "
+                    f"{type(CONFIG_MANAGER).__name__}"
+                )
+            except Exception:
+                pass
             return CONFIG_MANAGER
     except Exception:
         pass
     if ConfigManager is not None:
         try:
-            return ConfigManager()
+            mgr = ConfigManager()
+            try:
+                print(
+                    "[WM-DBG][DYSP][SRC] runtime manager=ConfigManager() "
+                    f"{type(mgr).__name__}"
+                )
+            except Exception:
+                pass
+            return mgr
         except Exception:
             pass
     return None
@@ -37,6 +52,16 @@ def _cfg() -> dict:
     if mgr is not None and hasattr(mgr, "load"):
         try:
             cfg = mgr.load() or {}
+            try:
+                paths = (cfg.get("paths") or {}) if isinstance(cfg, dict) else {}
+                print(
+                    "[WM-DBG][DYSP][SRC] cfg paths:"
+                    f" anchor_root={paths.get('anchor_root')}"
+                    f" data_root={paths.get('data_root')}"
+                    f" logs_dir={paths.get('logs_dir')}"
+                )
+            except Exception:
+                pass
             if isinstance(cfg, dict):
                 return cfg
         except Exception:
@@ -64,7 +89,12 @@ def _root_path(*parts: str) -> str:
         try:
             path_root = getattr(mgr, "path_root", None)
             if callable(path_root):
-                return path_root(*parts)
+                result = path_root(*parts)
+                try:
+                    print(f"[WM-DBG][DYSP][SRC] path_root{parts} -> {result}")
+                except Exception:
+                    pass
+                return result
         except Exception:
             pass
     return os.path.join(os.getcwd(), *parts)
@@ -76,7 +106,12 @@ def _data_path(*parts: str) -> str:
         try:
             path_data = getattr(mgr, "path_data", None)
             if callable(path_data):
-                return path_data(*parts)
+                result = path_data(*parts)
+                try:
+                    print(f"[WM-DBG][DYSP][SRC] path_data{parts} -> {result}")
+                except Exception:
+                    pass
+                return result
         except Exception:
             pass
     return os.path.join("data", *parts)
@@ -122,6 +157,10 @@ def load_tool_choices() -> List[Tuple[str, str]]:
         _resolve_rel_path("tools_dir"),
         _data_path("narzedzia"),
     ) or _root_path("narzedzia")
+    try:
+        print(f"[WM-DBG][DYSP][SRC] tools_dir_selected={tools_dir}")
+    except Exception:
+        pass
     out = []
 
     try:
@@ -186,6 +225,17 @@ def load_machine_choices() -> List[Tuple[str, str]]:
         _resolve_rel_path("machines"),
         _data_path("maszyny", "maszyny.json"),
     )
+    try:
+        print(
+            "[WM-DBG][DYSP][SRC] machine_candidates="
+            f"root:{_root_path('maszyny', 'maszyny.json')} | "
+            f"get_machines_path:{machine_path} | "
+            f"resolve_rel:{_resolve_rel_path('machines')} | "
+            f"data:{_data_path('maszyny', 'maszyny.json')}"
+        )
+        print(f"[WM-DBG][DYSP][SRC] machine_path_selected={path}")
+    except Exception:
+        pass
     if not path:
         return []
 
@@ -255,6 +305,10 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
         _resolve_rel_path("warehouse"),
         _data_path("magazyn", "katalog.json"),
     ]
+    try:
+        print(f"[WM-DBG][DYSP][SRC] magazyn_candidates={candidates}")
+    except Exception:
+        pass
 
     for path in [p for p in candidates if p]:
         try:

--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -48,12 +48,27 @@ def _runtime_cfg_manager():
         from start import CONFIG_MANAGER  # type: ignore
 
         if CONFIG_MANAGER is not None:
+            try:
+                print(
+                    "[WM-DBG][DYSP][STORE] runtime manager=start.CONFIG_MANAGER "
+                    f"{type(CONFIG_MANAGER).__name__}"
+                )
+            except Exception:
+                pass
             return CONFIG_MANAGER
     except Exception:
         pass
     if ConfigManager is not None:
         try:
-            return ConfigManager()
+            mgr = ConfigManager()
+            try:
+                print(
+                    "[WM-DBG][DYSP][STORE] runtime manager=ConfigManager() "
+                    f"{type(mgr).__name__}"
+                )
+            except Exception:
+                pass
+            return mgr
         except Exception:
             pass
     return None
@@ -63,7 +78,12 @@ def _data_root() -> Path:
     mgr = _runtime_cfg_manager()
     if mgr is not None:
         try:
-            return Path(mgr.path_data())
+            path = Path(mgr.path_data())
+            try:
+                print(f"[WM-DBG][DYSP][STORE] data_root={path}")
+            except Exception:
+                pass
+            return path
         except Exception:
             pass
     return Path("data")
@@ -72,6 +92,10 @@ def _data_root() -> Path:
 def get_dyspozycje_path() -> Path:
     path = _data_root() / DISP_FILE_NAME
     path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        print(f"[WM-DBG][DYSP][STORE] dyspozycje_path={path}")
+    except Exception:
+        pass
     return path
 
 


### PR DESCRIPTION
### Motivation
- Add lightweight runtime diagnostics to understand which configuration manager and filesystem paths are used when resolving dyspozycje (tasks) sources and storage.
- Ensure logging is non-intrusive so resolution issues can be debugged without changing runtime behavior.

### Description
- In `dyspozycje_store.py` added debug prints in `_runtime_cfg_manager()` to indicate whether `start.CONFIG_MANAGER` or a `ConfigManager()` instance is used, and added prints for resolved `data_root` and final `dyspozycje_path`.
- In `dyspozycje_sources.py` added debug prints showing the selected runtime manager, loaded config `paths` values, results of `_root_path()` and `_data_path()` calls, and the chosen candidates for tools, machines and magazyn sources.
- All debug prints are wrapped in local `try/except` blocks to avoid raising exceptions if logging itself fails and to preserve original control flow.

### Testing
- Ran the full test suite with `pytest`, which collected 269 tests and produced `222 passed`, `46 skipped`, and `5 failed`.
- The failing tests were `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive[Edwin]`, `test_gui_logowanie.py::test_logowanie_case_insensitive[EDWIN]`, `test_gui_logowanie.py::test_logowanie_callback_error`, and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`.
- Failures included tkinter display/root related runtime errors in the GUI login tests and a `KeyError` on `status` in the orders test, and were observed while running the suite after these debug-log-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67b0a04888323928d8fa5cf643f75)