### PR TITLE
Dodaj tryb gościa (readonly) — przycisk „Wejdź jako gość” i ograniczenia w panelu

### DIFF
--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -617,6 +617,12 @@ def ekran_logowania(root=None, on_login=None, update_available=False):
     entry_pin.pack(ipadx=10, ipady=6)
     _focus_pin()
     ttk.Button(box, text="Zaloguj", command=logowanie, style="WM.Side.TButton").pack(pady=16)
+    ttk.Button(
+        box,
+        text="Wejdź jako gość",
+        command=_login_guest,
+        style="WM.Side.TButton",
+    ).pack(pady=(0, 8))
     entry_pin.bind("<Return>", lambda e: logowanie())
     if cfg.get("auth.pinless_brygadzista", False):
         ttk.Button(
@@ -950,6 +956,37 @@ def _login_pinless():
         error_dialogs.show_error_dialog("Błąd", "Nie znaleziono brygadzisty")
     except Exception as e:
         error_dialogs.show_error_dialog("Błąd", f"Błąd podczas logowania: {e}")
+
+
+def _login_guest():
+    """Uruchom WM w trybie gościa (readonly, bez uwierzytelniania)."""
+
+    try:
+        logger.info("[WM-SEC] Uruchomiono tryb gościa readonly")
+        extra = {
+            "guest": True,
+            "readonly": True,
+            "login": "__guest__",
+            "rola": "gosc",
+        }
+        if _on_login_cb:
+            try:
+                _on_login_cb(root_global, "__guest__", "gosc", extra)
+                return
+            except TypeError:
+                try:
+                    _on_login_cb("__guest__", "gosc", extra)
+                    return
+                except TypeError:
+                    _on_login_cb("__guest__", "gosc")
+                    return
+        gui_panel.uruchom_panel(root_global, "__guest__", "gosc")
+    except Exception as exc:
+        logger.exception("[WM-ERR][LOGIN] Tryb gościa nie uruchomił się")
+        messagebox.showerror(
+            "Tryb gościa",
+            f"Nie udało się uruchomić trybu gościa.\n\n{exc}",
+        )
 
 
 def logowanie():

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -581,11 +581,18 @@ def panel_chat(root, frame, login=None, rola=None):
 # ---------- Główny panel ----------
 
 def uruchom_panel(root, login, rola):
+    is_guest = (
+        str(login or "").strip() == "__guest__"
+        or str(rola or "").strip().lower() in {"gosc", "gość", "guest"}
+    )
     if not ensure_theme_applied(root):
         apply_theme(root)
-    root.title(
-        f"Warsztat Menager v{APP_VERSION} - zalogowano jako {login} ({rola})"
-    )
+    if is_guest:
+        root.title(f"Warsztat Menager v{APP_VERSION} - tryb gościa / podgląd")
+    else:
+        root.title(
+            f"Warsztat Menager v{APP_VERSION} - zalogowano jako {login} ({rola})"
+        )
     clear_frame(root)
     if _register_notification_root is not None:
         try:
@@ -594,11 +601,17 @@ def uruchom_panel(root, login, rola):
             pass
     setattr(root, "current_shift", _current_shift_label(datetime.now()))
 
-    last_visit = _load_last_visit(login)
-    profile = get_user(login) or {}
+    if is_guest:
+        last_visit = datetime.now(timezone.utc)
+        profile = {}
+    else:
+        last_visit = _load_last_visit(login)
+        profile = get_user(login) or {}
     modules_disabled = set()
     if isinstance(profile, dict):
         modules_disabled = set(profile.get("modules_disabled", []))
+    if is_guest:
+        modules_disabled.update({"uzytkownicy", "ustawienia", "jarvis", "chat"})
     disabled_modules: set[str] = set()
     markers: list[tk.Widget] = []
     def _clear_markers() -> None:
@@ -610,7 +623,8 @@ def uruchom_panel(root, login, rola):
                 pass
         markers.clear()
         last_visit = datetime.now(timezone.utc)
-        _save_last_visit(login, last_visit)
+        if not is_guest:
+            _save_last_visit(login, last_visit)
 
     def _maybe_mark_button(widget: tk.Widget) -> None:
         lm = getattr(widget, "last_modified", None)
@@ -635,7 +649,8 @@ def uruchom_panel(root, login, rola):
     header  = ttk.Frame(main, style="WM.TFrame");      header.pack(fill="x", padx=12, pady=(10,6))
     ttk.Label(header, text="Panel główny", style="WM.H1.TLabel").pack(side="left")
     # NOWE: czytelny login/rola po prawej stronie nagłówka
-    ttk.Label(header, text=f"{login} ({rola})", style="WM.Muted.TLabel").pack(side="right")
+    header_user_text = "GOŚĆ (podgląd)" if is_guest else f"{login} ({rola})"
+    ttk.Label(header, text=header_user_text, style="WM.Muted.TLabel").pack(side="right")
 
     current_action_var = tk.StringVar(master=root, value="Aktualnie: —")
     current_action_label = ttk.Label(
@@ -649,6 +664,8 @@ def uruchom_panel(root, login, rola):
     setattr(root, "active_login", login)
     setattr(root, "current_user", login)
     setattr(root, "username", login)
+    setattr(root, "_wm_guest", is_guest)
+    setattr(root, "_wm_readonly", is_guest)
 
     footer  = ttk.Frame(main, style="WM.TFrame");      footer.pack(fill="x", padx=12, pady=(6,10))
     footer_btns = ttk.Frame(footer, style="WM.TFrame"); footer_btns.pack(side="right")
@@ -832,6 +849,21 @@ def uruchom_panel(root, login, rola):
         clear_frame(content)
 
     def otworz_panel(funkcja, nazwa):
+        if is_guest:
+            blocked_guest_modules = {
+                "Użytkownicy",
+                "Ustawienia",
+                "Jarvis",
+                "Chat",
+                "Profil",
+            }
+            if str(nazwa) in blocked_guest_modules:
+                messagebox.showinfo(
+                    "Tryb gościa",
+                    "Tryb gościa jest tylko do podglądu.\n"
+                    "Ten moduł wymaga zalogowania.",
+                )
+                return
         flow = None
         if funkcja is panel_narzedzia:
             flow = PerfFlow("TOOLS_OPEN")
@@ -1009,7 +1041,7 @@ def uruchom_panel(root, login, rola):
     start_panel = None
     start_name = ""
     admin_roles = ADMIN_ROLE_NAMES | {"kierownik", "brygadzista", "lider"}
-    is_admin = str(rola).strip().lower() in admin_roles
+    is_admin = (not is_guest) and str(rola).strip().lower() in admin_roles
 
     def _format_modules(modules) -> str:
         items = list(modules)
@@ -1035,10 +1067,12 @@ def uruchom_panel(root, login, rola):
     def _build_sidebar(initial: bool = False) -> None:
         nonlocal profile, disabled_modules, start_panel, start_name, modules_disabled
         clear_frame(side)
-        profile = get_user(login) or {}
+        profile = {} if is_guest else (get_user(login) or {})
         modules_disabled = set()
         if isinstance(profile, dict):
             modules_disabled = set(profile.get("modules_disabled", []))
+        if is_guest:
+            modules_disabled.update({"uzytkownicy", "ustawienia", "jarvis", "chat"})
 
         try:
             manifest = zaladuj_manifest(CONFIG_MANAGER)


### PR DESCRIPTION
### Motivation
- Dodać możliwość uruchomienia programu w trybie podglądu bez logowania, aby szybciej ocenić UI/flow bez uprawnień i zapisu zmian.

### Description
- W `gui_logowanie.py` dodano funkcję `_login_guest()` która ustawia `extra = {"guest": True, "readonly": True, "login": "__guest__", "rola": "gosc"}`, loguje `[WM-SEC] Uruchomiono tryb gościa readonly` i wywołuje callback logowania lub `gui_panel.uruchom_panel` bez uwierzytelniania i bez zapisu ostatniego użytkownika.
- Na ekranie logowania w `gui_logowanie.py` dodano przycisk `Wejdź jako gość` pod przyciskiem `Zaloguj` wywołujący `_login_guest`.
- W `gui_panel.py` w `uruchom_panel(root, login, rola)` dodano detekcję trybu gościa (`is_guest`) oraz dla gościa: zmieniony tytuł okna, nagłówek `GOŚĆ (podgląd)`, brak pobierania profilu (`profile = {}`), brak odczytu/zapisu `last_visit`, ustawienie atrybutów `root._wm_guest` i `root._wm_readonly`, oraz rozszerzenie `modules_disabled` o moduły edycyjne/administracyjne (co najmniej `uzytkownicy`, `ustawienia`, `jarvis`, `chat`).
- W `gui_panel.py` dodano blokadę w `otworz_panel(funkcja, nazwa)` eliminującą otwieranie wybranych modułów dla gościa i wyświetlającą komunikat `Tryb gościa jest tylko do podglądu. Ten moduł wymaga zalogowania.`, oraz zapewniono, że gość nie jest traktowany jako admin.

### Testing
- Uruchomiono `pytest` w repozytorium i zebrano 269 testów (222 zaliczonych, 5 niezaliczonych, 46 pominiętych). 
- Niepowodzenia testów to głównie problemy środowiskowe/niezwiązane z funkcją gościa: trzy porażki w `test_gui_logowanie.py` wynikające z braku displayu/Tkinter (wywołanie `messagebox` bez $DISPLAY) oraz jeden test `test_logowanie_callback_error` ujawniający różnicę w obsłudze błędu callbacku, a także jeden niezależny `KeyError` w `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja` z powodu brakującego pola `status` w danych testowych; te awarie nie są bezpośrednio spowodowane przez dodanie trybu gościa.
- Polecenie użyte do uruchomienia testów: `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edebf065ac8323801de2a8a9612899)