### PR TITLE
Kolorowanie listy narzędzi według postępu

### DIFF
--- a/narzedzia_ui/list_panel.py
+++ b/narzedzia_ui/list_panel.py
@@ -181,6 +181,32 @@ def _tool_progress_pct(tool: Mapping[str, Any]) -> str:
     return f"{pct}%"
 
 
+def _progress_value(progress_text: str) -> int:
+    """Zwraca liczbę 0-100 z tekstu typu '75%'."""
+
+    raw = str(progress_text or "").strip().replace("%", "")
+    try:
+        value = int(float(raw.replace(",", ".")))
+    except (TypeError, ValueError):
+        value = 0
+    return max(0, min(100, value))
+
+
+def _progress_tag(progress_text: str) -> str:
+    """Dobiera tag koloru do postępu narzędzia."""
+
+    progress = _progress_value(progress_text)
+    if progress <= 0:
+        return "progress_0"
+    if progress < 50:
+        return "progress_low"
+    if progress < 90:
+        return "progress_mid"
+    if progress < 100:
+        return "progress_high"
+    return "progress_done"
+
+
 REFRESH_INTERVAL_SECONDS = 30
 
 
@@ -620,6 +646,15 @@ class ToolsThreeTabsView(ttk.Frame):
             )
             self.tv_inprog.column(column, width=widths.get(column, 120), anchor="w")
 
+        # Kolory postępu w zakładce "Narzędzia".
+        # Tkinter Treeview koloruje tagiem cały wiersz, nie pojedynczą komórkę,
+        # więc celowo kolorujemy cały rekord według kolumny "Postęp".
+        self.tv_inprog.tag_configure("progress_0", foreground="#9ca3af")
+        self.tv_inprog.tag_configure("progress_low", foreground="#f87171")
+        self.tv_inprog.tag_configure("progress_mid", foreground="#facc15")
+        self.tv_inprog.tag_configure("progress_high", foreground="#86efac")
+        self.tv_inprog.tag_configure("progress_done", foreground="#22c55e")
+
     def _build_tab_all(self) -> None:
         top = ttk.Frame(self.tab_all)
         top.pack(fill="x", padx=8, pady=6)
@@ -813,16 +848,18 @@ class ToolsThreeTabsView(ttk.Frame):
         self._clear_tree(self.tv_inprog)
         for tool in tools:
             active, total = _tool_tasks_counts(tool)
+            progress_text = _tool_progress_pct(tool)
             self.tv_inprog.insert(
                 "",
                 "end",
+                tags=(_progress_tag(progress_text),),
                 values=(
                     _tool_id(tool),
                     _tool_name(tool),
                     _tool_type_label(tool),
                     _tool_status_label(tool),
                     _pretty_dt(_tool_current_visit_start(tool)),
-                    _tool_progress_pct(tool),
+                    progress_text,
                     f"{active}/{total}",
                     str(_tool_visits_count(tool)),
                 ),


### PR DESCRIPTION
### Motivation
- Ułatwić szybkie rozpoznanie stanu realizacji narzędzi na liście „W toku” przez zastosowanie kolorów zależnych od wartości postępu.
- Tkinter `Treeview` pozwala na kolorowanie całego wiersza za pomocą tagów, więc kolor przypisany jest do rekordu zgodnie z kolumną „Postęp”.

### Description
- Dodano `_progress_value(progress_text)` do bezpiecznego parsowania wartości postępu (np. `75%`, `75,5%`) i ograniczania jej do zakresu `0–100`.
- Dodano `_progress_tag(progress_text)` mapujące wartość postępu na tagi kolorów: `progress_0`, `progress_low`, `progress_mid`, `progress_high`, `progress_done`.
- Skonfigurowano kolory tagów na `tv_inprog` w zakładce „Narzędzia” i podczas wstawiania wierszy przypisano odpowiedni tag według wyliczonego `progress_text`.
- Przy wstawianiu wierszy użyto pojedynczego obliczenia `progress_text` (zamiast dublowania wywołań) i tej samej wartości umieszczono w kolumnie „Postęp”.

### Testing
- Uruchomiono pełny zestaw testów za pomocą `pytest -q`, który wykazał istniejące wcześniej błędy niezwiązane z tą zmianą (suite zawiera wiele porzuconych/niezaliczonych testów).
- Uruchomiono wybrane testy `pytest -q test_gui_narzedzia_config.py test_gui_narzedzia_tasks.py`, które zakończyły się z jednym niepowodzeniem: `test_gui_narzedzia_config.py::test_load_config_logs` oraz czterema zaliczonymi testami.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae6bf972c8323a95841da3ffd1db9)