### PR TITLE
Add close/delete actions for Dyspozycje and record closure audit fields

### DIFF
--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -167,6 +167,8 @@ def make_dyspozycja(
         "obiekt_id": str(obiekt_id or "").strip(),
         "utworzono": _now_iso(),
         "wykonano": "",
+        "zamknieto_at": "",
+        "zamkniete_przez": "",
         "uwagi": "",
         "meta": dict(meta or {}),
     }
@@ -190,6 +192,8 @@ def normalize_dyspozycja(item: dict[str, Any] | None) -> dict[str, Any]:
         "obiekt_id": str(src.get("obiekt_id") or "").strip(),
         "utworzono": str(src.get("utworzono") or _now_iso()).strip(),
         "wykonano": str(src.get("wykonano") or "").strip(),
+        "zamknieto_at": str(src.get("zamknieto_at") or "").strip(),
+        "zamkniete_przez": _normalize_login(src.get("zamkniete_przez")),
         "uwagi": str(src.get("uwagi") or "").strip(),
         "meta": dict(src.get("meta") or {}),
     }
@@ -279,10 +283,13 @@ def close_dyspozycja(
     dyspozycja_id: str,
     *,
     uwagi: str = "",
+    closed_by: str = "",
 ) -> dict[str, Any] | None:
     updates = {
         "status": "zamknieta",
         "wykonano": _now_iso(),
+        "zamknieto_at": _now_iso(),
+        "zamkniete_przez": _normalize_login(closed_by),
     }
     if str(uwagi or "").strip():
         updates["uwagi"] = str(uwagi).strip()

--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import logging
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox, simpledialog, ttk
 from typing import Any, Callable
 
-from dyspozycje_store import load_dyspozycje
+from dyspozycje_store import close_dyspozycja, delete_dyspozycja, load_dyspozycje
 
 from ui_dialogs_safe import error_box
 
@@ -65,6 +65,7 @@ class ZleceniaView(ttk.Frame):
 
     def __init__(self, master: tk.Widget) -> None:
         super().__init__(master, padding=8)
+        self._login_user = self._resolve_login_user()
         self._after = _AfterGuard(self)
         self._refresh_error_shown = False
         self._order_rows: dict[str, dict] = {}
@@ -76,6 +77,26 @@ class ZleceniaView(ttk.Frame):
         self.bind("<Destroy>", self._on_destroy, add=True)
         self._refresh()
         self._schedule_refresh()
+
+    def _resolve_login_user(self) -> str:
+        candidates = [
+            getattr(self.master, "login_sesji", None),
+            getattr(self.master, "current_user", None),
+            getattr(self.master, "user_login", None),
+        ]
+        for value in candidates:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        try:
+            root = self.winfo_toplevel()
+        except Exception:
+            root = None
+        if root is not None:
+            for attr in ("login_sesji", "current_user", "user_login"):
+                value = getattr(root, attr, None)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
 
     # region UI helpers -------------------------------------------------
     def _build_toolbar(self) -> None:
@@ -95,6 +116,13 @@ class ZleceniaView(ttk.Frame):
         else:
             btn_edit.state(["disabled"])
         btn_edit.pack(side="left", padx=(8, 0))
+
+        ttk.Button(toolbar, text="Zamknij Dyspozycję", command=self._on_close).pack(
+            side="left", padx=(8, 0)
+        )
+        ttk.Button(toolbar, text="Usuń Dyspozycję", command=self._on_delete).pack(
+            side="left", padx=(8, 0)
+        )
 
     def _build_tree(self) -> None:
         columns = ("typ", "status", "tytul", "przypisane", "termin")
@@ -216,6 +244,98 @@ class ZleceniaView(ttk.Frame):
                 "Dyspozycje",
                 f"Nie udało się otworzyć edycji Dyspozycji.\n{exc}",
             )
+
+    def _selected_row(self) -> dict[str, Any] | None:
+        selection = self.tree.selection()
+        if not selection:
+            return None
+        iid = selection[0]
+        mapped = dict(self._order_rows.get(iid, {}) or {})
+        return mapped or None
+
+    def _on_close(self) -> None:
+        mapped = self._selected_row()
+        if not mapped:
+            messagebox.showinfo(
+                "Dyspozycje",
+                "Najpierw wybierz Dyspozycję do zamknięcia.",
+                parent=self,
+            )
+            return
+        dysp_id = str(mapped.get("id") or "").strip()
+        if not dysp_id:
+            return
+        if str(mapped.get("status") or "").strip().lower() == "zamknieta":
+            messagebox.showinfo(
+                "Dyspozycje",
+                "Ta Dyspozycja jest już zamknięta.",
+                parent=self,
+            )
+            return
+        note = simpledialog.askstring(
+            "Zamknij Dyspozycję",
+            "Uwagi przy zamknięciu (opcjonalnie):",
+            parent=self,
+        )
+        who = self._login_user or str(mapped.get("autor") or "").strip()
+        changed = close_dyspozycja(
+            dysp_id,
+            uwagi=note or "",
+            closed_by=who,
+        )
+        if not changed:
+            messagebox.showerror(
+                "Dyspozycje",
+                "Nie udało się zamknąć Dyspozycji.",
+                parent=self,
+            )
+            return
+        try:
+            self.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
+        except Exception:
+            pass
+        messagebox.showinfo(
+            "Dyspozycje",
+            f"Dyspozycja została zamknięta przez: {who or '-'}",
+            parent=self,
+        )
+
+    def _on_delete(self) -> None:
+        mapped = self._selected_row()
+        if not mapped:
+            messagebox.showinfo(
+                "Dyspozycje",
+                "Najpierw wybierz Dyspozycję do usunięcia.",
+                parent=self,
+            )
+            return
+        dysp_id = str(mapped.get("id") or "").strip()
+        if not dysp_id:
+            return
+        ok = messagebox.askyesno(
+            "Usuń Dyspozycję",
+            f"Czy na pewno usunąć Dyspozycję:\n{dysp_id}?",
+            parent=self,
+        )
+        if not ok:
+            return
+        deleted = delete_dyspozycja(dysp_id)
+        if not deleted:
+            messagebox.showerror(
+                "Dyspozycje",
+                "Nie udało się usunąć Dyspozycji.",
+                parent=self,
+            )
+            return
+        try:
+            self.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
+        except Exception:
+            pass
+        messagebox.showinfo(
+            "Dyspozycje",
+            "Dyspozycja została usunięta.",
+            parent=self,
+        )
 
     def _on_double_click(self, event: Any) -> None:
         del event


### PR DESCRIPTION
### Motivation
- Provide audit information when a dyspozycja is closed and let users close or remove dyspozycje from the GUI. 

### Description
- Extend the dyspozycja data model with closure metadata fields `zamknieto_at` and `zamkniete_przez` and normalize them in `dyspozycje_store.py`.
- Add `closed_by` parameter to `close_dyspozycja()` and write `zamknieto_at` / `zamkniete_przez` when closing a record in `dyspozycje_store.py`.
- Enhance `ZleceniaView` in `gui_zlecenia.py` with a `_resolve_login_user()` helper, new toolbar buttons for `Zamknij Dyspozycję` and `Usuń Dyspozycję`, a `_selected_row()` helper, and handlers `_on_close()` / `_on_delete()` that validate selection, call store helpers (`close_dyspozycja`, `delete_dyspozycja`), and emit `<<DyspozycjeUpdated>>` after changes.
- Import and wire `close_dyspozycja` and `delete_dyspozycja` into the GUI module and use `simpledialog` for optional closure notes.

### Testing
- Ran `pytest` for the repository; test run collected `269` items with `222` passed, `46` skipped, and `5` failed.
- The failing tests were `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive[Edwin]`, `test_gui_logowanie.py::test_logowanie_case_insensitive[EDWIN]`, `test_gui_logowanie.py::test_logowanie_callback_error`, and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6880dadc08323a0c3de7b9ed42edb)