### PR TITLE
Add dyspozycje_store imports to gui_profile.py

### DIFF
--- a/gui_profile.py
+++ b/gui_profile.py
@@ -32,6 +32,8 @@ import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox, ttk
 
+from dyspozycje_store import assigned_to_login, visible_for_login
+
 try:
     from ui_theme_guard import ensure_theme_applied
 except Exception:  # pragma: no cover - optional dependency


### PR DESCRIPTION
### Motivation
- Prepare the profile GUI to use centralized dyspozycje helpers by making `assigned_to_login` and `visible_for_login` available in `gui_profile.py`.

### Description
- Added the import `from dyspozycje_store import assigned_to_login, visible_for_login` to `gui_profile.py` next to the other top-level imports.

### Testing
- Ran `pytest -q`; tests executed but the run finished with 5 failing tests (222 passed, 46 skipped), with failures unrelated to this import-only change: tkinter display/runtime errors in `test_gui_logowanie.py`, an assertion mismatch in `test_logowanie_callback_error`, and a `KeyError: 'status'` in `test_logika_zlecenia_i_maszyny.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68ab39be48323a441908afa3e0ac2)