### PR TITLE
Dodaj krokowe podpinanie brakujących plików root w bootstrapie

### DIFF
--- a/backend/bootstrap_root.py
+++ b/backend/bootstrap_root.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 
 from config_manager import (
     ConfigManager,
@@ -81,6 +82,75 @@ _DEFAULT_BOM = {
 log = logging.getLogger(__name__)
 
 
+def _ask_user_for_missing_file(label: str, expected_path: str) -> bool:
+    """Ask user to point missing JSON file and copy it to expected path.
+
+    Returns True only when user selected a file and it was copied.
+    Returns False on cancel/error so existing bootstrap defaults still work.
+    """
+
+    if not expected_path:
+        return False
+    if os.path.exists(expected_path):
+        return False
+
+    filename = os.path.basename(expected_path)
+    try:
+        from tkinter import filedialog, messagebox
+    except Exception:
+        return False
+
+    try:
+        messagebox.showinfo(
+            "Brakuje pliku danych WM",
+            "Brakuje wymaganego pliku danych WM.\n\n"
+            f"Element: {label}\n"
+            f"Brakujący plik: {filename}\n\n"
+            "WM szuka tutaj:\n"
+            f"{expected_path}\n\n"
+            "Wskaż właściwy plik JSON.\n"
+            "Jeżeli anulujesz, WM utworzy domyślny plik.",
+        )
+        selected = filedialog.askopenfilename(
+            title=f"Wskaż plik: {filename}",
+            filetypes=[
+                ("Pliki JSON", "*.json"),
+                ("Wszystkie pliki", "*.*"),
+            ],
+        )
+        if not selected:
+            return False
+
+        os.makedirs(os.path.dirname(expected_path) or ".", exist_ok=True)
+        shutil.copy2(selected, expected_path)
+        messagebox.showinfo(
+            "Plik podpięty",
+            "Skopiowano wskazany plik do lokalizacji WM.\n\n"
+            f"Źródło:\n{selected}\n\n"
+            f"Cel:\n{expected_path}",
+        )
+        return True
+    except Exception as exc:
+        try:
+            messagebox.showwarning(
+                "Nie udało się podpiąć pliku",
+                "WM nie mógł skopiować wskazanego pliku.\n\n"
+                f"Element: {label}\n"
+                f"Cel:\n{expected_path}\n\n"
+                f"Szczegóły: {exc}\n\n"
+                "Program spróbuje utworzyć domyślny plik.",
+            )
+        except Exception:
+            pass
+        log.warning(
+            "[ROOT] Nie udało się podpiąć pliku %s (%s): %s",
+            label,
+            expected_path,
+            exc,
+        )
+        return False
+
+
 def describe_root_targets(cfg: dict) -> list[tuple[str, str, str]]:
     """Return human-readable root targets checked/created during bootstrap.
 
@@ -109,14 +179,31 @@ def describe_root_targets(cfg: dict) -> list[tuple[str, str, str]]:
 def _ensure_all(cfg: dict) -> None:
     """Create minimal directory / file structure for root storage."""
 
-    ensure_dir_json(resolve_rel(cfg, "profiles"), _DEFAULT_PROFILES)
-    ensure_dir_json(get_machines_path(cfg), _DEFAULT_MACHINES)
-    ensure_dir_json(resolve_rel(cfg, "warehouse"), _DEFAULT_WAREHOUSE)
-    ensure_dir_json(resolve_rel(cfg, "bom"), _DEFAULT_BOM)
+    profiles_path = resolve_rel(cfg, "profiles")
+    if not _ask_user_for_missing_file("profile użytkowników", profiles_path):
+        ensure_dir_json(profiles_path, _DEFAULT_PROFILES)
+
+    machines_path = get_machines_path(cfg)
+    if not _ask_user_for_missing_file("maszyny", machines_path):
+        ensure_dir_json(machines_path, _DEFAULT_MACHINES)
+
+    warehouse_path = resolve_rel(cfg, "warehouse")
+    if not _ask_user_for_missing_file("magazyn", warehouse_path):
+        ensure_dir_json(warehouse_path, _DEFAULT_WAREHOUSE)
+
+    bom_path = resolve_rel(cfg, "bom")
+    if not _ask_user_for_missing_file("produkty/BOM", bom_path):
+        ensure_dir_json(bom_path, _DEFAULT_BOM)
+
     os.makedirs(resolve_rel(cfg, "tools_dir"), exist_ok=True)
     os.makedirs(resolve_rel(cfg, "orders_dir"), exist_ok=True)
     tools_defs_path = resolve_rel(cfg, "tools_defs")
     if tools_defs_path:
+        if os.path.splitext(tools_defs_path)[1].lower() == ".json":
+            _ask_user_for_missing_file(
+                "definicje/zadania narzędzi",
+                tools_defs_path,
+            )
         os.makedirs(os.path.dirname(tools_defs_path), exist_ok=True)
 
 


### PR DESCRIPTION
### Motivation

- Przy starcie WM trzeba informować użytkownika dokładnie, którego pliku danych brakuje i gdzie go szukać, oraz umożliwić wskazanie właściwego pliku krok po kroku zamiast jednego ogólnego okna. 
- Po wskazaniu pliku WM powinien go skopiować do oczekiwanej lokalizacji i kontynuować sprawdzanie kolejnych brakujących plików. 
- Zachowano istniejące fallbacky: gdy użytkownik anuluje lub GUI jest niedostępne, program tworzy domyślne pliki jak dotychczas; zmieniono tylko `backend/bootstrap_root.py`.

### Description

- Dodano `import shutil` oraz funkcję pomocniczą ` _ask_user_for_missing_file(label, expected_path)` która lokalnie próbuje zaimportować `tkinter.filedialog` i `tkinter.messagebox`, pyta użytkownika o brakujący plik, kopiuje go przy pomocy `shutil.copy2` i zwraca `True` gdy plik został podpięty, lub `False` przy anulowaniu/błędzie. 
- W ` _ask_user_for_missing_file` wyświetlane są jasne komunikaty z nazwą elementu, nazwą pliku i pełną oczekiwaną ścieżką, oraz zastosowany jest filtr plików JSON (`("Pliki JSON", "*.json")`).
- Zmieniono ` _ensure_all(cfg)` tak, by przed każdym wywołaniem `ensure_dir_json` dla następujących plików wywołać ` _ask_user_for_missing_file`: `profiles` (profile użytkowników), `maszyny` (machines), `warehouse` (magazyn) i `bom` (produkty/BOM), i pominąć `ensure_dir_json` tylko gdy użytkownik wskazał i skopiowano plik. 
- Dla `tools_defs_path` dodano minimalne sprawdzenie: gdy ścieżka wygląda na plik `.json` uruchamiane jest pytanie o ten plik, a w przypadku anulowania zachowane jest dotychczasowe tworzenie katalogu docelowego.

### Testing

- Uruchomiono testy automatyczne poleceniem `pytest -q` po wprowadzeniu zmian. 
- Wynik testów: `5 failed, 222 passed, 46 skipped`. 
- Nie zidentyfikowano regresji w zmienionym module; zgłoszone niepowiązane błędy to testy GUI/Tkinter wymagające `$DISPLAY` oraz inne istniejące asercje środowiskowe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede40e356c8323b59906ade66adb14)