### PR TITLE
Dodaj listę docelowych ścieżek root w oknie „Wybór folderu WM”

### DIFF
--- a/backend/bootstrap_root.py
+++ b/backend/bootstrap_root.py
@@ -81,6 +81,31 @@ _DEFAULT_BOM = {
 log = logging.getLogger(__name__)
 
 
+def describe_root_targets(cfg: dict) -> list[tuple[str, str, str]]:
+    """Return human-readable root targets checked/created during bootstrap.
+
+    Tuple format:
+    - label
+    - path
+    - kind: "file" or "dir"
+    """
+
+    tools_defs_path = resolve_rel(cfg, "tools_defs")
+    targets = [
+        ("profile użytkowników", resolve_rel(cfg, "profiles"), "file"),
+        ("maszyny", get_machines_path(cfg), "file"),
+        ("magazyn", resolve_rel(cfg, "warehouse"), "file"),
+        ("produkty/BOM", resolve_rel(cfg, "bom"), "file"),
+        ("narzędzia", resolve_rel(cfg, "tools_dir"), "dir"),
+        ("zlecenia", resolve_rel(cfg, "orders_dir"), "dir"),
+    ]
+
+    if tools_defs_path:
+        targets.append(("definicje/zadania narzędzi", tools_defs_path, "file"))
+
+    return [(label, str(path or ""), kind) for label, path, kind in targets if path]
+
+
 def _ensure_all(cfg: dict) -> None:
     """Create minimal directory / file structure for root storage."""
 
@@ -137,4 +162,3 @@ def ensure_root_ready(config_path: str = "config.json") -> bool:
     _ensure_all(cfg)
     _migrate_legacy(cfg)
     return True
-

--- a/start.py
+++ b/start.py
@@ -792,7 +792,10 @@ def main():
     try:
         _info("ConfigManager: OK")
         try:
-            from backend.bootstrap_root import ensure_root_ready
+            from backend.bootstrap_root import (
+                describe_root_targets,
+                ensure_root_ready,
+            )
             from tkinter import messagebox
 
             manager = _ensure_config_manager()
@@ -805,6 +808,13 @@ def main():
             except Exception:
                 anchor = ""
                 data_root = ""
+
+            root_targets = []
+            try:
+                if manager is not None:
+                    root_targets = describe_root_targets(manager.load())
+            except Exception:
+                root_targets = []
 
             info_lines = [
                 "WM może zapytać teraz o folder roboczy programu.",
@@ -836,6 +846,20 @@ def main():
                         f"Obecny data_root: {data_root or '-'}",
                     ]
                 )
+
+            if root_targets:
+                info_lines.extend(
+                    [
+                        "",
+                        "WM będzie sprawdzał / tworzył:",
+                    ]
+                )
+                for label, target_path, kind in root_targets:
+                    typ = "plik" if kind == "file" else "folder"
+                    exists = os.path.exists(target_path)
+                    state = "OK" if exists else "BRAK"
+                    info_lines.append(f"- {label} ({typ}) [{state}]:")
+                    info_lines.append(f"  {target_path}")
 
             try:
                 messagebox.showinfo(


### PR DESCRIPTION
### Motivation
- Pokazać w oknie startowym dokładnie, jakie pliki i foldery WM będzie sprawdzał/tworzył w `root` bez zmiany istniejącej logiki tworzenia/migracji danych.

### Description
- Dodano funkcję `describe_root_targets(cfg)` w `backend/bootstrap_root.py`, która zwraca listę krotek `(label, path, kind)` opisujących cele root (plik/folder).
- Zaktualizowano importy w `start.py` oraz pobieranie `root_targets` z konfiguracji przez `describe_root_targets(manager.load())`.
- Rozszerzono komunikat „Wybór folderu WM” w `start.py` o sekcję "WM będzie sprawdzał / tworzył:", w której dla każdego celu wyświetlany jest typ (`plik`/`folder`), status `[OK]`/`BRAK` na podstawie `os.path.exists` oraz pełna ścieżka.
- Nie zmieniono logiki `ConfigManager`, migracji ani struktury danych — zmiana dotyczy wyłącznie diagnostyki ścieżek w komunikacie.

### Testing
- Uruchomiono `pytest -q`; wynik: `5 failed, 222 passed, 46 skipped`, porażki istnieją i dotyczą głównie testów GUI/Tkinter oraz jednej sprawy logiki zleceń, niepowiązane bezpośrednio z wprowadzoną diagnostyką ścieżek.
- Uruchomiono `python start.py` w środowisku CI/headless; start uruchomił logikę startową, ale GUI nie mogło się otworzyć z powodu braku `$DISPLAY` (TclError), co jest oczekiwane w tym środowisku i nie wynika z wprowadzonych zmian.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede283d9fc8323b51c662fe2335430)