### PR TITLE
Reserve WM global footer space by packing footer before content

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -764,15 +764,15 @@ def uruchom_panel(root, login, rola):
     current_action_label.pack(fill="x", padx=12, pady=(0, 6))
     setattr(root, "wm_current_source_var", current_action_var)
 
-    content = ttk.Frame(main, style="WM.Card.TFrame"); content.pack(fill="both", expand=True, padx=12, pady=6)
+    footer  = ttk.Frame(main, style="WM.TFrame");      footer.pack(side="bottom", fill="x", padx=12, pady=(6, 10))
+    footer_btns = ttk.Frame(footer, style="WM.TFrame"); footer_btns.pack(side="right")
+
+    content = ttk.Frame(main, style="WM.Card.TFrame"); content.pack(side="top", fill="both", expand=True, padx=12, pady=6)
     setattr(root, "content", content)
     setattr(root, "main_content", content)
     setattr(root, "active_login", login)
     setattr(root, "current_user", login)
     setattr(root, "username", login)
-
-    footer  = ttk.Frame(main, style="WM.TFrame");      footer.pack(fill="x", padx=12, pady=(6,10))
-    footer_btns = ttk.Frame(footer, style="WM.TFrame"); footer_btns.pack(side="right")
 
     # prawa część: stałe przyciski
     def _logout():


### PR DESCRIPTION
### Motivation
- The global WM footer was pushed out of view because the main `content` frame was packed with `expand=True` before the footer, allowing content to occupy the full vertical space. 
- The goal is to ensure the footer is always visible without changing module logic or adding a separate footer to the Machines module.

### Description
- Moved creation of `footer` and `footer_btns` in `uruchom_panel(...)` to be before the `content` frame creation in `gui_panel.py`.
- Changed `footer.pack(...)` to `footer.pack(side="bottom", fill="x", padx=12, pady=(6, 10))` so the footer reserves bottom space.
- Changed `content.pack(...)` to `content.pack(side="top", fill="both", expand=True, padx=12, pady=6)` so content fills the remaining area above the footer.
- Preserved all existing footer button logic and text unchanged and made no changes to ROOT logic, data modules, `start.py`, JSON handling, or `gui_maszyny.py`.

### Testing
- Ran `pytest` which started a full run (collected 269 items / 4 skipped) but observed pre-existing test failures (e.g. in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`) and the suite was not fully green. 
- Ran `timeout 180 pytest -q` which displayed test progress but hit the environment time limit and exited with code `124`, so a full timed run could not complete within the CI budget. 
- The change is layout-only and minimal; no new unit tests were added and footer/button logic remained intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e107289483238ede41dcfe0ed397)