### PR TITLE
Dodaj zakładkę Ustawienia → Dyspozycje (kolory i miganie)

### DIFF
--- a/gui_settings.py
+++ b/gui_settings.py
@@ -84,6 +84,7 @@ TAB_PATHS = "Ścieżki"
 TAB_BACKUP = "Kopia zapasowa"
 TAB_UI = "UI i wygląd"
 TAB_MODULES = "Moduły"
+TAB_DISPATCHES = "Dyspozycje"
 TAB_STATISTICS = "Statystyki"
 TAB_JARVIS = "Jarvis / powiadomienia"
 TAB_ADVANCED = "Zaawansowane / Dev"
@@ -2241,6 +2242,7 @@ class SettingsPanel:
         self.tab_ui = ttk.Frame(self.nb)
         self.tab_paths = ttk.Frame(self.nb)
         self.tab_modules = ttk.Frame(self.nb)
+        self.tab_dispatches = ttk.Frame(self.nb)
         self.tab_users = ttk.Frame(self.nb)
         self.tab_tools = ttk.Frame(self.nb)
         self.tab_backup = ttk.Frame(self.nb)
@@ -2265,6 +2267,7 @@ class SettingsPanel:
             (self.tab_paths, "Ścieżki", ""),
             (self.tab_tools, "Narzędzia", ""),
             (self.tab_modules, "Moduły", ""),
+            (self.tab_dispatches, "Dyspozycje", ""),
             (self.tab_backup, "Backup", ""),
             (self.tab_statistics, "Statystyki", ""),
             (self.tab_jarvis, "Jarvis", ""),
@@ -2314,6 +2317,14 @@ class SettingsPanel:
             text="💾 Kopie zapasowe"
         )
         self._backup_container.pack(fill="both", expand=True, padx=8, pady=8)
+
+        _scroll__dispatches_container = ScrolledFrame(self.tab_dispatches)
+        _scroll__dispatches_container.pack(fill="both", expand=True, padx=8, pady=8)
+        self._dispatches_container = ttk.LabelFrame(
+            _scroll__dispatches_container.inner,
+            text="Dyspozycje — wygląd i miganie",
+        )
+        self._dispatches_container.pack(fill="both", expand=True, padx=8, pady=8)
 
         _scroll__statistics_container = ScrolledFrame(self.tab_statistics)
         _scroll__statistics_container.pack(fill="both", expand=True, padx=8, pady=8)
@@ -2368,6 +2379,7 @@ class SettingsPanel:
             "jarvis.enabled",
         }
         self._build_manual_config_fields()
+        self._build_dispatches_settings_tab()
         self._build_statistics_settings_tab()
 
         # state for lazy creation of magazyn subtabs
@@ -2654,6 +2666,179 @@ class SettingsPanel:
                 counts = handler(frame, subtab, path_key)
             if counts:
                 self._log_tab_stats(title, *counts)
+
+    def _build_dispatches_settings_tab(self) -> None:
+        parent = getattr(self, "_dispatches_container", None)
+        if parent is None:
+            return
+
+        for child in parent.winfo_children():
+            child.destroy()
+
+        cfg = getattr(self, "cfg", None) or ConfigManager()
+
+        def _cfg_get(key: str, default: Any) -> Any:
+            getter = getattr(cfg, "get_path", None)
+            if callable(getter):
+                return getter(key, default)
+            getter = getattr(cfg, "get", None)
+            if callable(getter):
+                return getter(key, default)
+            return default
+
+        def _cfg_set(key: str, value: Any) -> None:
+            setter = getattr(cfg, "set_path", None)
+            if callable(setter):
+                setter(key, value)
+                return
+            setter = getattr(cfg, "set", None)
+            if callable(setter):
+                setter(key, value)
+
+        ttk.Label(
+            parent,
+            text=(
+                "Ustawienia wyglądu listy dyspozycji. Zmiany zapisują się "
+                "do config.json i będą użyte po odświeżeniu panelu Dyspozycji."
+            ),
+        ).pack(anchor="w", padx=8, pady=(8, 10))
+
+        fields = ttk.LabelFrame(parent, text="Kolory")
+        fields.pack(fill="x", padx=8, pady=8)
+        fields.columnconfigure(1, weight=1)
+
+        blink = ttk.LabelFrame(parent, text="Miganie")
+        blink.pack(fill="x", padx=8, pady=8)
+        blink.columnconfigure(1, weight=1)
+
+        values = {
+            "dyspozycje.ui.closed_foreground": tk.StringVar(
+                value=str(_cfg_get("dyspozycje.ui.closed_foreground", "#9ca3af"))
+            ),
+            "dyspozycje.ui.new_foreground": tk.StringVar(
+                value=str(_cfg_get("dyspozycje.ui.new_foreground", "#facc15"))
+            ),
+            "dyspozycje.ui.new_blink_foreground": tk.StringVar(
+                value=str(
+                    _cfg_get("dyspozycje.ui.new_blink_foreground", "#ffffff")
+                )
+            ),
+            "dyspozycje.ui.overdue_foreground": tk.StringVar(
+                value=str(_cfg_get("dyspozycje.ui.overdue_foreground", "#ef4444"))
+            ),
+            "dyspozycje.ui.overdue_blink_foreground": tk.StringVar(
+                value=str(
+                    _cfg_get("dyspozycje.ui.overdue_blink_foreground", "#ffffff")
+                )
+            ),
+            "dyspozycje.ui.overdue_blink_background": tk.StringVar(
+                value=str(
+                    _cfg_get("dyspozycje.ui.overdue_blink_background", "#7f1d1d")
+                )
+            ),
+            "dyspozycje.ui.new_blink_ms": tk.StringVar(
+                value=str(_cfg_get("dyspozycje.ui.new_blink_ms", 2000))
+            ),
+            "dyspozycje.ui.overdue_blink_ms": tk.StringVar(
+                value=str(_cfg_get("dyspozycje.ui.overdue_blink_ms", 500))
+            ),
+        }
+
+        blink_enabled = tk.BooleanVar(
+            value=bool(_cfg_get("dyspozycje.ui.blink_enabled", True))
+        )
+
+        def _row(parent_widget, row: int, label: str, key: str):
+            ttk.Label(parent_widget, text=label).grid(
+                row=row, column=0, sticky="w", padx=8, pady=4
+            )
+            ent = ttk.Entry(parent_widget, textvariable=values[key], width=18)
+            ent.grid(row=row, column=1, sticky="w", padx=8, pady=4)
+            return ent
+
+        _row(fields, 0, "Zamknięte — tekst:", "dyspozycje.ui.closed_foreground")
+        _row(fields, 1, "Nowe — tekst:", "dyspozycje.ui.new_foreground")
+        _row(
+            fields,
+            2,
+            "Nowe miganie — tekst:",
+            "dyspozycje.ui.new_blink_foreground",
+        )
+        _row(fields, 3, "Po terminie — tekst:", "dyspozycje.ui.overdue_foreground")
+        _row(
+            fields,
+            4,
+            "Po terminie miganie — tekst:",
+            "dyspozycje.ui.overdue_blink_foreground",
+        )
+        _row(
+            fields,
+            5,
+            "Po terminie miganie — tło:",
+            "dyspozycje.ui.overdue_blink_background",
+        )
+
+        ttk.Checkbutton(
+            blink,
+            text="Włącz miganie dyspozycji",
+            variable=blink_enabled,
+        ).grid(row=0, column=0, columnspan=2, sticky="w", padx=8, pady=4)
+
+        _row(blink, 1, "Miganie nowych [ms]:", "dyspozycje.ui.new_blink_ms")
+        _row(blink, 2, "Miganie po terminie [ms]:", "dyspozycje.ui.overdue_blink_ms")
+
+        ttk.Label(
+            parent,
+            text=(
+                "Kolory wpisuj jako HEX, np. #ef4444. Częstotliwość "
+                "w milisekundach: 2000 = 2 sekundy, 500 = pół sekundy."
+            ),
+        ).pack(anchor="w", padx=8, pady=(4, 8))
+
+        def _safe_int(
+            value: str,
+            default: int,
+            min_value: int = 100,
+            max_value: int = 10000,
+        ) -> int:
+            try:
+                parsed = int(str(value).strip())
+            except Exception:
+                parsed = default
+            return max(min_value, min(max_value, parsed))
+
+        def _save_dispatches_ui() -> None:
+            try:
+                _cfg_set("dyspozycje.ui.blink_enabled", bool(blink_enabled.get()))
+                for key, var in values.items():
+                    if key.endswith("_ms"):
+                        default = 2000 if key.endswith("new_blink_ms") else 500
+                        _cfg_set(key, _safe_int(var.get(), default))
+                    else:
+                        _cfg_set(key, str(var.get()).strip() or "#ffffff")
+                saver = getattr(cfg, "save", None)
+                if callable(saver):
+                    saver()
+                messagebox.showinfo(
+                    "Dyspozycje",
+                    "Zapisano ustawienia wyglądu dyspozycji.",
+                    parent=self.win,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "[SETTINGS][DYSP] Nie udało się zapisać ustawień dyspozycji"
+                )
+                messagebox.showerror(
+                    "Dyspozycje",
+                    f"Nie udało się zapisać ustawień: {exc}",
+                    parent=self.win,
+                )
+
+        ttk.Button(
+            parent,
+            text="Zapisz ustawienia Dyspozycji",
+            command=_save_dispatches_ui,
+        ).pack(anchor="w", padx=8, pady=(4, 12))
 
     def _build_manual_config_fields(self) -> None:
         """Insert hand-crafted widgets tied to configuration keys."""

--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -8,6 +8,7 @@ import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
 from typing import Any, Callable
 
+from config_manager import ConfigManager
 from dyspozycje_store import (
     close_dyspozycja,
     delete_dyspozycja,
@@ -19,6 +20,45 @@ from ui_dialogs_safe import error_box
 
 
 logger = logging.getLogger(__name__)
+
+
+def _dysp_ui_config() -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "blink_enabled": True,
+        "closed_foreground": "#9ca3af",
+        "new_foreground": "#facc15",
+        "new_blink_foreground": "#ffffff",
+        "overdue_foreground": "#ef4444",
+        "overdue_blink_foreground": "#ffffff",
+        "overdue_blink_background": "#7f1d1d",
+        "new_blink_ms": 2000,
+        "overdue_blink_ms": 500,
+    }
+    try:
+        cfg = ConfigManager()
+        data = cfg.load()
+        ui = (((data or {}).get("dyspozycje") or {}).get("ui") or {})
+        out = dict(defaults)
+        out.update({k: v for k, v in ui.items() if v not in (None, "")})
+        out["new_blink_ms"] = int(
+            out.get("new_blink_ms") or defaults["new_blink_ms"]
+        )
+        out["overdue_blink_ms"] = int(
+            out.get("overdue_blink_ms") or defaults["overdue_blink_ms"]
+        )
+        blink_enabled = out.get("blink_enabled", True)
+        if isinstance(blink_enabled, str):
+            blink_enabled = blink_enabled.strip().lower() not in {
+                "0",
+                "false",
+                "nie",
+                "no",
+                "off",
+            }
+        out["blink_enabled"] = bool(blink_enabled)
+        return out
+    except Exception:
+        return defaults
 
 
 def _dysp_status(item: dict[str, Any]) -> str:
@@ -117,6 +157,7 @@ class ZleceniaView(ttk.Frame):
         self._refresh_error_shown = False
         self._order_rows: dict[str, dict] = {}
         self._order_ids: dict[str, str] = {}
+        self._dysp_ui = _dysp_ui_config()
         self._open_order_creator = _resolve_creator()
         self._build_toolbar()
         self._build_tree()
@@ -177,20 +218,29 @@ class ZleceniaView(ttk.Frame):
         for column in columns:
             self.tree.heading(column, text=column.capitalize())
             self.tree.column(column, anchor="center")
-        self.tree.tag_configure("dysp_closed", foreground="#9ca3af")
-        self.tree.tag_configure("dysp_new", foreground="#facc15")
-        self.tree.tag_configure("dysp_new_blink", foreground="#ffffff")
-        self.tree.tag_configure("dysp_overdue", foreground="#ef4444")
-        self.tree.tag_configure(
-            "dysp_overdue_blink",
-            foreground="#ffffff",
-            background="#7f1d1d",
-        )
+        self._apply_dysp_ui_config()
         self.tree.pack(fill="both", expand=True)
         self.tree.bind("<Double-1>", self._on_double_click, add=True)
         self._ensure_blink_started()
 
+    def _apply_dysp_ui_config(self) -> None:
+        self._dysp_ui = _dysp_ui_config()
+        ui = self._dysp_ui
+        self.tree.tag_configure("dysp_closed", foreground=ui["closed_foreground"])
+        self.tree.tag_configure("dysp_new", foreground=ui["new_foreground"])
+        self.tree.tag_configure(
+            "dysp_new_blink", foreground=ui["new_blink_foreground"]
+        )
+        self.tree.tag_configure("dysp_overdue", foreground=ui["overdue_foreground"])
+        self.tree.tag_configure(
+            "dysp_overdue_blink",
+            foreground=ui["overdue_blink_foreground"],
+            background=ui["overdue_blink_background"],
+        )
+
     def _ensure_blink_started(self) -> None:
+        if not self._dysp_ui.get("blink_enabled", True):
+            return
         if getattr(self.tree, "_wm_dysp_blink_started", False):
             return
         self.tree._wm_dysp_blink_started = True
@@ -207,8 +257,14 @@ class ZleceniaView(ttk.Frame):
                 tags.discard("dysp_new_blink")
                 tags.add("dysp_new_blink" if self._blink_state["new"] else "dysp_new")
                 self.tree.item(iid, tags=tuple(tags))
+        if not self._dysp_ui.get("blink_enabled", True):
+            self.tree._wm_dysp_blink_started = False
+            return
         try:
-            self.tree.after(2000, self._blink_dysp_new)
+            self.tree.after(
+                int(self._dysp_ui.get("new_blink_ms", 2000)),
+                self._blink_dysp_new,
+            )
         except Exception:
             pass
 
@@ -219,11 +275,19 @@ class ZleceniaView(ttk.Frame):
             if "dysp_overdue" in tags or "dysp_overdue_blink" in tags:
                 tags.discard("dysp_overdue")
                 tags.discard("dysp_overdue_blink")
-                toggle = "dysp_overdue_blink" if self._blink_state["overdue"] else "dysp_overdue"
-                tags.add(toggle)
+                if self._blink_state["overdue"]:
+                    tags.add("dysp_overdue_blink")
+                else:
+                    tags.add("dysp_overdue")
                 self.tree.item(iid, tags=tuple(tags))
+        if not self._dysp_ui.get("blink_enabled", True):
+            self.tree._wm_dysp_blink_started = False
+            return
         try:
-            self.tree.after(500, self._blink_dysp_overdue)
+            self.tree.after(
+                int(self._dysp_ui.get("overdue_blink_ms", 500)),
+                self._blink_dysp_overdue,
+            )
         except Exception:
             pass
 
@@ -239,7 +303,11 @@ class ZleceniaView(ttk.Frame):
         if not root:
             return
         # nowy event dla Dyspozycji
-        root.bind("<<DyspozycjeUpdated>>", lambda _event: self._reload_orders(), add=True)
+        root.bind(
+            "<<DyspozycjeUpdated>>",
+            lambda _event: self._reload_orders(),
+            add=True,
+        )
 
     def _fill_orders_table(self, rows: list[dict]) -> None:
         for item in self.tree.get_children():
@@ -291,6 +359,8 @@ class ZleceniaView(ttk.Frame):
                 self._order_ids[iid] = order_key
 
     def _reload_orders(self) -> None:
+        self._apply_dysp_ui_config()
+        self._ensure_blink_started()
         try:
             rows = load_dyspozycje()
         except Exception as exc:  # pragma: no cover - wymagane GUI
@@ -454,6 +524,8 @@ class ZleceniaView(ttk.Frame):
 
     # region Refresh ----------------------------------------------------
     def _refresh(self) -> None:
+        self._apply_dysp_ui_config()
+        self._ensure_blink_started()
         try:
             rows = _load_orders_rows()
             try:


### PR DESCRIPTION
### Motivation
- Umożliwić konfigurację wyglądu listy dyspozycji (kolory tagów i parametry migania) z poziomu okna Ustawień zamiast wartości na stałe w kodzie.
- Zachować domyślne wartości i nie modyfikować modelu dyspozycji, zapisu statusów ani logiki zamykania dyspozycji.

### Description
- Dodano stałą zakładki `TAB_DISPATCHES` oraz nowy tab `Dyspozycje` w `gui_settings.py` z kontenerem "Dyspozycje — wygląd i miganie" i formularzem pól kolorów, przełącznika migania i pól interwałów migania.
- W `gui_settings.py` dodano `_build_dispatches_settings_tab()` z delikatnymi helperami kompatybilnymi z `ConfigManager` (obsługa `get_path`/`get` i `set_path`/`set`), walidacją liczb (`_safe_int`) i zapisem ustawień do configu.
- W `gui_zlecenia.py` dodano helper `_dysp_ui_config()` który ładuje sekcję `dyspozycje.ui` z fallbackami do zdefiniowanych domyślnych wartości, oraz metodę `_apply_dysp_ui_config()` która aplikuje kolory do `Treeview` zamiast wartości na stałe.
- Zmieniono logikę migania: przed uruchomieniem timerów sprawdzane jest `blink_enabled`, a wywołania `after` używają skonfigurowanych interwałów `new_blink_ms` i `overdue_blink_ms`; zachowano dotychczasowe tagi (`dysp_closed`, `dysp_new`, `dysp_new_blink`, `dysp_overdue`, `dysp_overdue_blink`) i bezpieczne domyślne wartości.
- Zmiany ograniczono do warstwy UI i konfiguracji; nie modyfikowano modelu dyspozycji, zapisu statusów ani logiki zamykania.

### Testing
- Skompilowano pliki: `python3 -m py_compile gui_settings.py gui_zlecenia.py` (sukces).
- Uruchomiono selektywne testy GUI: `pytest tests/test_settings_window.py tests/test_settings_gui.py` (zebrane testy GUI zostały pominięte w środowisku headless i zakończone jako skipped).
- Uruchomiono `pytest -q tests/test_dyspo_settings_schema.py` (testy zostały pominiete/skipped w tym środowisku).
- Pełne `pytest --maxfail=1` przerwano przez istniejący, niezwiązany z tą zmianą, błąd środowiska headless (Tkinter: brak `$DISPLAY` → test logowania GUI), więc wynik nie jest związany z wprowadzoną funkcjonalnością.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1910ae5b708323b357c72290b523f2)