### PR TITLE
Add centralized WM root resolver and integrate it into startup and path helpers

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from core.path_utils import get_app_root as _resolve_app_root
+try:
+    from core import root_paths as _root_paths
+except Exception:  # pragma: no cover - fallback na starszy start
+    _root_paths = None
 
 
 def get_app_root() -> Path:
@@ -14,6 +18,8 @@ def get_app_root() -> Path:
     Logika jest scentralizowana w core.path_utils.get_app_root().
     """
 
+    if _root_paths is not None:
+        return _root_paths.get_app_root()
     return _resolve_app_root()
 
 
@@ -23,6 +29,8 @@ def get_data_root(cfg: Optional[Dict[str, Any]]) -> Path:
     env_root = os.getenv("WM_DATA_ROOT")
     if env_root:
         return Path(env_root)
+    if _root_paths is not None:
+        return _root_paths.get_data_root()
 
     cfg = cfg or {}
     paths = cfg.get("paths") or {}
@@ -68,7 +76,10 @@ _SETTINGS_STATE: Optional[Dict[str, Any]] = None
 _SETTINGS_GETTER: Optional[Callable[[str], Any]] = None
 
 _DEFAULT_BASE_DIR = get_app_root()
-_DEFAULT_ANCHOR = os.path.normpath(str(_DEFAULT_BASE_DIR))
+if _root_paths is not None:
+    _DEFAULT_ANCHOR = os.path.normpath(str(_root_paths.get_root_anchor()))
+else:
+    _DEFAULT_ANCHOR = os.path.normpath(str(_DEFAULT_BASE_DIR))
 
 
 def _is_abs(path: str) -> bool:
@@ -93,6 +104,8 @@ def _raw_anchor_value() -> str:
         if os.path.basename(norm_candidate).lower() == "data":
             return os.path.dirname(norm_candidate)
         return norm_candidate
+    if _root_paths is not None:
+        return str(_root_paths.get_root_anchor())
     return _DEFAULT_ANCHOR
 
 
@@ -127,6 +140,8 @@ def _data_root() -> str:
     data_raw = _read("paths.data_root")
     if isinstance(data_raw, str) and data_raw.strip():
         return _expand_path(data_raw.strip())
+    if _root_paths is not None:
+        return str(_root_paths.get_data_root())
     return os.path.join(_anchor_root(), "data")
 
 def bind_settings(state: Dict[str, Any]) -> None:

--- a/core/root_paths.py
+++ b/core/root_paths.py
@@ -1,0 +1,270 @@
+# version: 1.0
+"""Centralny resolver ROOT dla Warsztat Menager.
+
+APP_ROOT = folder programu / repozytorium / Git
+WM_ROOT  = folder danych wybrany przez użytkownika
+DATA_ROOT = WM_ROOT / "data"
+
+Ten moduł nie dotyka mechanizmu aktualizacji Git.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT_FILE_NAME = "wm_root.json"
+DEFAULT_ROOT_NAME = "wm"
+
+
+def _norm(path: Path | str) -> Path:
+    p = path if isinstance(path, Path) else Path(str(path))
+    try:
+        return p.expanduser().resolve()
+    except Exception:
+        return p.expanduser()
+
+
+def get_app_root() -> Path:
+    """Zwraca folder programu/repozytorium, a nie folder danych."""
+
+    if getattr(sys, "frozen", False):
+        return _norm(Path(sys.executable).parent)
+    return _norm(Path(__file__).resolve().parents[1])
+
+
+def root_file_path(app_root: Path | None = None) -> Path:
+    return _norm((app_root or get_app_root()) / ROOT_FILE_NAME)
+
+
+def _read_root_file(path: Path) -> Path | None:
+    try:
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if isinstance(payload, dict):
+            raw = str(payload.get("root") or "").strip()
+        else:
+            raw = ""
+        if not raw:
+            return None
+        return _norm(Path(raw))
+    except Exception as exc:
+        print(f"[WM-ROOT][WARN] Nie można odczytać {path}: {exc}")
+        return None
+
+
+def _write_root_file(path: Path, wm_root: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump({"root": str(wm_root)}, handle, ensure_ascii=False, indent=2)
+
+
+def _default_wm_root() -> Path:
+    drive = Path.cwd().anchor or "C:\\"
+    try:
+        return _norm(Path(drive) / DEFAULT_ROOT_NAME)
+    except Exception:
+        return _norm(get_app_root() / DEFAULT_ROOT_NAME)
+
+
+def _ask_root_folder(initial: Path) -> Path | None:
+    try:
+        import tkinter as tk
+        from tkinter import filedialog, messagebox
+    except Exception:
+        return None
+
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        try:
+            messagebox.showinfo(
+                "Folder danych WM",
+                "Wskaż jeden główny folder danych Warsztat Menager.\n\n"
+                "Przykład:\n"
+                "C:\\wm\n\n"
+                "Nie wybieraj folderu programu ani samego folderu data.",
+                parent=root,
+            )
+        except Exception:
+            pass
+        selected = filedialog.askdirectory(
+            parent=root,
+            initialdir=str(initial),
+            title="Wskaż główny folder danych WM",
+        )
+        root.destroy()
+    except Exception as exc:
+        print(f"[WM-ROOT][WARN] Nie udało się pokazać wyboru ROOT: {exc}")
+        return None
+
+    if not selected:
+        return None
+    return _norm(Path(selected))
+
+
+def resolve_wm_root(*, prompt: bool = False) -> Path:
+    """Ustal WM_ROOT z ENV, wm_root.json albo wyboru użytkownika."""
+
+    app_root = get_app_root()
+
+    env_root = os.environ.get("WM_ROOT") or os.environ.get("WM_APP_ROOT")
+    if env_root:
+        wm_root = _norm(Path(env_root))
+        return wm_root
+
+    pointer = root_file_path(app_root)
+    from_file = _read_root_file(pointer)
+    if from_file is not None:
+        return from_file
+
+    initial = _default_wm_root()
+    selected = _ask_root_folder(initial) if prompt else None
+    wm_root = selected or initial
+    try:
+        _write_root_file(pointer, wm_root)
+        print(f"[WM-ROOT][BOOT] Zapisano ROOT_FILE: {pointer}")
+    except Exception as exc:
+        print(f"[WM-ROOT][WARN] Nie można zapisać ROOT_FILE {pointer}: {exc}")
+    return wm_root
+
+
+def get_root_anchor() -> Path:
+    return resolve_wm_root(prompt=False)
+
+
+def get_data_root() -> Path:
+    return get_root_anchor() / "data"
+
+
+def path_config() -> Path:
+    return get_root_anchor() / "config.json"
+
+
+def path_logs() -> Path:
+    return get_root_anchor() / "logs"
+
+
+def path_backup() -> Path:
+    return get_root_anchor() / "backup"
+
+
+def path_assets() -> Path:
+    return get_root_anchor() / "assets"
+
+
+def path_profiles() -> Path:
+    return get_data_root() / "profiles.json"
+
+
+def path_tools_dir() -> Path:
+    return get_data_root() / "narzedzia"
+
+
+def path_machines() -> Path:
+    return get_data_root() / "maszyny" / "maszyny.json"
+
+
+def path_warehouse() -> Path:
+    return get_data_root() / "magazyn" / "magazyn.json"
+
+
+def path_bom() -> Path:
+    return get_data_root() / "produkty" / "bom.json"
+
+
+def path_orders_dir() -> Path:
+    return get_data_root() / "zlecenia"
+
+
+def path_dyspozycje() -> Path:
+    return get_data_root() / "dyspozycje" / "dyspozycje.json"
+
+
+def ensure_root_tree() -> None:
+    """Tworzy strukturę katalogów wyłącznie pod WM_ROOT."""
+
+    dirs = [
+        get_root_anchor(),
+        get_data_root(),
+        path_logs(),
+        path_backup(),
+        path_assets(),
+        get_data_root() / "user",
+        path_tools_dir(),
+        get_data_root() / "maszyny",
+        get_data_root() / "magazyn",
+        get_data_root() / "produkty",
+        get_data_root() / "polprodukty",
+        path_orders_dir(),
+        get_data_root() / "dyspozycje",
+        get_data_root() / "layout",
+    ]
+    for directory in dirs:
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def install_environment(*, prompt: bool = False) -> dict[str, str]:
+    """Ustawia ENV dla reszty aplikacji i zwraca snapshot ścieżek."""
+
+    wm_root = resolve_wm_root(prompt=prompt)
+    data_root = wm_root / "data"
+
+    os.environ["WM_ROOT"] = str(wm_root)
+    os.environ["WM_APP_ROOT"] = str(wm_root)
+    os.environ["WM_DATA_ROOT"] = str(data_root)
+    os.environ["WM_CONFIG_FILE"] = str(wm_root / "config.json")
+
+    ensure_root_tree()
+
+    return {
+        "app_root": str(get_app_root()),
+        "root_file": str(root_file_path()),
+        "wm_root": str(wm_root),
+        "config": str(path_config()),
+        "data_root": str(data_root),
+        "profiles": str(path_profiles()),
+        "tools_dir": str(path_tools_dir()),
+        "machines": str(path_machines()),
+        "warehouse": str(path_warehouse()),
+        "bom": str(path_bom()),
+        "orders_dir": str(path_orders_dir()),
+        "dyspozycje": str(path_dyspozycje()),
+        "logs_dir": str(path_logs()),
+        "backup_dir": str(path_backup()),
+    }
+
+
+def print_root_diagnostics(snapshot: dict[str, Any] | None = None) -> None:
+    snap = snapshot or install_environment(prompt=False)
+    print("[WM-ROOT][BOOT] =====================================")
+    print(f"[WM-ROOT][BOOT] APP_ROOT    = {snap.get('app_root')}")
+    print(f"[WM-ROOT][BOOT] ROOT_FILE   = {snap.get('root_file')}")
+    print(f"[WM-ROOT][BOOT] WM_ROOT     = {snap.get('wm_root')}")
+    print(f"[WM-ROOT][BOOT] CONFIG      = {snap.get('config')}")
+    print(f"[WM-ROOT][BOOT] DATA_ROOT   = {snap.get('data_root')}")
+    print(f"[WM-ROOT][BOOT] PROFILES    = {snap.get('profiles')}")
+    print(f"[WM-ROOT][BOOT] TOOLS_DIR   = {snap.get('tools_dir')}")
+    print(f"[WM-ROOT][BOOT] MACHINES    = {snap.get('machines')}")
+    print(f"[WM-ROOT][BOOT] WAREHOUSE   = {snap.get('warehouse')}")
+    print(f"[WM-ROOT][BOOT] BOM         = {snap.get('bom')}")
+    print(f"[WM-ROOT][BOOT] ORDERS_DIR  = {snap.get('orders_dir')}")
+    print(f"[WM-ROOT][BOOT] DYSP_FILE   = {snap.get('dyspozycje')}")
+    print(f"[WM-ROOT][BOOT] LOGS_DIR    = {snap.get('logs_dir')}")
+    print(f"[WM-ROOT][BOOT] BACKUP_DIR  = {snap.get('backup_dir')}")
+    print("[WM-ROOT][BOOT] =====================================")
+
+    app_data = get_app_root() / "data"
+    try:
+        if app_data.exists() and _norm(app_data) != _norm(get_data_root()):
+            print(f"[WM-ROOT][WARN] Wykryto lokalny folder data przy programie: {app_data}")
+            print(f"[WM-ROOT][WARN] Aktywny DATA_ROOT: {get_data_root()}")
+            print("[WM-ROOT][WARN] Lokalny folder data nie powinien być używany.")
+    except Exception:
+        pass

--- a/start.py
+++ b/start.py
@@ -31,6 +31,10 @@ from utils_json import ensure_json
 from utils import error_dialogs
 from config.paths import get_app_root, p_config, p_settings_schema
 from config_manager import ConfigManager
+try:
+    from core import root_paths as wm_root_paths
+except Exception:  # pragma: no cover - awaryjnie nie blokuj startu
+    wm_root_paths = None
 
 os.environ.setdefault("QT_LOGGING_RULES", "qt.qpa.*=false")
 
@@ -59,6 +63,15 @@ def _feature_flag_enabled(value, *, default: bool = True) -> bool:
             return False
         return default
     return bool(value)
+
+
+ROOT_SNAPSHOT = None
+if wm_root_paths is not None:
+    try:
+        # Bez okna dialogowego na etapie importu; właściwe pytanie nastąpi w main().
+        ROOT_SNAPSHOT = wm_root_paths.install_environment(prompt=False)
+    except Exception as exc:
+        print(f"[WM-ROOT][WARN] Wstępny bootstrap ROOT pominięty: {exc}")
 
 
 APP_ROOT = get_app_root()
@@ -203,6 +216,12 @@ from utils.moduly import zaladuj_manifest
 
 def _print_root_diagnostics(manager) -> None:
     """Emit podstawowe informacje diagnostyczne o ścieżkach <root>."""
+
+    if wm_root_paths is not None:
+        try:
+            wm_root_paths.print_root_diagnostics(ROOT_SNAPSHOT)
+        except Exception as exc:
+            print(f"[WM-ROOT][WARN] Diagnostyka centralnego ROOT nieudana: {exc}")
 
     print("[WM ROOT DIAGNOSTICS]")
     if manager is None:
@@ -419,7 +438,10 @@ def _ensure_user_file(login, rola):
     try:
         if not login:
             return
-        base = os.path.join("data", "user")
+        if wm_root_paths is not None:
+            base = str(wm_root_paths.get_data_root() / "user")
+        else:
+            base = os.path.join("data", "user")
         os.makedirs(base, exist_ok=True)
         path = os.path.join(base, f"{login}.json")
         if not os.path.exists(path):
@@ -436,6 +458,7 @@ def _ensure_user_file(login, rola):
             }
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
+            print(f"[WM-ROOT][USER] file={path}")
             _info(f"[{SESSION_ID}] Utworzono plik użytkownika: {path}")
     except Exception as e:
         _error(f"[{SESSION_ID}] Błąd tworzenia pliku użytkownika: {e}")
@@ -741,6 +764,19 @@ def main():
     # Opcjonalnie wycisz WARNING Qt
     # "Untested Windows version 10.0 detected!" – porządkuje logi.
     SESSION_ID = f"{datetime.now().strftime('%H%M%S')}"
+    global ROOT_SNAPSHOT, CONFIG_MANAGER, CONFIG_PATH
+    if wm_root_paths is not None:
+        try:
+            # Tu wolno pokazać wybór folderu ROOT, bo startuje właściwa aplikacja.
+            ROOT_SNAPSHOT = wm_root_paths.install_environment(prompt=True)
+            CONFIG_MANAGER = None
+            env_cfg = os.environ.get("WM_CONFIG_FILE")
+            if env_cfg:
+                CONFIG_PATH = Path(env_cfg).expanduser().resolve()
+            wm_root_paths.print_root_diagnostics(ROOT_SNAPSHOT)
+        except Exception as exc:
+            print(f"[WM-ROOT][WARN] Bootstrap ROOT w main() nieudany: {exc}")
+
     manager = _ensure_config_manager()
     _print_root_diagnostics(manager)
     _post_config_bootstrap()


### PR DESCRIPTION
### Motivation
- Centralize determination of application root (`APP_ROOT`) and data root (`WM_ROOT`/`DATA_ROOT`) to simplify path logic and user selection of a persistent data folder.
- Ensure the application can bootstrap environment variables and create the expected `data/` tree under a chosen `WM_ROOT` for portable installs.
- Surface diagnostics about active roots early in startup to help detect accidental use of a local `data/` folder near the program.

### Description
- Added new module `core/root_paths.py` which provides `get_app_root()`, `resolve_wm_root()`, `install_environment()`, `ensure_root_tree()` and several `path_*()` helpers plus `print_root_diagnostics()` and JSON `wm_root.json` read/write support.
- Updated `config/paths.py` to prefer values from `core.root_paths` (when importable) and fall back to the previous behavior to preserve backward compatibility by guarding imports with safe `try/except` fallbacks and using `get_root_anchor()`/`get_data_root()` where appropriate.
- Integrated bootstrap and diagnostics into `start.py` by attempting a non-interactive `install_environment(prompt=False)` at import time and a full interactive `install_environment(prompt=True)` inside `main()`, and updated `_ensure_user_file()` to create per-user files under the resolved data root.
- All changes preserve existing git update logic (`auto_update_on_start()`, `_wm_git_check_on_start()`, `_git_has_updates(Path.cwd())`) as requested and include defensive `try/except` guards so startup does not fail when `core.root_paths` cannot be used.

### Testing
- Ran `pytest -q` which executed the test suite and produced: `226 passed, 1 failed, 46 skipped`, with the single failing test `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja` raising `KeyError: 'status'` (failure appears unrelated to the root bootstrap integration logic). 
- Verified syntax compilation with `python3 -m py_compile start.py config/paths.py core/root_paths.py`, which succeeded. 
- Attempted `py -3.13 -m py_compile start.py config/paths.py core/root_paths.py` but the `py` launcher is not available in the container (`py: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa95679e48323bb003e29bcdc2bae)