### PR TITLE
Handle unavailable git log when loading patch commits

### DIFF
--- a/tools/patcher.py
+++ b/tools/patcher.py
@@ -111,16 +111,23 @@ def get_commits(limit: int = 20, branch: str = "Rozwiniecie") -> List[Tuple[str,
     """
     cmd = ["git", "log", f"-n{limit}", "--format=%H%x09%s", branch]
     try:
-        result = _run(cmd)
+        result = subprocess.check_output(
+            cmd,
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
     except Exception as exc:
+        print(f"[WM-DBG][PATCHER][GIT] git log unavailable: {exc}")
         logger.warning(
             "[PATCHER] get_commits failed for branch=%s: %s",
             branch,
             exc,
         )
         return []
+    if not result.strip():
+        return []
     commits: List[Tuple[str, str]] = []
-    for line in result.stdout.strip().splitlines():
+    for line in result.strip().splitlines():
         commit_hash, message = line.split("\t", 1)
         commits.append((commit_hash, message))
     _append_audit(


### PR DESCRIPTION
### Motivation
- Make `get_commits()` in the patching utilities resilient when `git log` is unavailable or returns no output, so UI code that lists patch commits can fail gracefully.

### Description
- Replace internal `_run(cmd)` usage with a direct `subprocess.check_output(...)` call in `tools/patcher.py::get_commits()` and capture `stderr` by passing `stderr=subprocess.STDOUT`.
- Print a small WM debug message on failure and log a warning when `git log` cannot be executed or raises an exception using `print()` and `logger.warning()`.
- Return an empty list early when the command returns empty output via `if not result.strip(): return []` to avoid downstream errors.
- Adjust parsing to operate on the plain text result (`result.strip().splitlines()`) instead of `result.stdout`.

### Testing
- Ran `pytest -q tests/test_patcher.py` which passed (`2 passed`).
- Started a full `pytest -q` run which exhibited unrelated, preexisting failures in other tests and therefore does not reflect this change's test impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044ae91f4c83238887a5ceb823deb0)