### PR TITLE
Wyróżnienie bieżącego dnia w kalendarzu planowania

### DIFF
--- a/gui_planowanie.py
+++ b/gui_planowanie.py
@@ -354,14 +354,30 @@ class PlanowanieUI:
             ttk.Label(week_hdr, text=day_name).pack(side="left", fill="x", expand=True)
 
         month_matrix = calendar.Calendar(firstweekday=0).monthdatescalendar(self.calendar_year, self.calendar_month)
+        today = date.today()
         for row_idx, week in enumerate(month_matrix):
             row = ttk.Frame(self.cal_frame)
             row.pack(fill="both", expand=True, pady=2)
             for day in week:
-                tile = tk.Frame(row, relief="groove", borderwidth=1, bg="#1f2937")
+                is_today = day == today
+                is_current_month = day.month == self.calendar_month
+                bg = "#fff3b0" if is_today else ("#1f2937" if is_current_month else "#111827")
+                fg = "#111827" if is_today else "white"
+                border = 3 if is_today else 1
+                highlight = "#f39c12" if is_today else "#374151"
+
+                tile = tk.Frame(
+                    row,
+                    relief="solid" if is_today else "groove",
+                    borderwidth=border,
+                    bg=bg,
+                    highlightthickness=2 if is_today else 0,
+                    highlightbackground=highlight,
+                )
                 tile.pack(side="left", fill="both", expand=True, padx=1, pady=1)
                 tile.bind("<Button-1>", lambda _e, d=day: self._open_day_plan(d))
-                tk.Label(tile, text=f"{day.day}", fg="white", bg="#1f2937", anchor="w", font=("Arial", 12, "bold")).pack(fill="x")
+                day_title = f"{day.day}  DZISIAJ" if is_today else f"{day.day}"
+                tk.Label(tile, text=day_title, fg=fg, bg=bg, anchor="w", font=("Arial", 12, "bold")).pack(fill="x")
                 for order in self.store.data.get("orders", []):
                     for st in order.get("stages", []):
                         s = _parse_dt(st.get("start"))


### PR DESCRIPTION
### Motivation
- Ułatwić użytkownikom szybkie zlokalizowanie aktualnej daty w widoku kalendarza poprzez wyraźne wyróżnienie kafelka bieżącego dnia.
- Poprawić czytelność siatki miesiąca przez wizualne odróżnienie dni spoza aktualnego miesiąca.

### Description
- Zmieniono renderowanie w `PlanowanieUI._render_calendar` aby obliczać `today = date.today()` i porównywać z datą każdego kafelka. 
- Dodano flagi `is_today` i `is_current_month` oraz przypisanie stylów `bg`, `fg`, `border` i `highlight` zależnie od stanu dnia. 
- Kafelek bieżącego dnia otrzymuje `relief="solid"`, grubszą ramkę i obrys oraz etykietę `DZISIAJ` obok numeru dnia. 
- Dni spoza aktualnego miesiąca mają ciemniejsze tło, a logika wyświetlania zleceń w kafelku pozostała bez zmian.

### Testing
- Uruchomiono `pytest` i proces testowy uruchomiony lokalnie wskazał istniejące, niepowiązane wcześniej błędy w innych modułach testowych. 
- Próba uruchomienia `pytest -q` z limitem czasowym zakończyła się przekroczeniem limitu (timeout), więc pełne zielone przejście testów nie zostało osiągnięte w środowisku CI/sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b07edbc108323a7031c45a334ea0b)