### PR TITLE
Add CommonFieldsStep for dyspozycja wizard

### DIFF
--- a/wm/dyspo_wizard/steps/common_fields.py
+++ b/wm/dyspo_wizard/steps/common_fields.py
@@ -1,0 +1,120 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class CommonFieldsStep(ttk.Frame):
+    def __init__(self, parent, context):
+        super().__init__(parent)
+        self.context = context
+
+        self.columnconfigure(1, weight=1)
+
+        ttk.Label(self, text="Opis *").grid(
+            row=0,
+            column=0,
+            sticky="nw",
+            padx=8,
+            pady=4,
+        )
+
+        self.desc_text = tk.Text(
+            self,
+            height=8,
+            wrap="word",
+        )
+
+        self.desc_text.grid(
+            row=0,
+            column=1,
+            sticky="nsew",
+            padx=8,
+            pady=4,
+        )
+
+        self.desc_text.insert(
+            "1.0",
+            context.get("description", ""),
+        )
+
+        ttk.Label(self, text="Priorytet").grid(
+            row=1,
+            column=0,
+            sticky="w",
+            padx=8,
+            pady=4,
+        )
+
+        self.priority_var = tk.StringVar()
+
+        self.priority_box = tk.OptionMenu(
+            self,
+            self.priority_var,
+            "średnio pilne",
+            "pilne",
+            "średnio pilne",
+            "czas jest",
+        )
+
+        self.priority_box.grid(
+            row=1,
+            column=1,
+            sticky="ew",
+            padx=8,
+            pady=4,
+        )
+
+        self.priority_var.trace_add(
+            "write",
+            self._update_priority_color,
+        )
+
+        current_priority = (
+            context.get("priority")
+            or "średnio pilne"
+        )
+
+        self.priority_var.set(current_priority)
+
+        self._update_priority_color()
+
+    def _update_priority_color(self, *_args):
+        value = str(self.priority_var.get()).strip().lower()
+
+        if value == "pilne":
+            fg = "#ff3b30"
+            bg = "#3a0d0d"
+        elif value == "średnio pilne":
+            fg = "#ffd60a"
+            bg = "#3a3200"
+        else:
+            fg = "#5ac8fa"
+            bg = "#0b2530"
+
+        try:
+            self.priority_box.config(
+                fg=fg,
+                bg=bg,
+                activeforeground=fg,
+                activebackground=bg,
+                highlightbackground=bg,
+            )
+        except Exception:
+            pass
+
+    def collect_data(self):
+        self.context["description"] = (
+            self.desc_text.get("1.0", "end")
+            .strip()
+        )
+
+        self.context["priority"] = (
+            self.priority_var.get().strip()
+        )
+
+        # kompatybilność starego modelu danych
+        # część kodu może nadal oczekiwać title
+        if not self.context.get("title"):
+            desc = self.context["description"]
+            self.context["title"] = (
+                desc[:60] if desc else "Dyspozycja"
+            )


### PR DESCRIPTION
### Motivation
- Provide a reusable wizard step to collect common fields for a dyspozycja (description and priority) and keep compatibility with older data that expects a `title`.

### Description
- Add `wm/dyspo_wizard/steps/common_fields.py` implementing `CommonFieldsStep` as a `ttk.Frame` with a description `Text` control and a priority `OptionMenu`.
- Add dynamic color updates for the priority control using `self.priority_var.trace_add` and the `_update_priority_color` helper.
- Initialize the priority from the incoming `context` or default to `"średnio pilne"`, and persist `description` and `priority` into `context` in `collect_data`.
- Provide a backwards-compatible fallback in `collect_data` that sets `context["title"]` from the first 60 characters of the description or to `"Dyspozycja"` when no title is present.

### Testing
- Ran `pytest`, which started the test suite and surfaced pre-existing GUI test failures; the run did not complete successfully.
- Attempted `pytest -q` in this environment, but the run did not complete to produce a full result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0418fda0088323bd996bb31735530d)