### PR TITLE
Ujednolicenie komunikatów UI dla wyboru folderu ROOT WM

### DIFF
--- a/core/root_paths.py
+++ b/core/root_paths.py
@@ -85,11 +85,20 @@ def _ask_root_folder(initial: Path) -> Path | None:
         root.withdraw()
         try:
             messagebox.showinfo(
-                "Folder danych WM",
-                "Wskaż jeden główny folder danych Warsztat Menager.\n\n"
-                "Przykład:\n"
+                "Wybór głównego folderu WM",
+                "Program musi wiedzieć, gdzie ma trzymać dane warsztatu.\n\n"
+                "Wskaż JEDEN główny folder ROOT, np.:\n"
                 "C:\\wm\n\n"
-                "Nie wybieraj folderu programu ani samego folderu data.",
+                "W tym folderze program będzie tworzył m.in.:\n"
+                "C:\\wm\\data\\narzedzia\n"
+                "C:\\wm\\data\\magazyn\n"
+                "C:\\wm\\data\\maszyny\n"
+                "C:\\wm\\data\\zlecenia\n"
+                "C:\\wm\\logs\n"
+                "C:\\wm\\backup\n\n"
+                "Nie wybieraj folderu programu, np. C:\\Warsztat-menager.\n"
+                "Nie wybieraj też samego folderu data.\n\n"
+                "Najprościej: utwórz albo wybierz C:\\wm.",
                 parent=root,
             )
         except Exception:
@@ -97,7 +106,7 @@ def _ask_root_folder(initial: Path) -> Path | None:
         selected = filedialog.askdirectory(
             parent=root,
             initialdir=str(initial),
-            title="Wskaż główny folder danych WM",
+            title="Wybierz główny folder ROOT WM, np. C:\\wm",
         )
         root.destroy()
     except Exception as exc:

--- a/gui_settings.py
+++ b/gui_settings.py
@@ -657,9 +657,24 @@ def _build_root_section(
 
         def _change_root_folder() -> None:
             current = root_var.get() or str(Path.cwd())
+            messagebox.showinfo(
+                "Wybór głównego folderu WM",
+                "Wskaż JEDEN główny folder ROOT, np.:\n"
+                "C:\\wm\n\n"
+                "Program będzie tam zapisywał dane modułów:\n"
+                "<root>\\data\\narzedzia\n"
+                "<root>\\data\\magazyn\n"
+                "<root>\\data\\maszyny\n"
+                "<root>\\data\\zlecenia\n"
+                "<root>\\logs\n"
+                "<root>\\backup\n\n"
+                "Nie wybieraj folderu programu ani samego folderu data.\n"
+                "Po zmianie ROOT uruchom program ponownie.",
+                parent=parent,
+            )
             selected = filedialog.askdirectory(
                 parent=parent,
-                title="Wybierz główny folder danych WM",
+                title="Wybierz główny folder ROOT WM, np. C:\\wm",
                 initialdir=current,
             )
             if not selected:


### PR DESCRIPTION
### Motivation
- Ujednolicić i doprecyzować komunikaty pokazywane użytkownikowi przy wyborze głównego folderu danych (WM_ROOT), aby zmniejszyć ryzyko wskazania niewłaściwego katalogu.

### Description
- Zaktualizowano treść `messagebox.showinfo` w `core/root_paths.py` tak, aby miała nowy tytuł, jasne instrukcje, przykładową ścieżkę (`C:\wm`) oraz listę katalogów, które program utworzy pod ROOT; zmieniono też tytuł okna wyboru katalogu na `Wybierz główny folder ROOT WM, np. C:\wm`.

### Testing
- Uruchomiono `pytest` i otrzymano wynik `6 failed, 221 passed, 46 skipped`, gdzie niepowodzenia dotyczą istniejących problemów niezwiązanych z wprowadzonymi zmianami (m.in. testy GUI/Tkinter wymagające DISPLAY i niezwiązane asercje domenowe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0444022a48323a45e06b78f2072fe)