### PR TITLE
Add settings modules debug logging

### DIFF
--- a/gui_settings.py
+++ b/gui_settings.py
@@ -2412,6 +2412,48 @@ class SettingsPanel:
             "dyspo",
         }
 
+        def _debug_settings_modules_tab(tab: dict[str, Any]) -> None:
+            """Loguje, jak zakładka z configu trafia do Ustawienia → Moduły.
+
+            Etap 1 audytu: tylko diagnostyka, bez zmiany działania UI.
+            """
+
+            try:
+                tab_id = str(tab.get("id") or "").strip().lower()
+                title = str(
+                    tab.get("title") or tab.get("label") or tab_id or ""
+                ).strip()
+                handler = handlers.get(tab_id)
+                handler_name = (
+                    getattr(handler, "__name__", "generic")
+                    if handler
+                    else "generic"
+                )
+                groups_count = len(tab.get("groups") or [])
+                fields_count = len(tab.get("fields") or [])
+                subtabs_count = len(tab.get("subtabs") or [])
+                status = (
+                    "MODULES" if tab_id in modules_ids else "OUTSIDE_MODULES"
+                )
+                print(
+                    "[WM-DBG][SETTINGS][MODULES] "
+                    f"id={tab_id or '-'} | "
+                    f"title={title or '-'} | "
+                    f"target={status} | "
+                    f"handler={handler_name} | "
+                    f"groups={groups_count} | "
+                    f"fields={fields_count} | "
+                    f"subtabs={subtabs_count}"
+                )
+            except Exception as exc:
+                try:
+                    print(
+                        "[WM-DBG][SETTINGS][MODULES][WARN] "
+                        f"debug failed: {exc}"
+                    )
+                except Exception:
+                    pass
+
         # allow_users policzone wyżej – tutaj już tylko używamy tej wartości
         if allow_users:
             users_nb = ttk.Notebook(self._users_container)
@@ -2425,6 +2467,7 @@ class SettingsPanel:
             users_nb.add(users_profile_frame, text="Profil użytkownika")
 
         for tab in schema.get("tabs", []):
+            _debug_settings_modules_tab(tab)
             tab_id_raw = tab.get("id")
             tab_id = str(tab_id_raw or "").strip().lower()
             title = tab.get("title", tab.get("id", ""))


### PR DESCRIPTION
### Motivation
- Add lightweight diagnostics to help audit how settings schema tabs are classified and routed into the "Moduły" area without changing UI behavior.
- Provide visibility into which handler is selected and simple counts of groups/fields/subtabs to speed up troubleshooting of settings schema mapping.

### Description
- Introduced `_debug_settings_modules_tab(tab: dict[str, Any])` in `gui_settings.py` to emit a one-line diagnostic for each settings tab showing `id`, `title`, target (`MODULES` or `OUTSIDE_MODULES`), chosen handler name, and counts of `groups`, `fields`, and `subtabs`.
- The helper is invoked for each tab before existing routing logic in the `for tab in schema.get("tabs", [])` loop so it only logs diagnostics and does not alter routing or UI construction.
- Error handling in the helper is defensive to avoid breaking settings construction if logging itself fails.

### Testing
- Ran `python -m py_compile gui_settings.py` which succeeded.
- Ran repository checks (`git diff --check`) which reported no issues.
- Ran `pytest`; the test run was started but GUI-related tests failed in the headless CI environment, so the full suite could not complete successfully due to display issues for `tkinter`.
- Ran `pytest -x test_gui_logowanie.py` which failed with `tkinter`/`messagebox` errors caused by no X display (`no display name and no $DISPLAY` and related `RuntimeError`), i.e. an environment limitation rather than a functional regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194461ced483238a4a8a6304d0b5ff)