### PR TITLE
Embedded guest start + login/logout in top-right header

### DIFF
--- a/config.defaults.json
+++ b/config.defaults.json
@@ -32,7 +32,9 @@
     "pin_length": 4,
     "pinless_brygadzista": false,
     "auto_login_enabled": false,
-    "auto_login_profile": ""
+    "auto_login_profile": "",
+    "embedded_login": true,
+    "guest_start": true
   },
   "paths": {
     "data_root": "data",

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -908,8 +908,8 @@ def uruchom_panel(root, login, rola):
     session_btn_text = "Zaloguj" if is_guest else "Wyloguj"
     session_btn_cmd = _open_login_popup if is_guest else _logout
     ttk.Button(
-        footer_btns, text=session_btn_text, command=session_btn_cmd, style="WM.Side.TButton"
-    ).pack(side="right", padx=(6, 0))
+        session_wrap, text=session_btn_text, command=session_btn_cmd, style="WM.Side.TButton"
+    ).pack(side="left")
     # --- licznik automatycznego wylogowania ---
     try:
         cm = globals().get("CONFIG_MANAGER")


### PR DESCRIPTION
### Motivation
- Umożliwić uruchamianie programu od razu w trybie podglądu/gościa z małym panelem logowania w prawym górnym rogu, przy minimalnych zmianach i zachowaniu pełnoekranowego ekranu logowania jako fallback.

### Description
- Dodano domyślne flagi `auth.embedded_login` i `auth.guest_start` w `config.defaults.json` oraz przeniesiono przycisk `Zaloguj`/`Wyloguj` z stopki do nagłówka (`session_wrap`) w `gui_panel.py`, przy czym istniejąca logika popupu logowania (`gui_logowanie.open_login_popup`) i pełnoekranowego loginu pozostała bez zmian.

### Testing
- Uruchomiono `pytest -q tests/test_start_auto_login.py tests/test_gui_panel_permissions.py` które przeszły (`2 passed, 3 skipped`), a próba uruchomienia pełnego `pytest -q` została rozpoczęta w tym środowisku, ale nie dokończono jej z powodu limitów czasu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044e7e80a48323a772403f63dec4ff)