### PR TITLE
Add support for 'lista' alias when parsing magazyn JSON

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -330,6 +330,8 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
                 rows = data.get("produkty") or []
             elif isinstance(data.get("stany"), list):
                 rows = data.get("stany") or []
+            elif isinstance(data.get("lista"), list):
+                rows = data.get("lista") or []
             elif isinstance(data.get("rows"), list):
                 rows = data.get("rows") or []
             elif isinstance(data.get("data"), list):


### PR DESCRIPTION
### Motivation
- Rozszerzyć akceptowalne aliasy sekcji w plikach katalogu magazynowego, aby obsłużyć wejściowe JSONy używające klucza `lista`.

### Description
- W `dyspozycje_sources.py` (funkcja `load_magazyn_choices`) dodano rozpoznawanie klucza `lista` jako dodatkowego źródła rekordów (obok `items`, `pozycje`, `magazyn`, `produkty`, `stany`, `rows`, `data`).

### Testing
- Uruchomiono `pytest`; zmiana nie powoduje nowych błędów, jednak testy zwróciły 5 istniejących niepowodzeń w testach GUI/logowania i logiki zleceń (`test_gui_logowanie.py` oraz `test_logika_zlecenia_i_maszyny.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddb37955483238067c06701f56ddf)