### PR TITLE
Resilient local feedback data-root resolution and logging

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -1177,12 +1177,46 @@ def uruchom_panel(root, login, rola):
             except Exception:
                 sent = False
             if not sent:
+                def _feedback_data_root() -> str:
+                    """Zwraca aktywny ROOT/data dla lokalnego zapisu opinii."""
+
+                    try:
+                        from core import root_paths as wm_root_paths
+
+                        data_root = wm_root_paths.get_data_root()
+                        if data_root:
+                            return str(data_root)
+                    except Exception:
+                        pass
+
+                    try:
+                        cm = globals().get("CONFIG_MANAGER")
+                        if cm is not None:
+                            data_root = cm.path_data()
+                            if data_root:
+                                return str(data_root)
+                    except Exception:
+                        pass
+
+                    try:
+                        env_data_root = os.environ.get("WM_DATA_ROOT")
+                        if env_data_root:
+                            return str(env_data_root)
+                    except Exception:
+                        pass
+
+                    return "data"
+
                 try:
-                    data_root = CONFIG_MANAGER.path_data()
+                    data_root = _feedback_data_root()
                 except Exception:
                     data_root = "data"
                 os.makedirs(data_root, exist_ok=True)
                 path = os.path.join(data_root, "opinie.json")
+                try:
+                    print(f"[WM-ROOT][FEEDBACK] zapis opinii: {path}")
+                except Exception:
+                    pass
                 try:
                     with open(path, "r", encoding="utf-8") as fh:
                         data = json.load(fh)


### PR DESCRIPTION
### Motivation
- Ensure local feedback persistence works even when the global `CONFIG_MANAGER` is unavailable or the application is running under a different root, by resolving the active data root from multiple sources.
- Improve observability of local feedback saves by logging the resolved save path before writing `opinie.json`.

### Description
- Added a helper `def _feedback_data_root() -> str` that resolves the data root by trying `core.root_paths.get_data_root()`, then `CONFIG_MANAGER.path_data()`, then the `WM_DATA_ROOT` environment variable, and finally falling back to the literal `"data"`.
- Replaced the direct use of `CONFIG_MANAGER.path_data()` in the feedback fallback path with a call to `_feedback_data_root()` and ensured the directory is created with `os.makedirs(..., exist_ok=True)`.
- Added a safe `print`-based debug log (`[WM-ROOT][FEEDBACK] zapis opinii: {path}`) just before reading/writing `opinie.json` to aid troubleshooting in headless or alternate-root deployments.

### Testing
- Ran `python -m py_compile gui_panel.py` and it completed successfully.
- Ran `pytest`, which exercised the test-suite and resulted in failures; the run reported `5 failed, 35 passed, 5 skipped` and included GUI/headless failures related to Tkinter `$DISPLAY` and one config-log assertion failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1920c191a88323acef7d0a331f1fd0)