### PR TITLE
Constrain Maszyny panel to content frame so global footer remains visible

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2265,9 +2265,15 @@ def panel_maszyny(root, frame, login=None, rola=None):
     except Exception:
         pass
 
+    for child in frame.winfo_children():
+        child.destroy()
+
+    module_frame = ttk.Frame(frame)
+    module_frame.pack(fill="both", expand=True)
+
     _open_maszyny = _open_machines_panel  # alias nazwy
     if open_dyspo_wizard is not None:
-        toolbar = ttk.Frame(frame)
+        toolbar = ttk.Frame(module_frame)
         toolbar.pack(fill="x", padx=6, pady=(6, 0))
         target = root
         if hasattr(root, "winfo_toplevel"):
@@ -2283,7 +2289,10 @@ def panel_maszyny(root, frame, login=None, rola=None):
             ),
         ).pack(side=tk.RIGHT)
         bind_ctrl_d(target, context={"module": "Maszyny"})
-    _open_maszyny(root, frame, Renderer=None)
+
+    panel_container = ttk.Frame(module_frame)
+    panel_container.pack(fill="both", expand=True)
+    _open_maszyny(root, panel_container, Renderer=None)
 
 
 def init_maszyny_view(


### PR DESCRIPTION
### Motivation
- The Maszyny module could expand its widgets in a way that pushed the global WM footer (from `gui_panel.py`) out of view, so the goal is to ensure the Maszyny UI is strictly contained inside the central content container without changing data logic.
- The change must avoid touching ROOT handling, machine loading, JSON persistence, data model and should not refactor unrelated modules.

### Description
- Reworked `panel_maszyny(...)` in `gui_maszyny.py` to clear the incoming `frame` and build a `module_frame` and a nested `panel_container` under it, so module widgets live only inside that container (call site: `gui_maszyny.py` around lines ~2254–2295). 
- Switched the toolbar and the call to `_open_machines_panel(...)` to use the new `module_frame` / `panel_container` instead of attaching widgets directly to the outer frame, keeping `root` only as an application handle for status/shortcuts/dialogs.
- No changes were made to ROOT logic, machine loading, JSON save/load logic, or data models; this is purely a UI containment fix.

### Testing
- Ran the automated test suite with `pytest` after the change as required; the test run started and completed execution but the repository contains existing unrelated test failures (not introduced by this change) e.g. failures reported in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`.
- The change is limited to `panel_maszyny` layout containment and does not modify other functional behavior covered by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d3bd78388323b3f09dd3db274c51)