### PR TITLE
Normalize 'warning' status and use WM palette for hall-map dots

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -89,6 +89,7 @@ MACHINE_STATUS_ALIASES = {
     "serwis/przegląd": "alert",
     "warn": "warn",
     "warm": "warn",
+    "warning": "warn",
     "awaria": "warn",
     "uszkodzona": "warn",
     "uszkodzone": "warn",
@@ -1383,8 +1384,9 @@ class MachineHallRenderer:
         return clamped_x, clamped_y
 
     def _status_color(self, status):
-        key = str(status or "").strip().upper()
-        return self.COLORS.get(key, self.COLORS["_"])
+        """Kolor kółka maszyny zgodny z polskimi statusami WM."""
+
+        return _machine_status_color(status)
 
     def _node_center(self, r: Dict, idx: int, radius: int) -> tuple[int, int]:
         cols, cell_w, cell_h, pad_x, pad_y = 6, 120, 110, 70, 70
@@ -1460,7 +1462,7 @@ class MachineHallRenderer:
                 cy - radius,
                 cx + radius,
                 cy + radius,
-                fill=_status_color(r),
+                fill=self._status_color(r.get("status")),
                 outline="#0b0c0f",
                 width=1,
             )


### PR DESCRIPTION
### Motivation
- Ensure the hall-map machine dots use the same normalized WM machine-status palette as the rest of the app so status colors are consistent.
- Treat the textual status `warning` as a WM failure/warn alias so it renders with the expected failure color.

### Description
- Add the `"warning": "warn"` alias to `MACHINE_STATUS_ALIASES` so it normalizes to the `warn` status.
- Change the hall renderer `_status_color` helper to delegate to the global `_machine_status_color` function for schedule-aware, normalized color selection.
- Pass each row's `status` value to the renderer when creating the hall-map oval so the color reflects the normalized WM status.

### Testing
- `python -m py_compile gui_maszyny.py` succeeded.
- Focused assertions executed via a short Python script verified normalized colors for `warning`, `awaria`, `sprawna`, and `serwis` and passed.
- A full `pytest` run was started as required but did not complete cleanly in this environment because it surfaced unrelated pre-existing failures (Tkinter display errors and a config logging test) and the run was interrupted; those failures are unrelated to the machine-status changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8be74e5483238f9ae8aecfce9f17)