### PR TITLE
Podłączenie paska diagnostycznego źródła danych do modułów WM

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -732,6 +732,21 @@ def open_panel_magazyn(parent, root=None, app=None, notebook=None, *args, **kwar
      - notebook: opcjonalny ttk.Notebook
      - container: widget **albo** nazwa atrybutu (str), np. "content"
     """
+    try:
+        from gui_panel import wm_set_module_source
+        from config_manager import ConfigManager, resolve_rel
+
+        cfg = {}
+        try:
+            cfg = ConfigManager().load()
+        except Exception:
+            cfg = {}
+        stock_path = resolve_rel(cfg, "warehouse_stock")
+        target_root = root if root is not None else parent.winfo_toplevel()
+        wm_set_module_source(target_root, "Magazyn", stock_path)
+    except Exception:
+        pass
+
     # Config
     cfg = kwargs.get("config")
     if not isinstance(cfg, dict):
@@ -790,4 +805,3 @@ def open_panel_magazyn(parent, root=None, app=None, notebook=None, *args, **kwar
     parent._magazyn_embed = frame
     return frame
 # ⏹ KONIEC KODU
-

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2252,6 +2252,19 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
 
 
 def panel_maszyny(root, frame, login=None, rola=None):
+    try:
+        from gui_panel import wm_set_module_source
+        from config_manager import ConfigManager, get_machines_path
+
+        cfg = {}
+        try:
+            cfg = ConfigManager().load()
+        except Exception:
+            cfg = {}
+        wm_set_module_source(root, "Maszyny", get_machines_path(cfg))
+    except Exception:
+        pass
+
     _open_maszyny = _open_machines_panel  # alias nazwy
     if open_dyspo_wizard is not None:
         toolbar = ttk.Frame(frame)

--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -3804,6 +3804,19 @@ def _phase_for_status(tool_mode: str, status_text: str) -> str | None:
 
 # ===================== UI GŁÓWNY =====================
 def panel_narzedzia(root, frame, login=None, rola=None):
+    try:
+        from gui_panel import wm_set_module_source
+        from utils_paths import tools_dir
+
+        cfg = {}
+        try:
+            cfg = ConfigManager().load()
+        except Exception:
+            cfg = {}
+        wm_set_module_source(root, "Narzędzia", tools_dir(cfg))
+    except Exception:
+        pass
+
     bridge = _TOOLS_BRIDGE
     STATE.current_login = login
     STATE.current_role = rola

--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -8,7 +8,12 @@ import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
 from typing import Any, Callable
 
-from dyspozycje_store import close_dyspozycja, delete_dyspozycja, load_dyspozycje
+from dyspozycje_store import (
+    close_dyspozycja,
+    delete_dyspozycja,
+    get_dyspozycje_path,
+    load_dyspozycje,
+)
 
 from ui_dialogs_safe import error_box
 
@@ -356,10 +361,11 @@ class ZleceniaView(ttk.Frame):
             rows = _load_orders_rows()
             try:
                 from gui_panel import wm_set_module_source
+
                 wm_set_module_source(
                     self.winfo_toplevel(),
                     "Dyspozycje / Zlecenia",
-                    getattr(storage, "ORDERS_FILE", ""),
+                    str(get_dyspozycje_path()),
                 )
             except Exception:
                 pass

--- a/ustawienia_systemu.py
+++ b/ustawienia_systemu.py
@@ -82,6 +82,23 @@ def panel_ustawien(
     wires variable traces so callers using legacy APIs continue to work.
     """
 
+    try:
+        from gui_panel import wm_set_module_source
+
+        detected_config_path = os.environ.get("WM_CONFIG_FILE")
+        if not detected_config_path:
+            try:
+                from start import CONFIG_MANAGER
+
+                detected_config_path = str(
+                    getattr(CONFIG_MANAGER, "config_path", "") or ""
+                )
+            except Exception:
+                detected_config_path = ""
+        wm_set_module_source(root, "Ustawienia", detected_config_path)
+    except Exception:
+        pass
+
     clear_frame(frame)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Naprawić niedokończoną diagnostykę źródła danych w pasku górnym tak, aby moduły pokazywały rzeczywiste pliki/katalogi, bez zmiany logiki ROOT, zapisu JSON ani modelu danych.
- Usunąć błędne użycie niezdefiniowanej zmiennej `storage` w module Dyspozycji i podłączyć istniejący helper `wm_set_module_source` w modułach diagnostycznych.

### Description
- W `gui_zlecenia.py` rozszerzono import z `dyspozycje_store` o `get_dyspozycje_path` i zastąpiono `getattr(storage, "ORDERS_FILE", "")` bezpiecznym `str(get_dyspozycje_path())` w metodzie `_refresh`.
- W `gui_narzedzia.py` w `panel_narzedzia` dodano bezpieczny blok `try/except`, który wywołuje `wm_set_module_source(root, "Narzędzia", tools_dir(cfg))` po załadowaniu konfiguracji.
- W `gui_maszyny.py` w `panel_maszyny` dodano bezpieczny blok `try/except`, który wywołuje `wm_set_module_source(root, "Maszyny", get_machines_path(cfg))` po załadowaniu konfiguracji.
- W `gui_magazyn.py` na początku `open_panel_magazyn` dodano bezpieczny blok `try/except`, który wywołuje `wm_set_module_source(target_root, "Magazyn", resolve_rel(cfg, "warehouse_stock"))` używając `root` lub `parent.winfo_toplevel()` jako celu.
- W `ustawienia_systemu.py` w `panel_ustawien` dodano bezpieczny blok `try/except`, który ustawia źródło konfiguracji z `WM_CONFIG_FILE` lub fallbacku `start.CONFIG_MANAGER.config_path` przez `wm_set_module_source`.
- Zweryfikowano, że `gui_panel.py` publikuje `wm_current_source_var`, więc nie były wymagane zmiany w `gui_panel.py`.

### Testing
- Uruchomiono testy jednostkowe poleceniem `pytest -q --maxfail=1` zgodnie z wymaganiem po zmianach.
- Wynik testów: `1 failed, 9 passed, 5 skipped`, gdzie pojedynczy błąd to `test_gui_logowanie.py::test_logowanie_invalid_pair` i dotyczy niepowiązanego z tym patchem oczekiwanego komunikatu (`"Nieprawidłowy PIN"` vs oczekiwane `"Nieprawidłowy login lub PIN"`).
- Zmiany nie wprowadziły nowych błędów powiązanych z podłączaniem paska diagnostycznego i modyfikacje są otoczone bezpiecznymi `try/except` aby nie wpływać na logikę modułów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ce9e4680832389a6e01169aff5f2)