### PR TITLE
Set WM root environment variables during startup bootstrap

### DIFF
--- a/start.py
+++ b/start.py
@@ -776,9 +776,24 @@ def main():
             # Tu wolno pokazać wybór folderu ROOT, bo startuje właściwa aplikacja.
             ROOT_SNAPSHOT = wm_root_paths.install_environment(prompt=True)
             CONFIG_MANAGER = None
+            try:
+                os.environ["WM_ROOT"] = str(wm_root_paths.get_root_anchor())
+                os.environ["WM_DATA_ROOT"] = str(wm_root_paths.get_data_root())
+                os.environ["WM_CONFIG_FILE"] = str(wm_root_paths.path_config())
+            except Exception:
+                pass
             env_cfg = os.environ.get("WM_CONFIG_FILE")
             if env_cfg:
                 CONFIG_PATH = Path(env_cfg).expanduser().resolve()
+            try:
+                print(f"[WM-ROOT][START] CONFIG_PATH={CONFIG_PATH}")
+                print(f"[WM-ROOT][START] WM_ROOT={os.environ.get('WM_ROOT')}")
+                print(f"[WM-ROOT][START] WM_DATA_ROOT={os.environ.get('WM_DATA_ROOT')}")
+                print(
+                    f"[WM-ROOT][START] WM_CONFIG_FILE={os.environ.get('WM_CONFIG_FILE')}"
+                )
+            except Exception:
+                pass
             wm_root_paths.print_root_diagnostics(ROOT_SNAPSHOT)
         except Exception as exc:
             print(f"[WM-ROOT][WARN] Bootstrap ROOT w main() nieudany: {exc}")


### PR DESCRIPTION
### Motivation
- Ensure runtime components can rely on normalized WM root paths by exporting `WM_ROOT`, `WM_DATA_ROOT`, and `WM_CONFIG_FILE` immediately after `wm_root_paths.install_environment()`.
- Provide lightweight startup diagnostics so configuration resolution can be observed when bootstrapping the application.

### Description
- In `main()` of `start.py`, after `ROOT_SNAPSHOT = wm_root_paths.install_environment(prompt=True)`, export `WM_ROOT`, `WM_DATA_ROOT`, and `WM_CONFIG_FILE` into `os.environ` inside a `try/except` to avoid breaking startup on errors.
- Resolve `CONFIG_PATH` from the `WM_CONFIG_FILE` environment variable if present and print diagnostic lines showing the resolved `CONFIG_PATH` and effective `WM_*` environment variables, with the prints also wrapped in `try/except` to keep startup resilient.
- Leave existing root diagnostics call `wm_root_paths.print_root_diagnostics(ROOT_SNAPSHOT)` unchanged.

### Testing
- Ran `pytest` from repository root with `pytest`; it collected `269` tests and reported `221 passed`, `6 failed`, and `46 skipped`.
- The failing tests are related to headless GUI/Tkinter `$DISPLAY` issues and profile/data regression assertions, which appear unrelated to the env var export change and do not indicate a direct failure introduced by this patch.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08481d0c083239b09c487774b7b70)