### PR TITLE
Zablokuj moduł Dyspozycje dla gościa i otwieraj kreator w pełnym oknie

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -70,8 +70,12 @@ def open_dyspozycje_creator(
     root = master.winfo_toplevel() if master else None
     win = tk.Toplevel(root)
     win.title("Kreator – Edytuj Dyspozycję" if edit_mode else "Kreator – Dodaj Dyspozycję")
-    win.geometry("700x500")
-    win.resizable(False, False)
+    win.geometry("1200x800")
+    win.resizable(True, True)
+    try:
+        win.state("zoomed")
+    except Exception:
+        win.attributes("-zoomed", True)
 
     frame = ttk.Frame(win, padding=12)
     frame.pack(fill="both", expand=True)

--- a/gui_panel.py
+++ b/gui_panel.py
@@ -1245,7 +1245,7 @@ def uruchom_panel(root, login, rola):
             pad = (12, 6) if start_panel is None else 6
 
             role_allowed = not (key in {"uzytkownicy", "ustawienia"} and not is_admin)
-            if is_guest and key in {"ustawienia", "uzytkownicy", "magazyn", "narzedzia", "planowanie"}:
+            if is_guest and key in {"ustawienia", "uzytkownicy", "magazyn", "narzedzia", "planowanie", "zlecenia"}:
                 role_allowed = False
             if key == "planowanie":
                 role_allowed = str(rola).strip().lower() in {"admin", "administrator", "kierownik", "brygadzista"}


### PR DESCRIPTION
### Motivation
- Użytkownik gość powinien nie mieć dostępu do modułu Dyspozycje z panelu bocznego; kreator dyspozycji powinien otwierać się jako pełne okno.

### Description
- W `gui_panel.py` dodano `"zlecenia"` do listy modułów blokowanych dla roli gościa, co uniemożliwia otwarcie modułu Dyspozycje z panelu bocznego.
- W `gui_dyspozycje_creator.py` zmieniłem początkową geometrię okna na `1200x800` i ustawiłem `win.resizable(True, True)` aby okno było skalowalne.
- Dodałem próbę maksymalizacji okna przez `win.state("zoomed")` z fallbackiem na `win.attributes("-zoomed", True)` dla systemów, gdzie `state("zoomed")` nie jest wspierane.

### Testing
- Uruchomiono `pytest -q` i `pytest -q -x` po zmianach, testy uruchomiły się automatycznie.
- Testy GUI zależne od środowiska graficznego zakończyły się niepowodzeniem w tym środowisku, konkretnie `test_gui_logowanie.py::test_logowanie_success` zgłaszał błąd `TclError: no display name and no $DISPLAY`/`RuntimeError: No master specified` (headless CI/CLI), co uniemożliwiło pełne zielone przejście.
- Poza problemami środowiskowymi związanymi z brakiem wyświetlacza, pozostałe testy uruchomione lokalnie przeszły zgodnie z raportem (`8 passed, 1 failed, 5 skipped` w bieżącej sesji testowej).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0452dba96c832384e8a0b3ad9fae59)