### PR TITLE
Rozszerz wybór ról użytkownika w panelu GUI

### DIFF
--- a/gui_uzytkownicy.py
+++ b/gui_uzytkownicy.py
@@ -22,6 +22,7 @@ try:
         set_modules_visibility_map,
         load_profiles,
         save_profiles,
+        normalize_role_name,
     )
 except Exception:  # pragma: no cover - fallback, gdy moduł nie istnieje
     def get_disabled_modules_for(_login: str):
@@ -29,6 +30,9 @@ except Exception:  # pragma: no cover - fallback, gdy moduł nie istnieje
 
     def set_modules_visibility_map(_login: str, _show_map: dict):
         pass
+
+    def normalize_role_name(role: str) -> str:
+        return str(role or "").strip().lower()
 
     def load_profiles():
         return {}
@@ -115,6 +119,28 @@ SHIFT_MODE_CHOICES = {
     "Stała 2 zmiana (14:00–22:00)": "222",
     "Rotacja 1 → 2 → 1": "121",
     "Rotacja 2 → 1 → 2": "212",
+}
+
+ROLE_LABELS = [
+    ("administrator", "Administrator"),
+    ("kierownik", "Kierownik"),
+    ("brygadzista", "Brygadzista"),
+    ("operator", "Operator / Ślusarz"),
+    ("student", "Student"),
+    ("sezonowiec", "Sezonowiec"),
+    ("guest", "Gość"),
+]
+
+ROLE_KEYS = [role_key for role_key, _label in ROLE_LABELS]
+
+LEGACY_ROLE_ALIASES = {
+    "admin": "administrator",
+    "administrator": "administrator",
+    "user": "operator",
+    "uzytkownik": "operator",
+    "użytkownik": "operator",
+    "pracownik": "operator",
+    "serwisant": "operator",
 }
 
 
@@ -486,18 +512,23 @@ def _profile_display_name(profile: dict) -> str:
 
 
 def _role_to_choice(role: str | None) -> str:
-    """Normalizuje rolę na wartość UI ('admin' lub 'user')."""
+    """Normalizuje rolę profilu na klucz z nowej listy rang."""
 
     normalized = str(role or "").strip().lower()
-    if normalized in {"administrator", "admin"}:
-        return "admin"
-    return "user"
+    normalized = LEGACY_ROLE_ALIASES.get(normalized, normalized)
+    try:
+        normalized = normalize_role_name(normalized)
+    except Exception:
+        pass
+    return normalized if normalized in ROLE_KEYS else "operator"
 
 
 def _choice_to_role(choice: str) -> str:
     """Mapuje wartość z UI na zapis w profilu."""
 
-    return "administrator" if str(choice).strip().lower() == "admin" else "uzytkownik"
+    normalized = str(choice or "").strip().lower()
+    normalized = LEGACY_ROLE_ALIASES.get(normalized, normalized)
+    return normalized if normalized in ROLE_KEYS else "operator"
 
 
 def _slugify_login(name: str) -> str:
@@ -665,8 +696,8 @@ def panel_uzytkownicy(root, frame, login=None, rola=None):
         login_var = tk.StringVar(value=original_login)
         name_var = tk.StringVar(value=_profile_display_name(seed))
         role_var = tk.StringVar(value=_role_to_choice(seed.get("rola") or seed.get("role")))
-        if role_var.get() not in {"admin", "user"}:
-            role_var.set("user")
+        if role_var.get() not in ROLE_KEYS:
+            role_var.set("operator")
         pin_var = tk.StringVar(value=str(seed.get("pin", "")))
         shift_mode_var = tk.StringVar(
             value=_shift_mode_label_from_code(seed.get("tryb_zmian", "111"))
@@ -688,7 +719,7 @@ def panel_uzytkownicy(root, frame, login=None, rola=None):
         ttk.Label(form, text="Rola:").grid(row=2, column=0, sticky="w")
         role_combo = ttk.Combobox(
             form,
-            values=["admin", "user"],
+            values=ROLE_KEYS,
             textvariable=role_var,
             state="readonly",
         )
@@ -758,9 +789,9 @@ def panel_uzytkownicy(root, frame, login=None, rola=None):
                 return
 
             role_choice = role_var.get().strip().lower()
-            if role_choice not in {"admin", "user"}:
-                role_choice = "user"
-                role_var.set("user")
+            if role_choice not in ROLE_KEYS:
+                role_choice = "operator"
+                role_var.set("operator")
 
             pin_value = pin_var.get().strip()
             profiles_map = dict(state.get("profiles", {}))


### PR DESCRIPTION
### Motivation
- Rozszerzyć model ról w panelu użytkowników oraz zapewnić zgodność wsteczną ze starymi nazwami ról i odporność na brak modułu `wm_access`.

### Description
- Dodano import `normalize_role_name` z `wm_access` oraz lokalny fallback, aby normalizacja ról działała bez tej zależności.
- Wprowadzono `ROLE_LABELS`, `ROLE_KEYS` oraz `LEGACY_ROLE_ALIASES` definiujące nowy zestaw ról i mapowanie aliasów legacy na wartości kanoniczne.
- Zmieniono `_role_to_choice` oraz `_choice_to_role`, aby wykorzystywały aliasy i normalizację, zwracając `"operator"` jako domyślny fallback.
- Zaktualizowano formularz edycji użytkownika, aby `Combobox` używał `ROLE_KEYS` oraz aby walidacja i zapisywanie ról fallbackowały do `"operator"`.

### Testing
- Uruchomiono `pytest -x -q`; testy zatrzymały się z 1 niepowodzeniem a pozostałe testy przeszły lub zostały pominięte, ponieważ test suite napotkał błąd środowiskowy GUI.
- Niepowodzenie dotyczy `test_gui_logowanie.py::test_logowanie_success` z błędem Tkintera: `TclError: no display name and no $DISPLAY environment variable`; pozostałe wyniki z tej sesji: 1 failed, 8 passed, 5 skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e07756208323bac70162bce81238)