### PR TITLE
Add dyspozycja editing support from list view

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -13,7 +13,7 @@ from dyspozycje_sources import (
     load_tool_choices,
     load_zlecenie_wykonania_choices,
 )
-from dyspozycje_store import add_dyspozycja, make_dyspozycja
+from dyspozycje_store import add_dyspozycja, make_dyspozycja, update_dyspozycja
 
 try:
     from profiles_store import load_profiles_users, resolve_profiles_path
@@ -65,9 +65,11 @@ def open_dyspozycje_creator(
     context: dict[str, Any] | None = None,
 ) -> tk.Toplevel:
     ctx = dict(context or {})
+    edit_mode = bool(ctx.get("edit_mode"))
+    existing_id = str(ctx.get("id") or "").strip()
     root = master.winfo_toplevel() if master else None
     win = tk.Toplevel(root)
-    win.title("Kreator – Dodaj Dyspozycję")
+    win.title("Kreator – Edytuj Dyspozycję" if edit_mode else "Kreator – Dodaj Dyspozycję")
     win.geometry("700x500")
     win.resizable(False, False)
 
@@ -77,7 +79,7 @@ def open_dyspozycje_creator(
 
     ttk.Label(
         frame,
-        text="Nowa Dyspozycja",
+        text="Edycja Dyspozycji" if edit_mode else "Nowa Dyspozycja",
         style="WM.H1.TLabel",
     ).grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 12))
 
@@ -207,26 +209,43 @@ def open_dyspozycje_creator(
             )
             return
 
-        item = make_dyspozycja(
-            typ_dyspozycji=var_type.get().strip(),
-            tytul=title,
-            opis=txt_desc.get("1.0", "end").strip(),
-            autor=str(autor or "").strip(),
-            przypisane_do="" if var_all.get() else var_assigned.get().strip(),
-            dla_wszystkich=bool(var_all.get()),
-            termin=var_deadline.get().strip(),
-            priorytet=var_priority.get().strip(),
-            modul_zrodlowy=source_module["value"],
-            obiekt_id=object_id,
-            meta={"object_label": selected_label},
-        )
-        add_dyspozycja(item)
+        payload = {
+            "typ_dyspozycji": var_type.get().strip(),
+            "tytul": title,
+            "opis": txt_desc.get("1.0", "end").strip(),
+            "autor": str(autor or ctx.get("autor") or "").strip(),
+            "przypisane_do": "" if var_all.get() else var_assigned.get().strip(),
+            "dla_wszystkich": bool(var_all.get()),
+            "termin": var_deadline.get().strip(),
+            "priorytet": var_priority.get().strip(),
+            "modul_zrodlowy": source_module["value"],
+            "obiekt_id": object_id,
+            "meta": {"object_label": selected_label},
+        }
+
+        if edit_mode and existing_id:
+            changed = update_dyspozycja(existing_id, payload)
+            if not changed:
+                messagebox.showerror(
+                    "Dyspozycje",
+                    "Nie udało się zapisać zmian Dyspozycji.",
+                    parent=win,
+                )
+                return
+        else:
+            item = make_dyspozycja(**payload)
+            add_dyspozycja(item)
+
         try:
             # NOWY event dla Dyspozycji (zamiast OrdersUpdated)
             win.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
         except Exception:
             pass
-        messagebox.showinfo("Dyspozycje", "Dyspozycja została zapisana.", parent=win)
+        messagebox.showinfo(
+            "Dyspozycje",
+            "Dyspozycja została zaktualizowana." if edit_mode else "Dyspozycja została zapisana.",
+            parent=win,
+        )
         win.destroy()
 
     ttk.Button(btns, text="Anuluj", command=win.destroy).pack(side="right", padx=(8, 0))

--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -89,6 +89,13 @@ class ZleceniaView(ttk.Frame):
             btn_add.state(["disabled"])
         btn_add.pack(side="left")
 
+        btn_edit = ttk.Button(toolbar, text="Edytuj Dyspozycję")
+        if self._open_order_creator:
+            btn_edit.configure(command=self._on_edit)
+        else:
+            btn_edit.state(["disabled"])
+        btn_edit.pack(side="left", padx=(8, 0))
+
     def _build_tree(self) -> None:
         columns = ("typ", "status", "tytul", "przypisane", "termin")
         self.tree = ttk.Treeview(self, columns=columns, show="headings")
@@ -180,6 +187,36 @@ class ZleceniaView(ttk.Frame):
                 f"Nie udało się otworzyć kreatora Dyspozycji.\n{exc}",
             )
 
+    def _on_edit(self) -> None:
+        if not self._open_order_creator:
+            return
+        selection = self.tree.selection()
+        if not selection:
+            messagebox.showinfo(
+                "Dyspozycje",
+                "Najpierw wybierz Dyspozycję do edycji.",
+                parent=self,
+            )
+            return
+        iid = selection[0]
+        mapped = dict(self._order_rows.get(iid, {}) or {})
+        if not mapped:
+            return
+        mapped["edit_mode"] = True
+        try:
+            self._open_order_creator(
+                self,
+                autor=str(mapped.get("autor") or ""),
+                context=mapped,
+            )
+        except Exception as exc:  # pragma: no cover - wymagane GUI
+            logger.exception("[DYSP] Błąd otwierania edycji Dyspozycji: %s", exc)
+            error_box(
+                self,
+                "Dyspozycje",
+                f"Nie udało się otworzyć edycji Dyspozycji.\n{exc}",
+            )
+
     def _on_double_click(self, event: Any) -> None:
         del event
         selection = self.tree.selection()
@@ -189,20 +226,7 @@ class ZleceniaView(ttk.Frame):
         mapped = self._order_rows.get(iid, {})
         if not mapped:
             return
-        body = (
-            f"ID: {mapped.get('id', '')}\n"
-            f"Typ: {mapped.get('typ_dyspozycji', '')}\n"
-            f"Status: {mapped.get('status', '')}\n"
-            f"Tytuł: {mapped.get('tytul', '')}\n"
-            f"Opis: {mapped.get('opis', '')}\n"
-            f"Priorytet: {mapped.get('priorytet', '')}\n"
-            f"Termin: {mapped.get('termin', '')}\n"
-            f"Przypisane do: {'wszyscy' if mapped.get('dla_wszystkich') else mapped.get('przypisane_do', '')}\n"
-            f"Moduł źródłowy: {mapped.get('modul_zrodlowy', '')}\n"
-            f"Obiekt ID: {mapped.get('obiekt_id', '')}\n"
-            f"Autor: {mapped.get('autor', '')}"
-        )
-        messagebox.showinfo("Szczegóły Dyspozycji", body, parent=self)
+        self._on_edit()
 
     # endregion ---------------------------------------------------------
 


### PR DESCRIPTION
### Motivation
- Provide an in-place edit flow so existing Dyspozycje can be edited from the list view using the same creator UI.
- Reuse the creator logic to avoid duplicate forms and to keep create/update payload handling consistent.
- Improve UX by adding explicit toolbar action and making double-click open the editor.

### Description
- Added `update_dyspozycja` import and detection of `edit_mode` and `id` in `open_dyspozycje_creator` to toggle window title and header.
- Consolidated form values into a single `payload` and route to `update_dyspozycja(existing_id, payload)` when editing, otherwise use `make_dyspozycja` + `add_dyspozycja` for creation.
- Updated save confirmation message to reflect create vs update result and show an error if the update call reports no change.
- In `ZleceniaView` added an `Edytuj Dyspozycję` toolbar button, implemented `_on_edit` to open the creator with `edit_mode=True`, and made double-click reuse the edit flow.

### Testing
- Ran `pytest` after changes; the test run collected 269 items and completed with `222 passed, 5 failed, 46 skipped`.
- Failures are GUI/login related and one order-loading test: `test_logowanie_success`, two parametrized `test_logowanie_case_insensitive` variants, `test_logowanie_callback_error`, and `test_wczytanie_wielu_zlecen_filtracja`.
- The failing tests are environment/GU I-related (`tkinter`/no `$DISPLAY`) and one domain test unrelated to the dyspozycja edit flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6836bb5ac8323809ef36642dc8de3)