### PR TITLE
Prefer runtime WM root anchors over config path overrides

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -298,10 +298,13 @@ def _absolute_with_root(path: str | None, root: str) -> str:
 
 def get_root(cfg: dict | None = None) -> str:
     cfg = cfg or {}
-    paths = cfg.get("paths") or {}
     forced_root = _wm_root_anchor()
-    if forced_root and not (paths.get("anchor_root") or paths.get("data_root")):
+    # WM_ROOT / core.root_paths jest nadrzędną prawdą runtime.
+    # Stare wpisy paths.anchor_root / paths.data_root w configu nie mogą nadpisywać
+    # folderu wybranego przez użytkownika przy starcie programu.
+    if forced_root:
         return _norm(forced_root)
+    paths = cfg.get("paths") or {}
 
     try:
         raw_anchor = paths.get("anchor_root")
@@ -351,7 +354,7 @@ def _resolve_rel_legacy(cfg: dict, what: str) -> str | None:
     cfg = cfg or {}
     paths_cfg = (cfg.get("paths") or {})
     root = (
-        paths_cfg.get("data_root") or _wm_data_root() or DEFAULTS["paths"]["data_root"]
+        _wm_data_root() or paths_cfg.get("data_root") or DEFAULTS["paths"]["data_root"]
     ).strip()
     relative_cfg = (cfg.get("relative") or {})
 
@@ -486,7 +489,7 @@ def _resolve_rroot_map(cfg: dict | None, key: str, *, dir_only: bool = False) ->
         last = parts[-1]
         if os.path.splitext(last)[1]:
             parts = parts[:-1]
-    root = get_root(cfg)
+    root = _wm_root_anchor() or get_root(cfg)
     if not parts:
         return root
     return _norm(os.path.join(root, *parts))


### PR DESCRIPTION
### Motivation
- Make the runtime-selected WM root (`WM_ROOT` / `core.root_paths`) authoritative so the folder chosen by the user at startup cannot be overridden by legacy config entries.
- Ensure relative-path resolution uses runtime data-root hints when available to avoid inconsistent path resolution.
- Anchor `root.*` mappings to the runtime anchor when present to keep mapping behavior consistent with runtime configuration.

### Description
- `get_root()` now immediately returns `_wm_root_anchor()` when present so legacy `paths.anchor_root`/`paths.data_root` cannot override the runtime anchor.
- `_resolve_rel_legacy()` now prefers `_wm_data_root()` before `paths.data_root` (then falls back to `DEFAULTS`) when constructing the effective data root.
- `_resolve_rroot_map()` now uses `_wm_root_anchor()` as the primary root for mapped `root.*` paths, with `get_root(cfg)` as a fallback.

### Testing
- Ran `pytest` from the repository root with `pytest`; the run executed 269 tests and produced 221 passed, 46 skipped, and 6 failed.
- The failing tests are: `test_gui_logowanie.py::test_logowanie_success`, `test_gui_logowanie.py::test_logowanie_case_insensitive[Edwin]`, `test_gui_logowanie.py::test_logowanie_case_insensitive[EDWIN]`, `test_gui_logowanie.py::test_logowanie_callback_error`, `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja`, and `test_profile_utils_regression.py::test_old_style_users_upgraded`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0847290988323afbacb3c0ec86031)