### PR TITLE
Add WM root selection guidance dialogs during startup

### DIFF
--- a/start.py
+++ b/start.py
@@ -793,10 +793,73 @@ def main():
         _info("ConfigManager: OK")
         try:
             from backend.bootstrap_root import ensure_root_ready
+            from tkinter import messagebox
+
+            manager = _ensure_config_manager()
+            anchor = ""
+            data_root = ""
+            try:
+                if manager is not None:
+                    anchor = str(manager.path_anchor() or "")
+                    data_root = str(manager.path_data() or "")
+            except Exception:
+                anchor = ""
+                data_root = ""
+
+            info_lines = [
+                "WM może zapytać teraz o folder roboczy programu.",
+                "",
+                "Wskaż główny folder WM (<root>), a nie pojedynczy podfolder.",
+                "",
+                "W tym folderze zwykle znajdują się lub będą tworzone m.in.:",
+                "- narzedzia\\",
+                "- maszyny\\",
+                "- magazyn\\",
+                "- zlecenia\\",
+                "- produkty\\",
+                "- polprodukty\\",
+                "- data\\",
+                "- logs\\",
+                "- backup\\",
+                "- config.json",
+                "",
+                "Przykład poprawnego wyboru:",
+                "C:\\wm",
+                "",
+                "Nie wybieraj od razu np. samego folderu data\\ albo magazyn\\.",
+            ]
+            if anchor or data_root:
+                info_lines.extend(
+                    [
+                        "",
+                        f"Obecny root: {anchor or '-'}",
+                        f"Obecny data_root: {data_root or '-'}",
+                    ]
+                )
+
+            try:
+                messagebox.showinfo(
+                    "Wybór folderu WM",
+                    "\n".join(info_lines),
+                    parent=None,
+                )
+            except Exception:
+                pass
 
             ensure_root_ready(str(CONFIG_PATH))
             _info("Root bootstrap: OK")
         except Exception as e:  # pragma: no cover - startup warning only
+            try:
+                messagebox.showwarning(
+                    "Problem ze ścieżkami WM",
+                    "Nie udało się przygotować folderu roboczego WM.\n\n"
+                    "Wskaż główny folder programu (<root>), w którym są lub będą trzymane dane.\n"
+                    "Typowy przykład: C:\\wm\n\n"
+                    f"Szczegóły: {e}",
+                    parent=None,
+                )
+            except Exception:
+                pass
             _error("Root bootstrap failed", str(e))
     except Exception:
         _error("ConfigManager: problem (pomijam)")


### PR DESCRIPTION
### Motivation
- Help users correctly select the main WM workspace (`<root>`) during the first-run/root selection flow to avoid choosing a subfolder by mistake.
- Surface current configured paths when available so users can verify the existing `path_anchor` and `path_data` before changing them.
- Provide a user-facing warning if the root bootstrap fails so the user gets guidance instead of only a log entry.

### Description
- Import and use `tkinter.messagebox` to show an informational dialog before calling `ensure_root_ready(...)` with guidance and an example path (`C:\wm`).
- Query the `ConfigManager` via `_ensure_config_manager()` to read `path_anchor()` and `path_data()` and append them to the informational text when present.
- Wrap `messagebox.showinfo` and `messagebox.showwarning` calls in `try/except` to avoid crashing non-GUI environments and show a warning with exception details on bootstrap failure.

### Testing
- Ran `pytest -q` to validate the test suite execution.
- Test run result: `5 failed, 222 passed, 46 skipped`.
- The failing tests are `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive` (two parameter cases), `test_gui_logowanie.py::test_logowanie_callback_error`, and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`, which appear related to GUI/display behavior and existing data handling rather than the new informational dialogs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcf72be6c83238b13346bf6f01403)