### PR TITLE
Prefer path_anchor resolution in dyspozycje _root_path

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -89,22 +89,22 @@ def _root_path(*parts: str) -> str:
     mgr = _runtime_cfg_manager()
     if mgr is not None:
         try:
-            path_root = getattr(mgr, "path_root", None)
-            if callable(path_root):
-                result = path_root(*parts)
+            path_anchor = getattr(mgr, "path_anchor", None)
+            if callable(path_anchor):
+                result = os.path.join(str(path_anchor()), *parts)
                 try:
-                    print(f"[WM-DBG][DYSP][SRC] path_root{parts} -> {result}")
+                    print(f"[WM-DBG][DYSP][SRC] path_anchor{parts} -> {result}")
                 except Exception:
                     pass
                 return result
         except Exception:
             pass
         try:
-            path_anchor = getattr(mgr, "path_anchor", None)
-            if callable(path_anchor):
-                result = os.path.join(str(path_anchor()), *parts)
+            path_root = getattr(mgr, "path_root", None)
+            if callable(path_root):
+                result = path_root(*parts)
                 try:
-                    print(f"[WM-DBG][DYSP][SRC] path_anchor{parts} -> {result}")
+                    print(f"[WM-DBG][DYSP][SRC] path_root{parts} -> {result}")
                 except Exception:
                     pass
                 return result


### PR DESCRIPTION
### Motivation
- Prefer an anchor-based resolution when available so path construction uses `ConfigManager.path_anchor()` before falling back to `ConfigManager.path_root()`.

### Description
- Reordered `_root_path` to try `mgr.path_anchor()` first and then `mgr.path_root()`, preserving existing debug logging and the fallback to `os.getcwd()`.

### Testing
- Ran `pytest -q` after the change; test run produced `5 failed, 222 passed, 46 skipped`, and the failing tests are existing GUI/login `tkinter`-related tests and a `zlecenia` test that appear unrelated to this small path-resolution change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd638cb5c8323a2e201c20c84bd5c)