### PR TITLE
Harden global task completion loader in tools dialog

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -6192,9 +6192,6 @@ def panel_narzedzia(root, frame, login=None, rola=None):
             tv.bind("<Button-3>", _show_task_menu)
 
         def _update_global_tasks(comment, ts):
-            state = STATE
-            if getattr(state, "global_tasks", None) is None:
-                state.global_tasks = []
             path = _resolve_path_candidate(
                 getattr(LZ, "TOOL_TASKS_PATH", None),
                 _default_tools_tasks_file(),
@@ -6204,9 +6201,14 @@ def panel_narzedzia(root, frame, login=None, rola=None):
                     data = json.load(f)
             except (OSError, json.JSONDecodeError):
                 data = []
-            state.global_tasks = data
+
+            if not isinstance(data, list):
+                data = []
+
             changed = False
             for item in data:
+                if not isinstance(item, dict):
+                    continue
                 if item.get("status") != "Zrobione":
                     item["status"] = "Zrobione"
                     item["by"] = login or "nieznany"


### PR DESCRIPTION
### Motivation

- Make the tools dialog more robust when loading and marking global tasks as done by avoiding assumptions about the JSON payload shape. 
- Avoid mutating the global `STATE` from a dialog-local helper and guard against malformed data to prevent runtime errors when reading legacy or corrupted task files.

### Description

- Updated `gui_narzedzia.py` in the helper `def _update_global_tasks(...)` to stop assigning `STATE.global_tasks` and operate on the local `data` variable only. 
- Add a type guard after JSON load to coerce non-list content to an empty list by checking `if not isinstance(data, list): data = []`.
- Skip non-dictionary entries when iterating tasks by checking `if not isinstance(item, dict): continue`, then set `status`, `by`, `ts_done` and optional `komentarz` for valid entries and write back only if something changed.

### Testing

- Ran the full test suite with `pytest`; the run produced `5 failed, 222 passed, 46 skipped` and the failures are in existing GUI login tests and an order-loading test unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c07854148323bed9895173f04971)