### PR TITLE
Uprość rozwiązywanie ścieżek i usuń fallbacky do `data/` w dyspozycje_sources

### DIFF
--- a/dyspozycje_sources.py
+++ b/dyspozycje_sources.py
@@ -104,17 +104,19 @@ def _root_path(*parts: str) -> str:
                 return result
         except Exception:
             pass
-        try:
-            path_root = getattr(mgr, "path_root", None)
-            if callable(path_root):
-                result = path_root(*parts)
-                try:
-                    print(f"[WM-DBG][DYSP][SRC] path_root{parts} -> {result}")
-                except Exception:
-                    pass
-                return result
-        except Exception:
-            pass
+    try:
+        cfg = _cfg()
+        paths = cfg.get("paths") or {}
+        anchor = str(paths.get("anchor_root") or "").strip()
+        if anchor:
+            result = os.path.join(anchor, *parts)
+            try:
+                print(f"[WM-DBG][DYSP][SRC] cfg_anchor{parts} -> {result}")
+            except Exception:
+                pass
+            return result
+    except Exception:
+        pass
     return os.path.join(os.getcwd(), *parts)
 
 
@@ -155,10 +157,7 @@ def _root_json_path(folder: str, filename: str) -> str:
 # NARZĘDZIA
 # =========================================================
 def load_tool_choices() -> List[Tuple[str, str]]:
-    tools_dir = _first_existing_path(
-        _root_path("narzedzia"),
-        _data_path("narzedzia"),
-    ) or _root_path("narzedzia")
+    tools_dir = _root_path("narzedzia")
     try:
         print(f"[WM-DBG][DYSP][SRC] tools_dir_selected={tools_dir}")
     except Exception:
@@ -227,7 +226,6 @@ def load_machine_choices() -> List[Tuple[str, str]]:
     path = _first_existing_path(
         _root_json_path("maszyny", "maszyny.json"),
         machine_path,
-        _data_path("maszyny", "maszyny.json"),
     )
     try:
         print(
@@ -304,7 +302,6 @@ def load_magazyn_choices() -> List[Tuple[str, str]]:
     candidates = [
         _root_path("magazyn", "magazyn.json"),
         _root_path("magazyn", "katalog.json"),
-        _data_path("magazyn", "katalog.json"),
     ]
     try:
         print(f"[WM-DBG][DYSP][SRC] magazyn_candidates={candidates}")
@@ -415,8 +412,6 @@ def load_zlecenie_wykonania_choices() -> List[Tuple[str, str]]:
     candidates = [
         ("produkt", _root_path("produkty")),
         ("polprodukt", _root_path("polprodukty")),
-        ("produkt", _data_path("produkty")),
-        ("polprodukt", _data_path("polprodukty")),
     ]
 
     for prefix, folder in candidates:
@@ -440,7 +435,6 @@ def load_zlecenie_wykonania_choices() -> List[Tuple[str, str]]:
     # katalog magazynowy jako "elementy / pozycje magazynowe"
     katalog_candidates = [
         _root_path("magazyn", "katalog.json"),
-        _data_path("magazyn", "katalog.json"),
     ]
     katalog = {}
     try:


### PR DESCRIPTION
### Motivation
- Uprościć logikę wyboru ścieżek źródłowych, aby preferować centralną konfigurację (anchor) zamiast wielu fallbacków. 
- Zmniejszyć złożoność i niejednoznaczność przy ładowaniu zasobów (narzędzia, maszyny, magazyn, zlecenia) przez usunięcie rozproszonego fallbacku do katalogu `data/`.

### Description
- Zmieniono `_root_path` tak, aby po sprawdzeniu `path_anchor` z menedżera uruchomieniowego sięgał do `paths.anchor_root` z globalnej konfiguracji (`_cfg()`), zamiast wywoływać `mgr.path_root` jako fallback. 
- Usunięto fallbacky do `_data_path(...)` i uproszczono wybór katalogów/plików na rzecz bezpośredniego użycia `_root_path(...)` w funkcjach `load_tool_choices`, `load_machine_choices`, `load_magazyn_choices` oraz `load_zlecenie_wykonania_choices` w pliku `dyspozycje_sources.py`.
- Zaktualizowano powiadomienia debugowe aby odzwierciedlały nowe źródło (`cfg_anchor`).

### Testing
- Uruchomiono `pytest`; testy zostały zebrane (269 przypadków) i wykonały się automatycznie. 
- Wynik: 222 testy przeszły, 46 zostało pominiętych, 5 testów nie powiodło się, więc test suite nie przeszedł końcowo. 
- Niepowodzenia pojawiły się w: `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive` (parametryzowane warianty) , `test_gui_logowanie.py::test_logowanie_callback_error` oraz `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edde5e5d80832384ede6338747e218)