### PR TITLE
Revert PR #29 (guest/read-only login) — safe revert of merge commit

### DIFF
--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -617,12 +617,6 @@ def ekran_logowania(root=None, on_login=None, update_available=False):
     entry_pin.pack(ipadx=10, ipady=6)
     _focus_pin()
     ttk.Button(box, text="Zaloguj", command=logowanie, style="WM.Side.TButton").pack(pady=16)
-    ttk.Button(
-        box,
-        text="Wejdź jako gość",
-        command=_login_guest,
-        style="WM.Side.TButton",
-    ).pack(pady=(0, 8))
     entry_pin.bind("<Return>", lambda e: logowanie())
     if cfg.get("auth.pinless_brygadzista", False):
         ttk.Button(
@@ -956,37 +950,6 @@ def _login_pinless():
         error_dialogs.show_error_dialog("Błąd", "Nie znaleziono brygadzisty")
     except Exception as e:
         error_dialogs.show_error_dialog("Błąd", f"Błąd podczas logowania: {e}")
-
-
-def _login_guest():
-    """Uruchom WM w trybie gościa (readonly, bez uwierzytelniania)."""
-
-    try:
-        logger.info("[WM-SEC] Uruchomiono tryb gościa readonly")
-        extra = {
-            "guest": True,
-            "readonly": True,
-            "login": "__guest__",
-            "rola": "gosc",
-        }
-        if _on_login_cb:
-            try:
-                _on_login_cb(root_global, "__guest__", "gosc", extra)
-                return
-            except TypeError:
-                try:
-                    _on_login_cb("__guest__", "gosc", extra)
-                    return
-                except TypeError:
-                    _on_login_cb("__guest__", "gosc")
-                    return
-        gui_panel.uruchom_panel(root_global, "__guest__", "gosc")
-    except Exception as exc:
-        logger.exception("[WM-ERR][LOGIN] Tryb gościa nie uruchomił się")
-        messagebox.showerror(
-            "Tryb gościa",
-            f"Nie udało się uruchomić trybu gościa.\n\n{exc}",
-        )
 
 
 def logowanie():

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -581,18 +581,11 @@ def panel_chat(root, frame, login=None, rola=None):
 # ---------- Główny panel ----------
 
 def uruchom_panel(root, login, rola):
-    is_guest = (
-        str(login or "").strip() == "__guest__"
-        or str(rola or "").strip().lower() in {"gosc", "gość", "guest"}
-    )
     if not ensure_theme_applied(root):
         apply_theme(root)
-    if is_guest:
-        root.title(f"Warsztat Menager v{APP_VERSION} - tryb gościa / podgląd")
-    else:
-        root.title(
-            f"Warsztat Menager v{APP_VERSION} - zalogowano jako {login} ({rola})"
-        )
+    root.title(
+        f"Warsztat Menager v{APP_VERSION} - zalogowano jako {login} ({rola})"
+    )
     clear_frame(root)
     if _register_notification_root is not None:
         try:
@@ -601,17 +594,11 @@ def uruchom_panel(root, login, rola):
             pass
     setattr(root, "current_shift", _current_shift_label(datetime.now()))
 
-    if is_guest:
-        last_visit = datetime.now(timezone.utc)
-        profile = {}
-    else:
-        last_visit = _load_last_visit(login)
-        profile = get_user(login) or {}
+    last_visit = _load_last_visit(login)
+    profile = get_user(login) or {}
     modules_disabled = set()
     if isinstance(profile, dict):
         modules_disabled = set(profile.get("modules_disabled", []))
-    if is_guest:
-        modules_disabled.update({"uzytkownicy", "ustawienia", "jarvis", "chat"})
     disabled_modules: set[str] = set()
     markers: list[tk.Widget] = []
     def _clear_markers() -> None:
@@ -623,8 +610,7 @@ def uruchom_panel(root, login, rola):
                 pass
         markers.clear()
         last_visit = datetime.now(timezone.utc)
-        if not is_guest:
-            _save_last_visit(login, last_visit)
+        _save_last_visit(login, last_visit)
 
     def _maybe_mark_button(widget: tk.Widget) -> None:
         lm = getattr(widget, "last_modified", None)
@@ -649,8 +635,7 @@ def uruchom_panel(root, login, rola):
     header  = ttk.Frame(main, style="WM.TFrame");      header.pack(fill="x", padx=12, pady=(10,6))
     ttk.Label(header, text="Panel główny", style="WM.H1.TLabel").pack(side="left")
     # NOWE: czytelny login/rola po prawej stronie nagłówka
-    header_user_text = "GOŚĆ (podgląd)" if is_guest else f"{login} ({rola})"
-    ttk.Label(header, text=header_user_text, style="WM.Muted.TLabel").pack(side="right")
+    ttk.Label(header, text=f"{login} ({rola})", style="WM.Muted.TLabel").pack(side="right")
 
     current_action_var = tk.StringVar(master=root, value="Aktualnie: —")
     current_action_label = ttk.Label(
@@ -664,8 +649,6 @@ def uruchom_panel(root, login, rola):
     setattr(root, "active_login", login)
     setattr(root, "current_user", login)
     setattr(root, "username", login)
-    setattr(root, "_wm_guest", is_guest)
-    setattr(root, "_wm_readonly", is_guest)
 
     footer  = ttk.Frame(main, style="WM.TFrame");      footer.pack(fill="x", padx=12, pady=(6,10))
     footer_btns = ttk.Frame(footer, style="WM.TFrame"); footer_btns.pack(side="right")
@@ -849,21 +832,6 @@ def uruchom_panel(root, login, rola):
         clear_frame(content)
 
     def otworz_panel(funkcja, nazwa):
-        if is_guest:
-            blocked_guest_modules = {
-                "Użytkownicy",
-                "Ustawienia",
-                "Jarvis",
-                "Chat",
-                "Profil",
-            }
-            if str(nazwa) in blocked_guest_modules:
-                messagebox.showinfo(
-                    "Tryb gościa",
-                    "Tryb gościa jest tylko do podglądu.\n"
-                    "Ten moduł wymaga zalogowania.",
-                )
-                return
         flow = None
         if funkcja is panel_narzedzia:
             flow = PerfFlow("TOOLS_OPEN")
@@ -1041,7 +1009,7 @@ def uruchom_panel(root, login, rola):
     start_panel = None
     start_name = ""
     admin_roles = ADMIN_ROLE_NAMES | {"kierownik", "brygadzista", "lider"}
-    is_admin = (not is_guest) and str(rola).strip().lower() in admin_roles
+    is_admin = str(rola).strip().lower() in admin_roles
 
     def _format_modules(modules) -> str:
         items = list(modules)
@@ -1067,12 +1035,10 @@ def uruchom_panel(root, login, rola):
     def _build_sidebar(initial: bool = False) -> None:
         nonlocal profile, disabled_modules, start_panel, start_name, modules_disabled
         clear_frame(side)
-        profile = {} if is_guest else (get_user(login) or {})
+        profile = get_user(login) or {}
         modules_disabled = set()
         if isinstance(profile, dict):
             modules_disabled = set(profile.get("modules_disabled", []))
-        if is_guest:
-            modules_disabled.update({"uzytkownicy", "ustawienia", "jarvis", "chat"})
 
         try:
             manifest = zaladuj_manifest(CONFIG_MANAGER)


### PR DESCRIPTION
### Motivation
- Undo the guest/read-only login changes introduced by the merge commit to remove the temporary guest mode while preserving repository history. 

### Description
- Reverted merge commit `d90036f6c25b6e9e73ec39327c280374da52f84a` with `git revert -m 1`, producing new revert commit `f83c0ec7a7fad7bc6d480999d0a32f7c8fff6ac7`. 
- Removed the guest login button and `_login_guest()` implementation from `gui_logowanie.py`. 
- Removed guest/read-only flag handling, guest-specific title/markers and guest module blocks from `gui_panel.py`. 
- Created backup branch `backup-przed-cofnieciem-pr29`; push to remote `Rozwiniecie` was not possible in this environment due to missing local branch/remote. 

### Testing
- Ran the revert command `git revert -m 1 d90036f6c25b6e9e73ec39327c280374da52f84a` which completed successfully and produced commit `f83c0ec7a7fa`. 
- Ran `pytest` which completed with `5 failed, 222 passed, 46 skipped` and failing tests in `test_gui_logowanie.py` (tkinter/default root errors and a callback assertion) and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja` (KeyError on 'status'). 
- Ran `git status` which shows the revert commit recorded but also unstaged and untracked changes in `data/...` and `narzedzia...`. 
- Attempted `git push origin Rozwiniecie` which failed because the environment lacked a local `Rozwiniecie` branch and/or a configured `origin` remote so pushing must be done from a properly configured clone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edeee958a883238edcfb2b3f7c1e51)