### PR TITLE
Usprawnij wybór i prezentację folderu danych ROOT

### DIFF
--- a/core/root_paths.py
+++ b/core/root_paths.py
@@ -18,7 +18,6 @@ from typing import Any
 
 
 ROOT_FILE_NAME = "wm_root.json"
-DEFAULT_ROOT_NAME = "wm"
 
 
 def _norm(path: Path | str) -> Path:
@@ -66,11 +65,11 @@ def _write_root_file(path: Path, wm_root: Path) -> None:
 
 
 def _default_wm_root() -> Path:
-    drive = Path.cwd().anchor or "C:\\"
+    """Tylko katalog startowy dla okna wyboru; nie jest automatycznie zapisywany."""
     try:
-        return _norm(Path(drive) / DEFAULT_ROOT_NAME)
+        return _norm(Path.home())
     except Exception:
-        return _norm(get_app_root() / DEFAULT_ROOT_NAME)
+        return _norm(get_app_root())
 
 
 def _ask_root_folder(initial: Path) -> Path | None:
@@ -85,20 +84,15 @@ def _ask_root_folder(initial: Path) -> Path | None:
         root.withdraw()
         try:
             messagebox.showinfo(
-                "Wybór głównego folderu WM",
-                "Program musi wiedzieć, gdzie ma trzymać dane warsztatu.\n\n"
-                "Wskaż JEDEN główny folder ROOT, np.:\n"
-                "C:\\wm\n\n"
-                "W tym folderze program będzie tworzył m.in.:\n"
-                "C:\\wm\\data\\narzedzia\n"
-                "C:\\wm\\data\\magazyn\n"
-                "C:\\wm\\data\\maszyny\n"
-                "C:\\wm\\data\\zlecenia\n"
-                "C:\\wm\\logs\n"
-                "C:\\wm\\backup\n\n"
-                "Nie wybieraj folderu programu, np. C:\\Warsztat-menager.\n"
-                "Nie wybieraj też samego folderu data.\n\n"
-                "Najprościej: utwórz albo wybierz C:\\wm.",
+                "Wybór głównego folderu danych WM",
+                "Wskaż folder, w którym Warsztat Menager ma trzymać dane.\n\n"
+                "Może to być dowolny folder na dysku lub pendrive, np.:\n"
+                "D:\\Dane_WM\n"
+                "E:\\Warsztat_Root\n"
+                "C:\\Moje_Dane_Warsztatu\n\n"
+                "Program utworzy w nim katalogi: data, logs, backup, assets.\n\n"
+                "Nie wybieraj folderu programu.\n"
+                "Nie wybieraj samego folderu data.",
                 parent=root,
             )
         except Exception:
@@ -106,7 +100,7 @@ def _ask_root_folder(initial: Path) -> Path | None:
         selected = filedialog.askdirectory(
             parent=root,
             initialdir=str(initial),
-            title="Wybierz główny folder ROOT WM, np. C:\\wm",
+            title="Wybierz główny folder danych WM",
         )
         root.destroy()
     except Exception as exc:
@@ -135,6 +129,11 @@ def resolve_wm_root(*, prompt: bool = False) -> Path:
 
     initial = _default_wm_root()
     selected = _ask_root_folder(initial) if prompt else None
+    if selected is None and prompt:
+        raise RuntimeError(
+            "Nie wybrano głównego folderu danych WM. "
+            "Wybierz folder ROOT, aby program wiedział gdzie zapisywać dane."
+        )
     wm_root = selected or initial
     try:
         _write_root_file(pointer, wm_root)

--- a/gui_settings.py
+++ b/gui_settings.py
@@ -617,12 +617,12 @@ def _build_root_section(
         except Exception:
             snap = {}
 
-        box = ttk.Labelframe(parent, text="📁 Główny folder WM / ROOT")
-        box.pack(fill="x", padx=8, pady=8)
+        root_box = ttk.Labelframe(parent, text="📁 Główny folder danych WM")
+        root_box.pack(fill="x", padx=8, pady=8)
 
         root_var = tk.StringVar(value=str(snap.get("wm_root", "—")))
 
-        root_row = ttk.Frame(box)
+        root_row = ttk.Frame(root_box)
         root_row.pack(fill="x", padx=8, pady=(8, 4))
         ttk.Label(root_row, text="Aktualny ROOT:", width=18).pack(side="left")
         root_entry = ttk.Entry(root_row, textvariable=root_var)
@@ -656,25 +656,22 @@ def _build_root_section(
                 pass
 
         def _change_root_folder() -> None:
-            current = root_var.get() or str(Path.cwd())
+            current = root_var.get()
+            if not current or current == "—":
+                current = str(Path.home())
             messagebox.showinfo(
-                "Wybór głównego folderu WM",
-                "Wskaż JEDEN główny folder ROOT, np.:\n"
-                "C:\\wm\n\n"
-                "Program będzie tam zapisywał dane modułów:\n"
-                "<root>\\data\\narzedzia\n"
-                "<root>\\data\\magazyn\n"
-                "<root>\\data\\maszyny\n"
-                "<root>\\data\\zlecenia\n"
-                "<root>\\logs\n"
-                "<root>\\backup\n\n"
-                "Nie wybieraj folderu programu ani samego folderu data.\n"
+                "Wybór głównego folderu danych WM",
+                "Wskaż folder, w którym Warsztat Menager ma trzymać dane.\n\n"
+                "Może to być dowolny folder na dysku lub pendrive.\n"
+                "Program utworzy w nim katalogi: data, logs, backup, assets.\n\n"
+                "Nie wybieraj folderu programu.\n"
+                "Nie wybieraj samego folderu data.\n\n"
                 "Po zmianie ROOT uruchom program ponownie.",
                 parent=parent,
             )
             selected = filedialog.askdirectory(
                 parent=parent,
-                title="Wybierz główny folder ROOT WM, np. C:\\wm",
+                title="Wybierz główny folder danych WM",
                 initialdir=current,
             )
             if not selected:
@@ -732,52 +729,49 @@ def _build_root_section(
             command=_change_root_folder,
         ).pack(side="left")
 
-        actions = ttk.Frame(box)
-        actions.pack(fill="x", padx=8, pady=(0, 8))
-        ttk.Button(actions, text="Otwórz ROOT", command=lambda: _open_path("wm_root")).pack(side="left", padx=(0, 6))
-        ttk.Button(actions, text="Otwórz DATA", command=lambda: _open_path("data_root")).pack(side="left", padx=6)
-        ttk.Button(actions, text="Odśwież", command=_refresh_root_preview).pack(side="left", padx=6)
+        root_actions = ttk.Frame(root_box)
+        root_actions.pack(fill="x", padx=8, pady=(0, 8))
+        ttk.Button(root_actions, text="Otwórz ROOT", command=lambda: _open_path("wm_root")).pack(side="left", padx=(0, 6))
+        ttk.Button(root_actions, text="Otwórz DATA", command=lambda: _open_path("data_root")).pack(side="left", padx=6)
+        ttk.Button(root_actions, text="Odśwież", command=_refresh_root_preview).pack(side="left", padx=6)
 
-        info = ttk.Label(
-            box,
+        ttk.Label(
+            root_box,
             text=(
-                "APP_ROOT to folder programu/repo/Git. WM_ROOT to folder danych.\n"
-                "Zmiana ROOT zapisuje tylko wm_root.json i wymaga restartu programu."
+                "ROOT to główny folder danych. Program tworzy w nim data, logs, backup i assets.\n"
+                "Folder programu/repozytorium pozostaje osobno i służy do uruchamiania oraz aktualizacji Git."
             ),
             justify="left",
             wraplength=760,
-        )
-        info.pack(fill="x", padx=8, pady=(0, 8))
+        ).pack(fill="x", padx=8, pady=(0, 8))
 
-        map_box = ttk.Labelframe(parent, text="🗂 Gdzie moduły zapisują dane")
-        map_box.pack(fill="x", padx=8, pady=8)
+        paths_box = ttk.Labelframe(parent, text="🗂 Aktualne ścieżki używane przez program")
+        paths_box.pack(fill="x", padx=8, pady=8)
 
-        module_paths = {
-            "Config": "config",
-            "Profile / użytkownicy": "profiles",
-            "Narzędzia": "tools_dir",
-            "Maszyny": "machines",
-            "Magazyn": "warehouse",
-            "Produkty / BOM": "bom",
-            "Zlecenia": "orders_dir",
-            "Dyspozycje": "dyspozycje",
-            "Logi": "logs_dir",
-            "Backup": "backup_dir",
-        }
-
-        rows_frame = ttk.Frame(map_box)
+        rows_frame = ttk.Frame(paths_box)
         rows_frame.pack(fill="x", padx=8, pady=8)
 
         def _row(label: str, key: str) -> None:
             row = ttk.Frame(rows_frame)
             row.pack(fill="x", pady=1)
-            ttk.Label(row, text=label, width=22).pack(side="left")
+            ttk.Label(row, text=label, width=24).pack(side="left")
             lbl = ttk.Label(row, text=str(snap.get(key, "—")))
             lbl.pack(side="left", fill="x", expand=True)
             labels[key] = lbl
 
-        for title, key in module_paths.items():
-            _row(title, key)
+        _row("APP_ROOT / program", "app_root")
+        _row("Plik wyboru ROOT", "root_file")
+        _row("Config", "config")
+        _row("DATA", "data_root")
+        _row("Profile / użytkownicy", "profiles")
+        _row("Narzędzia", "tools_dir")
+        _row("Maszyny", "machines")
+        _row("Magazyn", "warehouse")
+        _row("Produkty / BOM", "bom")
+        _row("Zlecenia", "orders_dir")
+        _row("Dyspozycje", "dyspozycje")
+        _row("Logi", "logs_dir")
+        _row("Backup", "backup_dir")
 
         hall_box = ttk.Labelframe(parent, text="🖼 Tło hali")
         hall_box.pack(fill="x", padx=8, pady=8)
@@ -850,7 +844,7 @@ def _build_root_section(
                     parent=parent,
                 )
 
-        diag_actions = ttk.Frame(map_box)
+        diag_actions = ttk.Frame(paths_box)
         diag_actions.pack(fill="x", padx=8, pady=(0, 8))
         ttk.Button(
             diag_actions,


### PR DESCRIPTION
### Motivation
- Uprościć i uczytelnić proces wyboru głównego folderu danych (WM_ROOT) oraz poprawić domyślny katalog startowy dla dialogu wyboru.
- Ułatwić diagnostykę i widoczność bieżących ścieżek używanych przez program w panelu ustawień.

### Description
- W `core/root_paths.py` zmieniono `_default_wm_root()` tak, aby używał katalogu domowego użytkownika jako punktu startowego dialogu i usunięto zależność od stałej `DEFAULT_ROOT_NAME`, z fallbackem do `get_app_root()`; dodano docstring wyjaśniający przeznaczenie tej funkcji.
- W `core/root_paths.py` zaktualizowano komunikaty w oknie wyboru oraz w `resolve_wm_root(prompt=True)` dodano jawne zgłoszenie `RuntimeError` gdy użytkownik uruchomi wybór ROOT i anuluje dialog.
- W `gui_settings.py` przebudowano sekcję ROOT: nowy nagłówek, czytelniejsze komunikaty, osobne ramki `root_box` i `paths_box`, poszerzone etykiety ścieżek oraz dodanie wierszy `APP_ROOT / program` i `Plik wyboru ROOT`; poprawiono logikę początkowego katalogu wyboru (`Path.home()` gdy brak wartości).
- Zmieniono nazwy i układ przycisków/akcji w UI (wybierz ROOT, otwórz ROOT/DATA, odśwież, kopiuj diagnostykę) oraz dostosowano opisy informacyjne.

### Testing
- Uruchomiono `pytest` na repozytorium; wynik: `6 failed, 221 passed, 46 skipped`.
- Niektóre niepowodzenia dotyczą środowiska/testów GUI i braków danych testowych (m.in. brak `$DISPLAY` dla tkinter oraz brak oczekiwanych plików `profiles.json`), które nie są bezpośrednio związane z wprowadzonymi zmianami.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04f3edba48323af221ff36f740890)