### PR TITLE
Load only numeric-named tool JSON files

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -165,6 +165,10 @@ def load_tool_choices() -> List[Tuple[str, str]]:
             if not filename.endswith(".json"):
                 continue
 
+            file_stem = os.path.splitext(filename)[0].strip()
+            if not file_stem.isdigit():
+                continue
+
             path = os.path.join(tools_dir, filename)
             try:
                 with open(path, "r", encoding="utf-8") as f:
@@ -177,7 +181,6 @@ def load_tool_choices() -> List[Tuple[str, str]]:
             elif isinstance(doc, dict) and isinstance(doc.get("tool"), dict):
                 doc = doc.get("tool") or {}
 
-            file_stem = os.path.splitext(filename)[0].strip()
             tool_id = str(
                 doc.get("id")
                 or doc.get("nr")


### PR DESCRIPTION
### Motivation
- Ensure `load_tool_choices()` ignores auxiliary or non-standard JSON files and only treats numeric-stem files as tool definitions.

### Description
- Added an early check in `load_tool_choices()` to skip files whose stem is not numeric (`file_stem.isdigit()`), and reuse the validated `file_stem` as the fallback `tool_id` when deriving labels.

### Testing
- Ran `pytest -q`; automated test run produced `222 passed, 5 failed, 46 skipped`, where the failing tests are unrelated GUI/Tkinter and order-filtering tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd97ae9348323bd449157e0ab68e9)