### PR TITLE
Start w trybie Gościa z osadzonym panelem logowania (header popup)

### DIFF
--- a/gui_logowanie.py
+++ b/gui_logowanie.py
@@ -1320,6 +1320,69 @@ def zamknij():
     finally:
         os._exit(0)
 
+
+def open_login_popup(parent, on_success):
+    """Lekki popup logowania do osadzenia w panelu głównym."""
+
+    popup = tk.Toplevel(parent)
+    popup.title("Logowanie")
+    popup.transient(parent)
+    popup.grab_set()
+    popup.resizable(False, False)
+
+    frame = ttk.Frame(popup, padding=12)
+    frame.pack(fill="both", expand=True)
+    ttk.Label(frame, text="Login").grid(row=0, column=0, sticky="w", pady=(0, 4))
+    login_var = tk.StringVar()
+    pin_var = tk.StringVar()
+    login_entry = ttk.Entry(frame, textvariable=login_var, width=30)
+    login_entry.grid(row=1, column=0, sticky="ew", pady=(0, 8))
+    ttk.Label(frame, text="PIN / hasło").grid(row=2, column=0, sticky="w", pady=(0, 4))
+    pin_entry = ttk.Entry(frame, textvariable=pin_var, show="*", width=30)
+    pin_entry.grid(row=3, column=0, sticky="ew", pady=(0, 10))
+
+    def _submit(_event=None):
+        login_display = login_var.get().strip()
+        pin = pin_var.get().strip()
+        if not login_display or not pin:
+            messagebox.showerror("Błąd", "Podaj login i PIN/hasło.", parent=popup)
+            return
+        login_key = login_display.lower()
+        user = authenticate(login_key, pin)
+        selected_profile = None
+        for profile in _load_profiles():
+            profile_login = str(profile.get("login", "")).strip()
+            if profile_login.casefold() == login_display.casefold():
+                selected_profile = profile
+                break
+        if not user and selected_profile is not None:
+            stored_pin = str(selected_profile.get("pin", "")).strip()
+            stored_password = str(selected_profile.get("haslo", "")).strip()
+            if pin and (pin == stored_pin or pin == stored_password):
+                user = {
+                    "login": selected_profile.get("login", login_display),
+                    "rola": selected_profile.get("rola", "pracownik"),
+                    "status": selected_profile.get("status", ""),
+                    "active": selected_profile.get("active", True),
+                }
+        if not user:
+            messagebox.showerror("Błąd", "Nieprawidłowy login lub PIN.", parent=popup)
+            return
+        rola = str(user.get("rola", "pracownik"))
+        login_final = str(user.get("login", login_display))
+        try:
+            ProfileService.set_active_user(login_final)
+        except Exception:
+            pass
+        popup.destroy()
+        on_success(login_final, rola, None)
+
+    ttk.Button(frame, text="Zaloguj", command=_submit).grid(row=4, column=0, sticky="e")
+    frame.columnconfigure(0, weight=1)
+    login_entry.focus_set()
+    popup.bind("<Return>", _submit)
+    return popup
+
 if __name__ == "__main__":
     root = tk.Tk()
     ekran_logowania(root)

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -746,13 +746,26 @@ def uruchom_panel(root, login, rola):
             dot.place(relx=1, x=-4, y=4, anchor="ne")
             markers.append(dot)
 
+    def _is_guest_role(role_value) -> bool:
+        return str(role_value or "").strip().lower() in {"guest", "gość", "gosc", ""}
+
+    is_guest = _is_guest_role(rola)
+
     side  = ttk.Frame(root, style="WM.Side.TFrame", width=220); side.pack(side="left", fill="y")
     main  = ttk.Frame(root, style="WM.TFrame");               main.pack(side="right", fill="both", expand=True)
 
     header  = ttk.Frame(main, style="WM.TFrame");      header.pack(fill="x", padx=12, pady=(10,6))
     ttk.Label(header, text="Panel główny", style="WM.H1.TLabel").pack(side="left")
     # NOWE: czytelny login/rola po prawej stronie nagłówka
-    ttk.Label(header, text=f"{login} ({rola})", style="WM.Muted.TLabel").pack(side="right")
+    session_wrap = ttk.Frame(header, style="WM.TFrame")
+    session_wrap.pack(side="right")
+    session_var = tk.StringVar(
+        master=root,
+        value="Niezalogowany / Gość" if is_guest else f"{login} ({rola})",
+    )
+    ttk.Label(session_wrap, textvariable=session_var, style="WM.Muted.TLabel").pack(
+        side="left", padx=(0, 8)
+    )
 
     root_status_text, root_status_warn = _wm_build_root_status_text()
     root_status_var = tk.StringVar(master=root, value=root_status_text)
@@ -789,21 +802,25 @@ def uruchom_panel(root, login, rola):
 
     # prawa część: stałe przyciski
     def _logout():
-        """Powrót do ekranu logowania + opcjonalne oznaczenie wylogowania."""
-        # heartbeat logout if available
+        """Wylogowanie do trybu gościa."""
         try:
             from presence import heartbeat
             heartbeat(login, rola, logout=True)
         except Exception:
             pass
+        uruchom_panel(root, login="Gość", rola="guest")
+
+    def _open_login_popup():
         try:
             import gui_logowanie
-            gui_logowanie.ekran_logowania(root)
-        except Exception:
-            try:
-                root.destroy()
-            except Exception:
-                pass
+            gui_logowanie.open_login_popup(
+                root,
+                on_success=lambda login_new, rola_new, extra=None: uruchom_panel(
+                    root, login_new, rola_new
+                ),
+            )
+        except Exception as exc:
+            messagebox.showerror("Logowanie", f"Nie można otworzyć okna logowania: {exc}")
     changelog_win = {"ref": None}
     btn_changelog = None
 
@@ -888,8 +905,10 @@ def uruchom_panel(root, login, rola):
     btn_changelog.pack(side="right", padx=(6, 0))
     _maybe_mark_button(btn_changelog)
     root.after(100, lambda: _toggle_changelog(auto=True))
+    session_btn_text = "Zaloguj" if is_guest else "Wyloguj"
+    session_btn_cmd = _open_login_popup if is_guest else _logout
     ttk.Button(
-        footer_btns, text="Wyloguj", command=_logout, style="WM.Side.TButton"
+        footer_btns, text=session_btn_text, command=session_btn_cmd, style="WM.Side.TButton"
     ).pack(side="right", padx=(6, 0))
     # --- licznik automatycznego wylogowania ---
     try:
@@ -1226,6 +1245,8 @@ def uruchom_panel(root, login, rola):
             pad = (12, 6) if start_panel is None else 6
 
             role_allowed = not (key in {"uzytkownicy", "ustawienia"} and not is_admin)
+            if is_guest and key in {"ustawienia", "uzytkownicy", "magazyn", "narzedzia", "planowanie"}:
+                role_allowed = False
             if key == "planowanie":
                 role_allowed = str(rola).strip().lower() in {"admin", "administrator", "kierownik", "brygadzista"}
             jarvis_allowed = can_access_jarvis(profile) if key == "jarvis" else True

--- a/start.py
+++ b/start.py
@@ -65,6 +65,17 @@ def _feature_flag_enabled(value, *, default: bool = True) -> bool:
     return bool(value)
 
 
+def _auth_flag(config_manager, key: str, default: bool) -> bool:
+    """Odczytaj flagę auth.* z ConfigManager z łagodnym fallbackiem."""
+
+    try:
+        if config_manager is None:
+            return default
+        return _feature_flag_enabled(config_manager.get(key, default), default=default)
+    except Exception:
+        return default
+
+
 ROOT_SNAPSHOT = None
 
 
@@ -955,7 +966,19 @@ def main():
             traceback.print_exc()
             _error("Błąd auto-logowania – przechodzę do standardowego ekranu logowania")
 
-        if not auto_logged:
+        embedded_login = _auth_flag(CONFIG_MANAGER, "auth.embedded_login", False)
+        guest_start = _auth_flag(CONFIG_MANAGER, "auth.guest_start", True)
+
+        if embedded_login and guest_start and not auto_logged:
+            try:
+                import gui_panel
+                gui_panel.uruchom_panel(root, login="Gość", rola="guest")
+            except Exception:
+                traceback.print_exc()
+                _error("Błąd uruchomienia trybu gościa – przechodzę do pełnego logowania")
+                embedded_login = False
+
+        if not auto_logged and not (embedded_login and guest_start):
             import gui_logowanie
 
             returned_root = gui_logowanie.ekran_logowania(


### PR DESCRIPTION
### Motivation
- Umożliwić uruchomienie aplikacji od razu w trybie podglądu/gościa bez pełnoekranowego ekranu logowania przy zachowaniu starego ekranu jako fallback.
- Dodać mały, wygodny panel logowania w prawym górnym rogu, który otwiera popup logowania bez niszczenia głównego okna.

### Description
- Dodano obsługę flag konfiguracyjnych `auth.embedded_login` i `auth.guest_start` oraz helper ` _auth_flag` w `start.py`, i gdy obie są aktywne uruchamiany jest panel główny w trybie gościa przez `gui_panel.uruchom_panel(root, login="Gość", rola="guest")`, przy czym stare wywołanie `gui_logowanie.ekran_logowania` pozostawiono jako fallback.
- W `gui_logowanie.py` dodano funkcję `open_login_popup(parent, on_success)` tworzącą lekki `Toplevel` z polami login/PIN/hasło, która korzysta z istniejącej logiki uwierzytelniania i wywołuje `on_success(login, rola, extra)` po poprawnym logowaniu.
- W `gui_panel.py` dodano wykrywanie roli gościa, panel sesji w prawym górnym nagłówku (etykieta sesji i przycisk kontekstowy) oraz mechanikę przycisku: dla gościa `Zaloguj` otwiera popup (`open_login_popup`), a dla zalogowanego `Wyloguj` przełącza na sesję `Gość` bez niszczenia głównego okna.
- W `gui_panel.py` wprowadzono ograniczenie dostępu w trybie gościa: moduły edycyjne/administracyjne (`ustawienia`, `uzytkownicy`, `magazyn`, `narzedzia`, `planowanie`) są blokowane dla roli `guest` (bez możliwości zapisu/edycji z poziomu UI).

### Testing
- Uruchomiono `pytest -q --maxfail=5` i całościowo `pytest -q`; testy zakończyły się częściowo niepowodzeniem z wynikiem `5 failed, 11 passed, 5 skipped`.
- Failures wystąpiły w testach GUI/logowania związanych z uruchomieniem `tkinter` w środowisku headless (`no DISPLAY`) i jednej asercji sprawdzającej obsługę błędu callbacku logowania; uruchomione polecenie: `pytest -q --maxfail=5` (zrzut wyników do logów).
- Pozostałe testy uruchomiły się i przeszły zgodnie z raportem testowym; dalsze dostosowanie testów GUI w środowisku CI/headless lub drobna poprawka obsługi błędów w `gui_logowanie.logowanie` może być potrzebna do pełnego zielonego passu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041bb98ed883238df4051699b33992)