### PR TITLE
Enable fullscreen mode on main panel with Esc/F11 toggles

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -703,6 +703,18 @@ def uruchom_panel(root, login, rola):
     root.title(
         f"Warsztat Menager v{APP_VERSION} - zalogowano jako {login} ({rola})"
     )
+    try:
+        root.attributes("-fullscreen", True)
+    except Exception:
+        try:
+            root.state("zoomed")
+        except Exception:
+            pass
+    try:
+        root.bind("<Escape>", lambda _event: root.attributes("-fullscreen", False))
+        root.bind("<F11>", lambda _event: root.attributes("-fullscreen", not bool(root.attributes("-fullscreen"))))
+    except Exception:
+        pass
     clear_frame(root)
     if _register_notification_root is not None:
         try:


### PR DESCRIPTION
### Motivation
- Start the main GUI panel in fullscreen when supported and provide simple keyboard controls to improve usability and window management.

### Description
- In `uruchom_panel` (in `gui_panel.py`) set `root.attributes("-fullscreen", True)` with a fallback to `root.state("zoomed")`, and bind `<Escape>` to exit fullscreen and `<F11>` to toggle fullscreen, all wrapped in `try/except` to preserve compatibility.

### Testing
- Ran `pytest` from the repository root; the test suite started but reported existing GUI-related failures (for example in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`) and no new tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045ab74a948323bd49b8944108b9cb)