### PR TITLE
Ensure active profiles file uses WM data root and add one-shot legacy migration

### DIFF
--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -218,26 +218,47 @@ def _maybe_migrate_profiles_to_root(root_path: Path) -> None:
 
 
 def _profiles_path() -> Path:
-    best_legacy_source, best_legacy_entries = _best_legacy_profiles_source()
-    if best_legacy_source and not _looks_like_default_admin_only(best_legacy_entries):
-        print(f"[WM-ROOT][LOGIN] profiles_path_legacy={best_legacy_source}")
-        return best_legacy_source
+    root_active = bool(
+        str(os.environ.get("WM_ROOT", "")).strip()
+        or str(os.environ.get("WM_DATA_ROOT", "")).strip()
+    )
 
-    if wm_root_paths is not None:
+    if wm_root_paths is not None and root_active:
         try:
             resolved = wm_root_paths.path_profiles()
             resolved.parent.mkdir(parents=True, exist_ok=True)
             _maybe_migrate_profiles_to_root(resolved)
+            try:
+                users = load_profiles_users(path=resolved) if resolved.exists() else []
+            except Exception:
+                users = []
+            print(
+                f"[WM-ROOT][PROFILES][ACTIVE] path={resolved} "
+                f"exists={1 if resolved.exists() else 0} users={len(users)}"
+            )
             print(f"[WM-ROOT][LOGIN] profiles_path={resolved}")
             return resolved
         except Exception:
             logger.exception("[WM-ERR][LOGIN] root_paths.path_profiles failed")
+
+    best_legacy_source, best_legacy_entries = _best_legacy_profiles_source()
+    if best_legacy_source and not _looks_like_default_admin_only(best_legacy_entries):
+        print(f"[WM-ROOT][LOGIN] profiles_path_legacy={best_legacy_source}")
+        return best_legacy_source
 
     try:
         cfg = ConfigManager()
     except Exception:
         cfg = None
     resolved = resolve_profiles_path(cfg)
+    try:
+        users = load_profiles_users(path=resolved) if resolved.exists() else []
+    except Exception:
+        users = []
+    print(
+        f"[WM-ROOT][PROFILES][ACTIVE] path={resolved} "
+        f"exists={1 if resolved.exists() else 0} users={len(users)}"
+    )
     print(f"[WM-ROOT][LOGIN] profiles_path_fallback={resolved}")
     return resolved
 

--- a/profiles_store.py
+++ b/profiles_store.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -37,29 +39,57 @@ def resolve_profiles_path(
     *,
     path: Path | str | None = None,
 ) -> Path:
+    target: Path
+    snapshot = _config_snapshot(cfg)
     if path is not None:
         target = _as_path(path)
     else:
-        snapshot = _config_snapshot(cfg)
-        try:
-            raw = cfg_get_profiles_path(snapshot)
-        except Exception:
-            raw = ""
-        if raw:
-            target = Path(raw)
+        env_data_root = os.environ.get("WM_DATA_ROOT", "").strip()
+        if env_data_root:
+            target = Path(env_data_root) / "profiles.json"
+        elif root_paths is not None:
+            target = root_paths.path_profiles()
         else:
-            target = (
-                root_paths.path_profiles()
-                if root_paths is not None
-                else Path("data") / "profiles.json"
-            )
+            try:
+                raw = cfg_get_profiles_path(snapshot)
+            except Exception:
+                raw = ""
+            if raw:
+                target = Path(raw)
+            else:
+                target = Path("data") / "profiles.json"
     try:
         resolved = target.expanduser().resolve()
     except Exception:
         resolved = target.expanduser()
     resolved.parent.mkdir(parents=True, exist_ok=True)
+    _maybe_migrate_legacy_root_profiles(resolved)
     logger.info("[WM-ROOT][PROFILES] profiles_path=%s", resolved)
     return resolved
+
+
+def _maybe_migrate_legacy_root_profiles(active_path: Path) -> None:
+    """One-shot copy from <ROOT>/profiles.json to <ROOT>/data/profiles.json."""
+
+    try:
+        root_dir = active_path.parent.parent
+        legacy_path = root_dir / "profiles.json"
+        if os.path.normcase(str(legacy_path.resolve())) == os.path.normcase(
+            str(active_path.resolve())
+        ):
+            return
+        active_exists = active_path.exists()
+        legacy_exists = legacy_path.exists()
+        if legacy_exists and not active_exists:
+            shutil.copy2(legacy_path, active_path)
+            print(f"[WM-ROOT][PROFILES][MIGRATE] {legacy_path} -> {active_path}")
+        elif legacy_exists and active_exists:
+            print(
+                "[WM-ROOT][PROFILES][WARN] legacy root profiles exists but active is "
+                f"data profiles: {legacy_path}"
+            )
+    except Exception:
+        logger.exception("[WM-ERR][PROFILES] legacy migration check failed")
 
 
 def _extract_users(payload: Any) -> list[dict]:

--- a/services/profile_service.py
+++ b/services/profile_service.py
@@ -85,10 +85,7 @@ def _users_file_path(file_path: Optional[str] = None) -> Path:
     resolved = resolve_profiles_path(None)
     if resolved.exists():
         return resolved
-    cwd_candidates = [
-        (Path.cwd() / "profiles.json").resolve(),
-        (Path.cwd() / "uzytkownicy.json").resolve(),
-    ]
+    cwd_candidates = [(Path.cwd() / "uzytkownicy.json").resolve()]
     for candidate in cwd_candidates:
         try:
             if candidate.exists():


### PR DESCRIPTION
### Motivation
- Ensure the application consistently treats the active profiles file as <WM_DATA_ROOT>/profiles.json instead of selecting <WM_ROOT>/profiles.json or cwd legacy files. 
- Preserve existing legacy root-level profiles and provide a safe one-time migration into the WM data folder when appropriate. 
- Add diagnostics and warnings so startup/login behavior clearly reports which profiles file is active and avoid promoting legacy files when a WM ROOT is active.

### Description
- Update `profiles_store.py` to resolve the active profiles path in this priority: `WM_DATA_ROOT` env → `core.root_paths.path_profiles()` → `ConfigManager()` path → fallback `data/profiles.json`, and ensure destination directories are created. 
- Add `_maybe_migrate_legacy_root_profiles` in `profiles_store.py` which copies `<ROOT>/profiles.json` → `<ROOT>/data/profiles.json` when the latter is missing (preserves the original and logs `[WM-ROOT][PROFILES][MIGRATE]`), and logs a warning `[WM-ROOT][PROFILES][WARN]` when both legacy and data profiles exist. 
- Change `gui_logowanie.py` `_profiles_path()` to prefer `core.root_paths.path_profiles()` when WM root/data root is active and only consider legacy candidates afterward, and add diagnostic output `[WM-ROOT][PROFILES][ACTIVE] path=... exists=... users=...`. 
- Modify `services/profile_service.py` to remove the fallback to `cwd/profiles.json` so the service will not use a legacy root-level profiles file as the active source (only keep `uzytkownicy.json` as a cwd legacy candidate). 
- No changes to profiles content, PINs, roles, user records, or authentication logic were made.

### Testing
- Ran `pytest -q -x`; outcome: tests mostly pass with `8 passed, 1 failed, 5 skipped` and the failing test is `test_logowanie_success` (GUI/Tk display-root interaction in the CI environment). 
- Ran the single login GUI test `pytest -q test_gui_logowanie.py::test_logowanie_success`; it failed due to Tkinter display/root errors in the headless test environment, while the new diagnostics show the resolver selecting the data profiles path (e.g. `[WM-ROOT][PROFILES][ACTIVE] path=... exists=... users=...]`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03118c834083238a59c4c11d0589f7)