### PR TITLE
Sidebar: use role-based permission check and fix effective modules filtering

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -1280,7 +1280,6 @@ def uruchom_panel(root, login, rola):
                 module_allowed = module_allowed and can_access_jarvis(profile)
             enabled = (
                 _module_is_active(key)
-                and key in allowed_modules
                 and module_allowed
             )
 

--- a/wm_access.py
+++ b/wm_access.py
@@ -490,6 +490,10 @@ def get_effective_allowed_modules(login: str, all_modules: list[str]) -> list[st
     if not isinstance(all_modules, (list, tuple, set)):
         all_modules = []
     normalized_all = [normalize_module_name(module) for module in all_modules]
+    disabled = {
+        normalize_module_name(module)
+        for module in get_disabled_modules_for(login)
+    }
     skip = {"panel_glowny"}
     try:
         _manifest = zaladuj_manifest()
@@ -500,6 +504,6 @@ def get_effective_allowed_modules(login: str, all_modules: list[str]) -> list[st
         for module in normalized_all
         if module
         and module not in skip
-        and is_module_allowed_for_user(login, "", module)
+        and module not in disabled
         and module_active(module, manifest=_manifest)
     ]


### PR DESCRIPTION
### Motivation
- Sidebar was combining two permission sources and could block modules that were allowed by role permissions saved in Rangi, so it must rely on a single source of truth: `is_module_allowed_for_user(login, normalized_role, key)` plus global manifest activity.
- `get_effective_allowed_modules(login, all_modules)` incorrectly queried `is_module_allowed_for_user(login, "", module)` (empty role normalizes to guest) and therefore could wrongly filter modules; it should only apply manifest activity and per-user `disabled_modules` for compatibility.

### Description
- Removed the legacy gate `and key in allowed_modules` from sidebar enablement logic in `gui_panel.py`, leaving `enabled` computed from ` _module_is_active(key)` and `is_module_allowed_for_user(login, normalized_role, key)` (with the existing `jarvis` special-case left intact).
- Rewrote `get_effective_allowed_modules(login, all_modules)` in `wm_access.py` to compute `disabled = {normalize_module_name(module) for module in get_disabled_modules_for(login)}` and replace the previous `is_module_allowed_for_user(login, "", module)` check with `module not in disabled`, while preserving `module_active(...)` and the `skip` set.
- Preserved behavior of `disabled_modules` as an individual per-user block and kept other constraints (manifest/global activity and `panel_glowny` skip) unchanged.

### Testing
- Ran `pytest` which collected `269` tests (with `4` skipped) and reported failures in GUI-related tests such as `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`, so the full suite did not pass in this environment.
- Ran `pytest -q` which also showed multiple failing tests (`F` markers); the modified code paths were exercised during the run and no new targeted tests were added specifically for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b12306bc8323a8de770026e3aea8)