### PR TITLE
Dodaj wyszukiwanie w panelu maszyn i opcję zamknięcia dyspozycji

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -13,7 +13,12 @@ from dyspozycje_sources import (
     load_tool_choices,
     load_zlecenie_wykonania_choices,
 )
-from dyspozycje_store import add_dyspozycja, make_dyspozycja, update_dyspozycja
+from dyspozycje_store import (
+    add_dyspozycja,
+    close_dyspozycja,
+    make_dyspozycja,
+    update_dyspozycja,
+)
 
 try:
     from profiles_store import load_profiles_users, resolve_profiles_path
@@ -222,6 +227,46 @@ def open_dyspozycje_creator(
     btns = ttk.Frame(win, padding=(12, 0, 12, 12))
     btns.pack(fill="x")
 
+    def _event_updated() -> None:
+        try:
+            win.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
+        except Exception:
+            pass
+
+    def _actor_login() -> str:
+        for candidate in (
+            autor,
+            ctx.get("autor"),
+            getattr(root, "active_login", ""),
+            getattr(root, "_wm_login", ""),
+            getattr(root, "login", ""),
+        ):
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return ""
+
+    def _close_current() -> None:
+        if not edit_mode or not existing_id:
+            return
+        if not messagebox.askyesno(
+            "Dyspozycje",
+            "Zamknąć tę dyspozycję?",
+            parent=win,
+        ):
+            return
+        changed = close_dyspozycja(existing_id, closed_by=_actor_login())
+        if not changed:
+            messagebox.showerror(
+                "Dyspozycje",
+                "Nie udało się zamknąć Dyspozycji.",
+                parent=win,
+            )
+            return
+        _event_updated()
+        messagebox.showinfo("Dyspozycje", "Dyspozycja została zamknięta.", parent=win)
+        win.destroy()
+
     def _save() -> None:
         selected_label = var_object_display.get().strip()
         object_id = options_map.get(selected_label, "").strip()
@@ -261,11 +306,7 @@ def open_dyspozycje_creator(
             item = make_dyspozycja(**payload)
             add_dyspozycja(item)
 
-        try:
-            # NOWY event dla Dyspozycji (zamiast OrdersUpdated)
-            win.winfo_toplevel().event_generate("<<DyspozycjeUpdated>>", when="tail")
-        except Exception:
-            pass
+        _event_updated()
         messagebox.showinfo(
             "Dyspozycje",
             "Dyspozycja została zaktualizowana." if edit_mode else "Dyspozycja została zapisana.",
@@ -275,6 +316,10 @@ def open_dyspozycje_creator(
 
     ttk.Button(btns, text="Anuluj", command=win.destroy).pack(side="right", padx=(8, 0))
     ttk.Button(btns, text="Zapisz", command=_save).pack(side="right")
+    if edit_mode and existing_id:
+        ttk.Button(btns, text="Zamknij dyspozycję", command=_close_current).pack(
+            side="left"
+        )
 
     cb_object.focus_set()
     win.transient(root)

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1622,8 +1622,15 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
     info = tk.StringVar(value="Maszyny")
     ttk.Label(toolbar, textvariable=info).pack(side="left")
 
+    search_var = tk.StringVar(value="")
+    ttk.Label(toolbar, text="Szukaj:").pack(side="left", padx=(12, 4))
+    entry_search = ttk.Entry(toolbar, textvariable=search_var, width=28)
+    entry_search.pack(side="left", padx=(0, 6))
+    btn_clear_search = ttk.Button(toolbar, text="Wyczyść")
+    btn_clear_search.pack(side="left", padx=(0, 8))
+
     filter_var = tk.StringVar(value="Wszystkie")
-    ttk.Label(toolbar, text="Filtr:").pack(side="left", padx=(12, 4))
+    ttk.Label(toolbar, text="Filtr:").pack(side="left", padx=(4, 4))
     filter_box = ttk.Combobox(
         toolbar,
         state="readonly",
@@ -1745,6 +1752,7 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
     def _recompute_visible_rows() -> None:
         nonlocal visible_rows
         mode = filter_var.get()
+        query = search_var.get().strip().lower()
 
         def predicate(machine: Dict[str, Any]) -> bool:
             key = _schedule_status_key(machine)
@@ -1758,7 +1766,39 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
                 return key == "done"
             return True
 
-        visible_rows = [row for row in rows_cache if predicate(row)]
+        def matches_search(machine: Dict[str, Any]) -> bool:
+            if not query:
+                return True
+            summary = machine.get("__schedule_summary") or {}
+            haystack = " ".join(
+                str(value or "")
+                for value in (
+                    machine.get("id"),
+                    machine.get("nr_ewid"),
+                    machine.get("nr"),
+                    machine.get("nazwa"),
+                    machine.get("typ"),
+                    machine.get("status"),
+                    machine.get("lokalizacja"),
+                    summary.get("next_label"),
+                    summary.get("status_label"),
+                )
+            ).lower()
+            return query in haystack
+
+        visible_rows = [
+            row for row in rows_cache if predicate(row) and matches_search(row)
+        ]
+
+    def _focus_first_machine_row() -> bool:
+        children = tree.get_children("")
+        if not children:
+            return False
+        first = children[0]
+        tree.selection_set(first)
+        tree.focus(first)
+        tree.see(first)
+        return True
 
     def _find_machine(machine_id: Optional[str]) -> Optional[Dict]:
         if not machine_id:
@@ -1858,6 +1898,27 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
                 _populate_details(_find_machine(selected_machine_id))
             else:
                 _populate_details(None)
+
+    def _apply_search(*_args) -> None:
+        _apply_filter()
+        if not selected_machine_id:
+            _focus_first_machine_row()
+
+    def _clear_search() -> None:
+        search_var.set("")
+        _apply_filter()
+        _focus_first_machine_row()
+
+    def _on_search_enter(_event=None) -> str:
+        children = tree.get_children("")
+        if not children:
+            return "break"
+        current = tree.selection()
+        if not current or current[0] != children[0]:
+            _focus_first_machine_row()
+        else:
+            _on_edit()
+        return "break"
 
     def _drag_commit(mid: str, x: int, y: int) -> None:
         nonlocal rows_cache
@@ -2235,12 +2296,15 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
     btn_restore.configure(command=_restore_plan)
     btn_assign_card.configure(command=_assign_card)
     btn_open_card.configure(command=_open_selected_card)
+    btn_clear_search.configure(command=_clear_search)
 
     tree.bind("<<TreeviewSelect>>", _on_tree_select)
     tree.bind("<Double-1>", lambda _e: _on_edit())
     upcoming_tree.bind("<<TreeviewSelect>>", _on_upcoming_select)
     history_tree.bind("<<TreeviewSelect>>", _on_history_select)
     filter_box.bind("<<ComboboxSelected>>", _apply_filter)
+    entry_search.bind("<KeyRelease>", lambda _event: _apply_search())
+    entry_search.bind("<Return>", _on_search_enter)
 
     _refresh_schedule_info()
     _recompute_visible_rows()


### PR DESCRIPTION
### Motivation
- Ułatwić szybkie znalezienie maszyn w panelu przez wprowadzenie wyszukiwania tekstowego po najważniejszych polach. 
- Poprawić UX listy maszyn poprzez fokusowanie pierwszego wyniku i obsługę klawisza Enter w polu wyszukiwania. 
- Dodać możliwość zamknięcia istniejącej dyspozycji bez wychodzenia z kreatora, wraz z zapisem kto zamknął dyspozycję i emitowaniem eventu odświeżającego widoki.

### Description
- W `gui_maszyny.py` dodano pole wyszukiwania (`search_var`) z `ttk.Entry` i przycisk `Wyczyść`, oraz przestawiono odstęp labelki filtra (`Filtr:`) dla zachowania układu. 
- Rozszerzono `_recompute_visible_rows()` o `matches_search()` aby filtrować `rows_cache` po polach takich jak `id`, `nr_ewid`, `nr`, `nazwa`, `typ`, `status`, `lokalizacja` oraz podsumowanie harmonogramu (`__schedule_summary`). 
- Dodano pomocnicze funkcje ` _focus_first_machine_row()`, `_apply_search()`, `_clear_search()` i `_on_search_enter()` oraz powiązano eventy `entry_search.bind('<KeyRelease>')` i `entry_search.bind('<Return>')` oraz przycisk `btn_clear_search.configure(command=_clear_search)`. 
- W `gui_dyspozycje_creator.py` zaimportowano `close_dyspozycja`, dodano wspólny helper `_event_updated()`, helper `_actor_login()` do wyznaczania autora zamknięcia oraz `_close_current()` z potwierdzeniem, wywołaniem `close_dyspozycja()` i komunikatami UI; w trybie edycji dodano przycisk `Zamknij dyspozycję` i zastąpiono bezpośrednie generowanie eventu użyciem `_event_updated()`.

### Testing
- Uruchomiono `pytest` po zmianach; test suite uruchomił się, ale wykryto istniejące niepowiązane błędy testów (m.in. w `test_gui_logowanie.py` i `test_gui_narzedzia_config.py`), więc całość testów nie przeszła. 
- Uruchomiono `pytest -q` w celu szybkiego sprawdzenia stanu; również potwierdziło obecność istniejących failing testów niezwiązanych z tym patchem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181cd119bc832398e660c1c2faecd6)