### PR TITLE
Fix quick theme persistence

### DIFF
--- a/gui_panel.py
+++ b/gui_panel.py
@@ -145,21 +145,47 @@ def _wm_save_theme(theme_name: str) -> bool:
         cm = globals().get("CONFIG_MANAGER")
         if cm is None:
             return False
-        if hasattr(cm, "set"):
-            cm.set("ui.theme", theme)
-        elif hasattr(cm, "set_path"):
+        if hasattr(cm, "set_path"):
             cm.set_path("ui.theme", theme)
+        elif hasattr(cm, "set"):
+            cm.set("ui.theme", theme)
         else:
-            data = cm.load()
+            data = getattr(cm, "merged", None)
             if not isinstance(data, dict):
-                data = {}
+                data = getattr(cm, "global_cfg", None)
+            if not isinstance(data, dict):
+                data = cm.load() if hasattr(cm, "load") else {}
+            if not isinstance(data, dict):
+                return False
             ui = data.setdefault("ui", {})
-            if isinstance(ui, dict):
-                ui["theme"] = theme
+            if not isinstance(ui, dict):
+                data["ui"] = {}
+                ui = data["ui"]
+            ui["theme"] = theme
+            try:
+                setattr(cm, "merged", data)
+            except Exception:
+                pass
+            try:
+                setattr(cm, "global_cfg", data)
+            except Exception:
+                pass
         if hasattr(cm, "save"):
             cm.save()
+        elif hasattr(cm, "save_config"):
+            cm.save_config()
+        else:
+            return False
+        try:
+            print(f"[WM-DBG][THEME] quick theme saved: ui.theme={theme}")
+        except Exception:
+            pass
         return True
-    except Exception:
+    except Exception as exc:
+        try:
+            print(f"[WM-DBG][THEME][WARN] quick theme save failed: {exc}")
+        except Exception:
+            pass
         return False
 
 


### PR DESCRIPTION
### Motivation
- Ensure quick theme changes are persisted reliably across different `ConfigManager` implementations by preferring the config-path API and adding fallbacks. 
- Make failures easier to diagnose by emitting lightweight debug/warning traces when quick theme save succeeds or fails.

### Description
- Prefer `cm.set_path("ui.theme", theme)` and fall back to `cm.set("ui.theme", theme)` when saving a quick theme. 
- Add fallback logic that writes `ui.theme` into `cm.merged` or `cm.global_cfg` or the result of `cm.load()`, normalizing the `ui` section before mutation. 
- Add support for `cm.save_config()` as a save fallback and emit `print` debug/warning messages on success or exception for easier diagnostics.

### Testing
- Ran `python -m py_compile gui_panel.py`, which succeeded. 
- Ran `pytest`, which was executed but timed out after showing GUI-related test failures (notably in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1922ddc308832396bff477d499eed8)