### PR TITLE
Use active dyspozycje path and improve legacy migration handling

### DIFF
--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -25,6 +25,11 @@ try:
 except Exception:  # pragma: no cover
     ConfigManager = None  # type: ignore
 
+try:
+    from core import root_paths as wm_root_paths
+except Exception:  # pragma: no cover
+    wm_root_paths = None  # type: ignore
+
 
 DISP_FILE_NAME = "dyspozycje.json"
 DISP_DIR_NAME = "dyspozycje"
@@ -116,26 +121,63 @@ def _legacy_dyspozycje_path() -> Path:
     return _data_root() / DISP_FILE_NAME
 
 
-def _migrate_legacy_if_needed(target: Path) -> None:
-    legacy = _legacy_dyspozycje_path()
-    if target.exists() or not legacy.exists():
-        return
-    try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(legacy, target)
-        print(
-            "[WM-DBG][DYSP][STORE] migrated legacy dyspozycje: "
-            f"{legacy} -> {target}"
-        )
-    except Exception as exc:
+def _legacy_root_dyspozycje_path() -> Path:
+    return _anchor_root() / DISP_DIR_NAME / DISP_FILE_NAME
+
+
+def _active_dyspozycje_path() -> Path:
+    if wm_root_paths is not None:
         try:
-            print(f"[WM-DBG][DYSP][STORE] migration failed: {exc}")
+            return wm_root_paths.path_dyspozycje()
         except Exception:
             pass
+    return _data_root() / DISP_DIR_NAME / DISP_FILE_NAME
+
+
+def _migrate_legacy_if_needed(target: Path) -> None:
+    legacy_candidates = [
+        _legacy_root_dyspozycje_path(),
+        _legacy_dyspozycje_path(),
+    ]
+    try:
+        target_norm = target.resolve()
+    except Exception:
+        target_norm = target
+
+    for legacy in legacy_candidates:
+        try:
+            if legacy.resolve() == target_norm:
+                continue
+        except Exception:
+            pass
+        if not legacy.exists():
+            continue
+        if target.exists():
+            try:
+                print(
+                    "[WM-DBG][DYSP][STORE][WARN] legacy dyspozycje exists "
+                    f"but active is data dyspozycje: {legacy}"
+                )
+            except Exception:
+                pass
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(legacy, target)
+            print(
+                "[WM-DBG][DYSP][STORE] migrated legacy dyspozycje: "
+                f"{legacy} -> {target}"
+            )
+            return
+        except Exception as exc:
+            try:
+                print(f"[WM-DBG][DYSP][STORE] migration failed: {exc}")
+            except Exception:
+                pass
 
 
 def get_dyspozycje_path() -> Path:
-    path = _anchor_root() / DISP_DIR_NAME / DISP_FILE_NAME
+    path = _active_dyspozycje_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     _migrate_legacy_if_needed(path)
     try:


### PR DESCRIPTION
### Motivation
- Support resolving the active `dyspozycje` storage location from a central provider when available to make path resolution consistent across the app.
- Make migration from older storage locations more robust by considering multiple legacy locations and avoiding accidental self-migration.

### Description
- Add optional import of `core.root_paths` as `wm_root_paths` and new helper function `_active_dyspozycje_path()` to prefer `wm_root_paths.path_dyspozycje()` with a fallback to `data/dyspozycje/dyspozycje.json`.
- Add `_legacy_root_dyspozycje_path()` and expand `_migrate_legacy_if_needed()` to inspect two legacy candidates, skip migration when legacy equals the target, warn when a legacy file exists but the target already exists, and copy the first viable legacy file to the active location.
- Switch `get_dyspozycje_path()` to use `_active_dyspozycje_path()` so the module uses the active path provider when available.

### Testing
- Ran `pytest`, which started the test suite (collected tests) but reported existing failures in the suite; failures appear unrelated to these changes.
- Ran `pytest -q`, which also reported failures and did not change the overall failing test status after this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035228167c832389dd97b039d646b6)