### PR TITLE
Add module path debug print in dyspozycje_sources

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -9,6 +9,11 @@ import sys
 from typing import List, Tuple
 
 try:
+    print(f"[WM-DBG][DYSP][SRC] module_file={__file__}")
+except Exception:
+    pass
+
+try:
     from config_manager import ConfigManager, get_config, get_machines_path, resolve_rel
 except Exception:  # pragma: no cover
     ConfigManager = None  # type: ignore


### PR DESCRIPTION
### Motivation
- Add a small startup debug log to help identify the module file path when troubleshooting Dyspozycje data sources.

### Description
- Inserted a defensive `try/except` block near imports in `dyspozycje_sources.py` that prints `[WM-DBG][DYSP][SRC] module_file=...` using `__file__` so the runtime path is logged without affecting execution.

### Testing
- Ran the test suite with `pytest`, which completed but reported `5 failed, 222 passed, 46 skipped` with failures in `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive` (parametrized), `test_gui_logowanie.py::test_logowanie_callback_error`, and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`, and these failures appear to be unrelated to the small debug-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edda8f4acc832389ca3c8d7ec5ca10)