### PR TITLE
Update CHANGELOG.md with 2026-05-12 diagnostics and GUI notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,30 @@
-..
+# Changelog
+
+## Dzisiejsze zmiany - 2026-05-12
+
+### ROOT / ścieżki danych
+- Dodano widoczny pasek diagnostyczny pokazujący aktywne ścieżki:
+  `ROOT`, `DATA` i `CONFIG`.
+- Dodano pasek aktualnego modułu pokazujący, z jakiego pliku lub katalogu moduł czyta dane.
+- Dodano ostrzeżenie `POZA ROOT!`, gdy moduł korzysta ze ścieżki spoza aktywnego ROOT.
+
+### Moduły i źródła danych
+- Podłączono diagnostykę źródła danych do modułów:
+  Narzędzia, Maszyny, Dyspozycje / Zlecenia, Magazyn i Ustawienia.
+- Naprawiono błędne źródło diagnostyczne w Dyspozycjach / Zleceniach, gdzie wcześniej używana była niezdefiniowana zmienna `storage`.
+- Dyspozycje / Zlecenia pokazują teraz realną ścieżkę zwracaną przez `get_dyspozycje_path()`.
+
+### GUI / układ programu
+- Naprawiono problem, przez który moduł Maszyny wypychał dolną globalną stopkę poza widoczny obszar okna.
+- Ograniczono panel Maszyn do właściwego kontenera modułu.
+- Zmieniono kolejność pakowania `footer` i `content`, aby globalna stopka WM była zawsze rezerwowana na dole okna.
+
+### Narzędzia
+- Wykryto, że Narzędzia czytają plik:
+  `C:\w-m\data\narzedzia\szablony_zadan.json`,
+  ale plik ma `zadania=0`.
+- Do dalszej naprawy pozostaje migracja albo uzupełnienie szablonów zadań w ROOT.
+
+### Profile
+- Wykryto niespójność ścieżki profili: część logiki może używać `<ROOT>\profiles.json` zamiast wymaganego `<ROOT>\data\profiles.json`.
+- Do dalszej naprawy pozostaje wymuszenie aktywnej ścieżki profili na `<ROOT>\data\profiles.json`.


### PR DESCRIPTION
### Motivation
- Replace the placeholder changelog with a structured entry documenting recent diagnostics and UI layout fixes observed during development on 2026-05-12.
- Capture findings about ROOT/DATA/CONFIG path diagnostics, module data-source tracing, and inconsistencies discovered in Narzędzia task templates and profile paths for follow-up.

### Description
- Replaced the placeholder content in `CHANGELOG.md` with a multi-section entry titled "Dzisiejsze zmiany - 2026-05-12" that details diagnostics for `ROOT`/`DATA`/`CONFIG`, module data-source wiring, GUI/footer layout fixes, and notes about Narzędzia and profile path inconsistencies.
- Documented that Dyspozycje/Zlecenia now show the real path from `get_dyspozycje_path()` and that an earlier undefined `storage` diagnostic source was fixed.
- Noted GUI fixes that keep the global footer reserved and constrained the Maszyny panel to its container, and recorded items requiring further migration or enforcement in ROOT data (task templates and profile path).

### Testing
- Ran `pytest` after the change; the test suite started (`collected 269 items / 4 skipped`) and reported existing GUI-related failures that are unrelated to this documentation-only change.
- `pytest` runs did not show new failures caused by this changelog edit; existing failing tests (e.g. in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`) remain to be investigated separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03125401b88323b79004a19391aacc)