### PR TITLE
Enable object search for machines in dyspozycje creator

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -117,10 +117,10 @@ def open_dyspozycje_creator(
     )
     cb_object.grid(row=3, column=1, sticky="ew", pady=4)
 
-    var_tool_search = tk.StringVar()
-    ent_tool_search = ttk.Entry(frame, textvariable=var_tool_search)
-    ent_tool_search.grid(row=2, column=1, sticky="ew", pady=4)
-    ent_tool_search.grid_remove()
+    var_object_search = tk.StringVar()
+    ent_object_search = ttk.Entry(frame, textvariable=var_object_search)
+    ent_object_search.grid(row=2, column=1, sticky="ew", pady=4)
+    ent_object_search.grid_remove()
 
     ttk.Label(frame, text="Opis:").grid(row=4, column=0, sticky="nw", pady=4)
     txt_desc = tk.Text(frame, height=6, width=54)
@@ -184,11 +184,11 @@ def open_dyspozycje_creator(
         all_labels = [label for _object_id, label in options]
         labels = list(all_labels)
         cb_object.configure(values=labels)
-        var_tool_search.set("")
-        if source_key == "narzedzia":
-            ent_tool_search.grid()
+        var_object_search.set("")
+        if source_key in {"narzedzia", "maszyny"}:
+            ent_object_search.grid()
         else:
-            ent_tool_search.grid_remove()
+            ent_object_search.grid_remove()
 
         ctx_object_id = str(ctx.get("obiekt_id") or "").strip()
         picked = ""
@@ -206,14 +206,18 @@ def open_dyspozycje_creator(
     cb_type.bind("<<ComboboxSelected>>", _refresh_object_choices)
     _refresh_object_choices()
 
-    def _filter_tools(*_args) -> None:
-        if source_module["value"] != "narzedzia":
+    def _filter_objects(*_args) -> None:
+        if source_module["value"] not in {"narzedzia", "maszyny"}:
             return
-        query = var_tool_search.get().strip().lower()
+        query = var_object_search.get().strip().lower()
         if not query:
             filtered = list(all_labels)
         else:
-            filtered = [label for label in all_labels if query in label.lower()]
+            filtered = [
+                label
+                for label in all_labels
+                if query in label.lower()
+            ]
         cb_object.configure(values=filtered)
         if filtered:
             current = var_object_display.get().strip()
@@ -222,7 +226,7 @@ def open_dyspozycje_creator(
         else:
             var_object_display.set("")
 
-    var_tool_search.trace_add("write", _filter_tools)
+    var_object_search.trace_add("write", _filter_objects)
 
     btns = ttk.Frame(win, padding=(12, 0, 12, 12))
     btns.pack(fill="x")


### PR DESCRIPTION
### Motivation
- Make the object search field generic and usable for both tools and machines so users can filter machine selections the same way as tools.

### Description
- Renamed the search state and widget from `var_tool_search`/`ent_tool_search` to `var_object_search`/`ent_object_search` in `gui_dyspozycje_creator.py`.
- Show the search entry for source types `narzedzia` and `maszyny` by checking `if source_key in {"narzedzia", "maszyny"}` in the refresh logic.
- Renamed `_filter_tools` to `_filter_objects`, broadened its condition to handle machines as well, and switched it to read from `var_object_search`.
- Reformatted the list-comprehension filter to PEP8-friendly multiline form and wired `var_object_search.trace_add` to the new filter function.

### Testing
- Ran `pytest` after the change via `pytest` as required by repository instructions and collected the full test suite.
- The test run reported existing failures in GUI-related tests such as `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`, so the suite did not fully pass.
- No new failures clearly attributable to the modified `gui_dyspozycje_creator.py` were indicated in the partial test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1822ab0c988323ac7f11ae8b66e755)