### PR TITLE
Use loaded start module for runtime CONFIG_MANAGER lookup in dyspozycje modules

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from typing import List, Tuple
 
 try:
@@ -18,17 +19,18 @@ except Exception:  # pragma: no cover
 
 def _runtime_cfg_manager():
     try:
-        from start import CONFIG_MANAGER  # type: ignore
-
-        if CONFIG_MANAGER is not None:
-            try:
-                print(
-                    "[WM-DBG][DYSP][SRC] runtime manager=start.CONFIG_MANAGER "
-                    f"{type(CONFIG_MANAGER).__name__}"
-                )
-            except Exception:
-                pass
-            return CONFIG_MANAGER
+        start_mod = sys.modules.get("start")
+        if start_mod is not None:
+            mgr = getattr(start_mod, "CONFIG_MANAGER", None)
+            if mgr is not None:
+                try:
+                    print(
+                        "[WM-DBG][DYSP][SRC] runtime manager=start.CONFIG_MANAGER "
+                        f"{type(mgr).__name__}"
+                    )
+                except Exception:
+                    pass
+                return mgr
     except Exception:
         pass
     if ConfigManager is not None:

--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -12,6 +12,7 @@ Cel:
 from __future__ import annotations
 
 import json
+import sys
 import uuid
 from copy import deepcopy
 from datetime import datetime
@@ -45,17 +46,18 @@ def _now_iso() -> str:
 
 def _runtime_cfg_manager():
     try:
-        from start import CONFIG_MANAGER  # type: ignore
-
-        if CONFIG_MANAGER is not None:
-            try:
-                print(
-                    "[WM-DBG][DYSP][STORE] runtime manager=start.CONFIG_MANAGER "
-                    f"{type(CONFIG_MANAGER).__name__}"
-                )
-            except Exception:
-                pass
-            return CONFIG_MANAGER
+        start_mod = sys.modules.get("start")
+        if start_mod is not None:
+            mgr = getattr(start_mod, "CONFIG_MANAGER", None)
+            if mgr is not None:
+                try:
+                    print(
+                        "[WM-DBG][DYSP][STORE] runtime manager=start.CONFIG_MANAGER "
+                        f"{type(mgr).__name__}"
+                    )
+                except Exception:
+                    pass
+                return mgr
     except Exception:
         pass
     if ConfigManager is not None:


### PR DESCRIPTION
### Motivation
- Importing `start` at runtime can introduce side effects and dependency-order issues, so prefer reading the runtime `CONFIG_MANAGER` from an already-loaded `start` module when available.

### Description
- Updated `dyspozycje_store.py` to `import sys` and replace the `from start import CONFIG_MANAGER` import with a `sys.modules.get('start')` lookup that returns `start.CONFIG_MANAGER` if present.
- Applied the same change to `dyspozycje_sources.py`, adding `import sys` and using the loaded `start` module to access `CONFIG_MANAGER` before falling back to `ConfigManager()`.
- Behavior falls back to instantiating `ConfigManager()` when no loaded `start` module or `CONFIG_MANAGER` is present, preserving prior fallback behavior.

### Testing
- Ran the full test suite with `pytest` in the repository root.
- Test run completed with 5 failures, 222 passed and 46 skipped, where the failures are GUI/Tkinter display-related (`test_gui_logowanie.py`) and one order-loading expectation (`test_logika_zlecenia_i_maszyny.py`) and do not appear to be caused by the runtime config lookup change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67fac621083239291cc17ad2f397f)