### PR TITLE
Fix warehouse path resolution and normalize warehouse payloads in GUI

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -44,6 +44,29 @@ from utils.path_utils import cfg_path
 log = logging.getLogger(__name__)
 
 
+def _is_absolute_path(path: str) -> bool:
+    """Return ``True`` when ``path`` points to an absolute location."""
+
+    if not path:
+        return False
+    if os.path.isabs(path):
+        return True
+    if path.startswith("\\\\"):
+        return True
+    if len(path) > 1 and path[1] == ":":
+        return True
+    return False
+
+
+def _norm(path: str) -> str:
+    if not path:
+        return ""
+    normalized = os.path.normpath(path)
+    if _is_absolute_path(normalized) or os.path.isabs(normalized):
+        return os.path.normcase(normalized)
+    return os.path.normcase(os.path.abspath(normalized))
+
+
 def _wm_root_env_active() -> bool:
     """Czy centralny ROOT jest już ustawiony w runtime."""
 
@@ -260,15 +283,6 @@ def get_profiles_path(cfg: dict | None = None) -> str:
     return _norm(os.path.join(get_root(cfg), "data", "profiles.json"))
 
 
-def _norm(path: str) -> str:
-    if not path:
-        return ""
-    normalized = os.path.normpath(path)
-    if _is_absolute_path(normalized) or os.path.isabs(normalized):
-        return os.path.normcase(normalized)
-    return os.path.normcase(os.path.abspath(normalized))
-
-
 def _looks_like_windows_path(path: str) -> bool:
     if not path:
         return False
@@ -316,20 +330,6 @@ def _normalize_user_path(path_str: str) -> Path:
     if candidate.is_absolute():
         return candidate.expanduser().resolve()
     return (base_root / candidate).expanduser().resolve()
-
-
-def _is_absolute_path(path: str) -> bool:
-    """Return ``True`` when ``path`` points to an absolute location."""
-
-    if not path:
-        return False
-    if os.path.isabs(path):
-        return True
-    if path.startswith("\\\\"):
-        return True
-    if len(path) > 1 and path[1] == ":":
-        return True
-    return False
 
 
 def _absolute_with_root(path: str | None, root: str) -> str:
@@ -1011,9 +1011,19 @@ def _migrate_legacy_keys(cfg: dict) -> bool:
         log.warning("[CFG-MIGRATE] Wyjątek podczas migracji: %r", e)
     return changed
 
+
 # Ścieżki domyślne (katalog główny aplikacji)
-SCHEMA_PATH = cfg_path("settings_schema.json")
-DEFAULTS_PATH = cfg_path("config.defaults.json")
+def _cfg_resource_path(filename: str) -> str:
+    """Zwraca ścieżkę zasobu konfiguracji z fallbackiem do katalogu kodu."""
+
+    candidate = cfg_path(filename)
+    if os.path.exists(candidate):
+        return candidate
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+
+
+SCHEMA_PATH = _cfg_resource_path("settings_schema.json")
+DEFAULTS_PATH = _cfg_resource_path("config.defaults.json")
 GLOBAL_PATH = cfg_path("config.json")
 LOCAL_PATH = cfg_path("config.local.json")
 SECRETS_PATH = cfg_path("secrets.json")

--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -328,6 +328,72 @@ def load_stock():
         return {}
 
 
+def _normalize_magazyn_payload(data):
+    """Normalizuje różne formaty magazynu do (items, order, format_name)."""
+
+    if not isinstance(data, (dict, list)):
+        return {}, [], type(data).__name__
+
+    if isinstance(data, list):
+        items = {}
+        order = []
+        for idx, rec in enumerate(data):
+            if not isinstance(rec, dict):
+                continue
+            item_id = str(
+                rec.get("id")
+                or rec.get("kod")
+                or rec.get("symbol")
+                or rec.get("nr")
+                or f"poz_{idx + 1:04d}"
+            ).strip()
+            if not item_id:
+                continue
+            copy = dict(rec)
+            copy.setdefault("id", item_id)
+            items[item_id] = copy
+            order.append(item_id)
+        return items, order, "list"
+
+    if isinstance(data.get("items"), dict):
+        items = data.get("items") or {}
+        meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
+        order = meta.get("order") if isinstance(meta.get("order"), list) else []
+        return items, order, "items"
+
+    if isinstance(data.get("pozycje"), dict):
+        items = data.get("pozycje") or {}
+        meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
+        order = meta.get("order") if isinstance(meta.get("order"), list) else []
+        return items, order, "pozycje"
+
+    if isinstance(data.get("items"), list):
+        items, order, _format_name = _normalize_magazyn_payload(
+            data.get("items") or []
+        )
+        return items, order, "items_list"
+
+    if isinstance(data.get("pozycje"), list):
+        items, order, _format_name = _normalize_magazyn_payload(
+            data.get("pozycje") or []
+        )
+        return items, order, "pozycje_list"
+
+    flat_items = {}
+    flat_order = []
+    for key, value in data.items():
+        if not isinstance(value, dict):
+            continue
+        copy = dict(value)
+        copy.setdefault("id", key)
+        flat_items[str(key)] = copy
+        flat_order.append(str(key))
+    if flat_items:
+        return flat_items, flat_order, "flat_dict"
+
+    return {}, [], "empty" if not data else "unknown_dict"
+
+
 def _load_data():
     """Czyta magazyn; preferuje ``magazyn_io`` z fallbackiem na plik."""
     path = get_path("warehouse.stock_source")
@@ -355,9 +421,14 @@ def _load_data():
         except Exception:
             data = {}
 
-    items = data.get("items") if isinstance(data.get("items"), dict) else {}
-    meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
-    order = meta.get("order") if isinstance(meta.get("order"), list) else []
+    items, order, format_name = _normalize_magazyn_payload(data)
+    try:
+        print(
+            "[WM-DBG][MAGAZYN] normalized "
+            f"format={format_name} items={len(items)} order={len(order)}"
+        )
+    except Exception:
+        pass
     return items, order
 
 
@@ -601,6 +672,11 @@ class MagazynFrame(ttk.Frame):
         for item_id in sorted_ids:
             item = items.get(item_id)
             if isinstance(item, dict):
+                item.setdefault("id", item_id)
+                item.setdefault("nazwa", item.get("kod") or item_id)
+                item.setdefault("typ", item.get("type") or item.get("rodzaj") or "")
+                item.setdefault("rozmiar", item.get("wymiar") or item.get("size") or "")
+                item.setdefault("stan", item.get("ilosc", item.get("ilość", 0)))
                 self._all_rows.append((item_id, item))
                 self._items_map[item_id] = item
 

--- a/logika_magazyn.py
+++ b/logika_magazyn.py
@@ -20,6 +20,7 @@ if not logging.getLogger().handlers:
     )
 
 from config_manager import ConfigManager
+from core import root_paths as wm_root_paths
 from magazyn_io import append_history
 try:
     from tkinter import messagebox
@@ -84,23 +85,102 @@ except Exception:
 _CFG = ConfigManager()
 
 
-MAGAZYN_PATH = "data/magazyn/magazyn.json"
-OLD_MAGAZYN_PATH = "data/magazyn.json"
+_DEFAULT_MAGAZYN_PATH = "data/magazyn/magazyn.json"
+_DEFAULT_OLD_MAGAZYN_PATH = "data/magazyn.json"
+_DEFAULT_SUROWCE_PATH = "data/magazyn/surowce.json"
+_DEFAULT_POLPRODUKTY_PATH = "data/magazyn/polprodukty.json"
+_DEFAULT_MATERIAL_SEQ_PATH = "data/magazyn/_seq_material.json"
+
+MAGAZYN_PATH = _DEFAULT_MAGAZYN_PATH
+OLD_MAGAZYN_PATH = _DEFAULT_OLD_MAGAZYN_PATH
 """Ścieżki do pliku magazynu (nowa i stara lokalizacja)."""
 
-SUROWCE_PATH = "data/magazyn/surowce.json"
+SUROWCE_PATH = _DEFAULT_SUROWCE_PATH
 """Ścieżka do pliku surowców magazynu."""
 
-POLPRODUKTY_PATH = "data/magazyn/polprodukty.json"
+POLPRODUKTY_PATH = _DEFAULT_POLPRODUKTY_PATH
 """Ścieżka do pliku półproduktów magazynu."""
+
+MATERIAL_SEQ_PATH = _DEFAULT_MATERIAL_SEQ_PATH
+"""Ścieżka do licznika identyfikatorów materiałów."""
+
+
+def _root_data_dir() -> str:
+    """Zwraca aktywny katalog danych dla magazynu."""
+
+    try:
+        data_root = wm_root_paths.get_data_root()
+        if data_root:
+            return str(data_root)
+    except Exception:
+        pass
+
+    try:
+        data_root = _CFG.path_data()
+        if data_root:
+            return str(data_root)
+    except Exception:
+        pass
+
+    env_data_root = os.environ.get("WM_DATA_ROOT")
+    if env_data_root:
+        return str(env_data_root)
+
+    return "data"
+
+
+def _mag_path(*parts: str) -> str:
+    if MAGAZYN_PATH != _DEFAULT_MAGAZYN_PATH:
+        return os.path.join(os.path.dirname(_warehouse_path()), *parts)
+    return os.path.join(_root_data_dir(), "magazyn", *parts)
+
+
+def _warehouse_path() -> str:
+    if MAGAZYN_PATH != _DEFAULT_MAGAZYN_PATH:
+        return MAGAZYN_PATH
+
+    try:
+        path = wm_root_paths.path_warehouse()
+        if path:
+            return str(path)
+    except Exception:
+        pass
+
+    return _mag_path("magazyn.json")
+
+
+def _legacy_warehouse_path() -> str:
+    if OLD_MAGAZYN_PATH != _DEFAULT_OLD_MAGAZYN_PATH:
+        return OLD_MAGAZYN_PATH
+    return os.path.join(_root_data_dir(), "magazyn.json")
+
+
+def _surowce_path() -> str:
+    if SUROWCE_PATH != _DEFAULT_SUROWCE_PATH:
+        return SUROWCE_PATH
+    return _mag_path("surowce.json")
+
+
+def _polprodukty_path() -> str:
+    if POLPRODUKTY_PATH != _DEFAULT_POLPRODUKTY_PATH:
+        return POLPRODUKTY_PATH
+    return _mag_path("polprodukty.json")
+
+
+def _material_seq_path() -> str:
+    if MATERIAL_SEQ_PATH != _DEFAULT_MATERIAL_SEQ_PATH:
+        return MATERIAL_SEQ_PATH
+    return _mag_path("_seq_material.json")
 
 
 def _migrate_legacy_path() -> None:
     """Przenosi stary plik magazynu do nowej lokalizacji, jeśli istnieje."""
-    if os.path.exists(OLD_MAGAZYN_PATH) and not os.path.exists(MAGAZYN_PATH):
-        os.makedirs(os.path.dirname(MAGAZYN_PATH), exist_ok=True)
+    old_path = _legacy_warehouse_path()
+    new_path = _warehouse_path()
+    if os.path.exists(old_path) and not os.path.exists(new_path):
+        os.makedirs(os.path.dirname(new_path), exist_ok=True)
         try:
-            os.replace(OLD_MAGAZYN_PATH, MAGAZYN_PATH)
+            os.replace(old_path, new_path)
         except OSError:
             pass
 
@@ -113,8 +193,9 @@ def _safe_load(path, default):
         with open(path, "r", encoding="utf-8") as fh:
             return json.load(fh)
     except FileNotFoundError:
-        if path == MAGAZYN_PATH and os.path.exists(OLD_MAGAZYN_PATH):
-            return _safe_load(OLD_MAGAZYN_PATH, default)
+        legacy_path = _legacy_warehouse_path()
+        if path == _warehouse_path() and os.path.exists(legacy_path):
+            return _safe_load(legacy_path, default)
         return default
     except (OSError, json.JSONDecodeError) as exc:
         print(f"[WM-DBG][MAG] Nie można odczytać {path}: {exc}")
@@ -157,12 +238,10 @@ _LOCK = RLock()
 
 DEFAULT_ITEM_TYPES = ["komponent", "półprodukt", "materiał"]
 
-MATERIAL_SEQ_PATH = "data/magazyn/_seq_material.json"
-
 
 def _magazyn_dir() -> str:
     """Zwraca katalog zawierający plik magazynu."""
-    return os.path.dirname(MAGAZYN_PATH)
+    return os.path.dirname(_warehouse_path())
 
 
 def _ensure_dirs():
@@ -191,7 +270,8 @@ def load_magazyn(include_external: bool = True):
         % include_external
     )
 
-    base = _safe_load(MAGAZYN_PATH, {"pozycje": {}, "historia": []})
+    magazyn_path = _warehouse_path()
+    base = _safe_load(magazyn_path, {"pozycje": {}, "historia": []})
     if not isinstance(base, dict):
         base = {"pozycje": {}, "historia": []}
 
@@ -204,8 +284,8 @@ def load_magazyn(include_external: bool = True):
     meta = base.get("meta") if isinstance(base.get("meta"), dict) else {}
 
     if include_external:
-        _merge_list_into(pozycje, _safe_load(SUROWCE_PATH, []), "surowiec")
-        _merge_list_into(pozycje, _safe_load(POLPRODUKTY_PATH, []), "półprodukt")
+        _merge_list_into(pozycje, _safe_load(_surowce_path(), []), "surowiec")
+        _merge_list_into(pozycje, _safe_load(_polprodukty_path(), []), "półprodukt")
 
     result = {"pozycje": pozycje, "historia": historia, "meta": meta}
     result["items"] = pozycje  # kompatybilność
@@ -246,11 +326,12 @@ def save_magazyn(data):
             if iid not in new_order:
                 new_order.append(iid)
         data["meta"]["order"] = new_order
-    lock_path = MAGAZYN_PATH + ".lock"
+    magazyn_path = _warehouse_path()
+    lock_path = magazyn_path + ".lock"
     lock_f = open(lock_path, "w")
     try:
         lock_file(lock_f)
-        tmp = MAGAZYN_PATH + ".tmp"
+        tmp = magazyn_path + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             try:
                 json.dump(data, f, ensure_ascii=False, indent=2)
@@ -262,13 +343,13 @@ def save_magazyn(data):
                     pass
                 raise
         try:
-            os.replace(tmp, MAGAZYN_PATH)
+            os.replace(tmp, magazyn_path)
         except Exception as e:
             _log_info(f"save_magazyn replace error: {e}")
             try:
-                if os.path.exists(MAGAZYN_PATH):
-                    os.remove(MAGAZYN_PATH)
-                os.rename(tmp, MAGAZYN_PATH)
+                if os.path.exists(magazyn_path):
+                    os.remove(magazyn_path)
+                os.rename(tmp, magazyn_path)
             except Exception as e2:
                 _log_info(f"save_magazyn rename error: {e2}")
                 try:
@@ -348,9 +429,10 @@ def save_polprodukt(record: dict) -> bool:
         data_rec["stan"] = float(data_rec["stan"])
 
     with _LOCK:
-        os.makedirs(os.path.dirname(POLPRODUKTY_PATH), exist_ok=True)
+        polprodukty_path = _polprodukty_path()
+        os.makedirs(os.path.dirname(polprodukty_path), exist_ok=True)
         try:
-            with open(POLPRODUKTY_PATH, "r", encoding="utf-8") as fh:
+            with open(polprodukty_path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
                 if not isinstance(data, dict):
                     data = {}
@@ -361,10 +443,10 @@ def save_polprodukt(record: dict) -> bool:
         if kod in data:
             return False
         data[kod] = data_rec
-        tmp = POLPRODUKTY_PATH + ".tmp"
+        tmp = polprodukty_path + ".tmp"
         with open(tmp, "w", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False, indent=2)
-        os.replace(tmp, POLPRODUKTY_PATH)
+        os.replace(tmp, polprodukty_path)
         _log_mag("polprodukt_zapisany", {"kod": kod})
         return True
 
@@ -470,7 +552,7 @@ def remove_item_type(nazwa: str, uzytkownik: str = "system") -> bool:
 
 def _load_material_seq() -> dict:
     try:
-        with open(MATERIAL_SEQ_PATH, "r", encoding="utf-8") as f:
+        with open(_material_seq_path(), "r", encoding="utf-8") as f:
             data = json.load(f)
             if isinstance(data, dict):
                 return {str(k): int(v) for k, v in data.items()}
@@ -481,7 +563,7 @@ def _load_material_seq() -> dict:
 
 def _save_material_seq(data: dict) -> None:
     _ensure_dirs()
-    with open(MATERIAL_SEQ_PATH, "w", encoding="utf-8") as f:
+    with open(_material_seq_path(), "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 


### PR DESCRIPTION
### Motivation
- Ensure warehouse IO uses the active DATA root (core runtime paths / ConfigManager / WM_DATA_ROOT) while keeping the ability to override legacy constant paths for tests and backward-compatibility. 
- Make the GUI loader resilient to multiple warehouse payload shapes (legacy `pozycje`, `items`, lists, or flat dicts) so the inventory view renders consistently. 
- Avoid startup/config failures when runtime config/schema files are located outside the repo by providing a safe path normalization and resource fallback for schema/defaults. 

### Description
- Added dynamic path helpers in `logika_magazyn.py` (`_root_data_dir`, `_mag_path`, `_warehouse_path`, `_legacy_warehouse_path`, `_surowce_path`, `_polprodukty_path`, `_material_seq_path`) and routed reads/writes through them while preserving legacy constant overrides. 
- Updated migration and safe-load logic to move/consume legacy warehouse files from the resolved data root (uses `core.root_paths` and ConfigManager fallbacks). 
- Switched save/load operations to use `_warehouse_path()` (and corresponding temp/lock paths) to ensure atomic writes in the active data tree. 
- In `gui_magazyn.py` added `_normalize_magazyn_payload()` to accept lists, `items`/`pozycje` dicts, and flat dicts, and updated `_load_data()`/`refresh()` to normalize payload and populate row defaults for alternate field names (`kod`, `type`/`rodzaj`, `wymiar`/`size`, `ilosc`/`ilość`). 
- In `config_manager.py` introduced `_norm`/_is_absolute helper earlier and `_cfg_resource_path()` fallback so `settings_schema.json` and `config.defaults.json` can be resolved from repo resources if runtime paths point elsewhere. 

### Testing
- Compiled modified modules with `python -m py_compile config_manager.py logika_magazyn.py gui_magazyn.py` which succeeded. 
- Ran focused tests `pytest tests/test_gui_magazyn_basic.py test_logika_magazyn.py -q -k 'not parallel_saves_are_serial'` which completed successfully (`15 passed, 1 skipped, 1 deselected`). 
- Attempted full `pytest` / longer runs; a full run timed out and exposed pre-existing GUI/test-environment failures (Tkinter/no-display and some unrelated GUI assertions) and a multiprocessing-related hang in `test_parallel_saves_are_serial`; these are environmental/intermittent and not introduced by the path/payload changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195e91879c83239d1cdb70076a469b)