### PR TITLE
Remove schedule color tag from machine tree rows

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1125,13 +1125,9 @@ def _tree_insert_row(tree: ttk.Treeview, machine: dict) -> str:
     item_id = tree.insert("", "end", iid=identifier or None, values=values)
     tag_identifier = identifier or item_id
     machine_status_tag = _ensure_tree_machine_status_tag(tree, machine.get("status"))
-    schedule_key = _schedule_status_key(machine)
-    schedule_tag = _ensure_tree_schedule_tag(tree, schedule_key)
     tags = [f"ROW::{tag_identifier}"]
     if machine_status_tag:
         tags.append(machine_status_tag)
-    if schedule_tag:
-        tags.append(schedule_tag)
     tree.item(item_id, tags=tuple(tags))
     return item_id
 


### PR DESCRIPTION
### Motivation
- Prevent schedule-status row coloring from overriding machine-status styling by not attaching `SCHEDULE::...` tags to machine tree rows while preserving the row identifier used for tooltip mapping.

### Description
- Stop creating and attaching the schedule-status tag in `_tree_insert_row`, keeping only the `ROW::...` identifier tag and the `MACHINE_STATUS::...` tag used for row styling.

### Testing
- Ran `python -m py_compile gui_maszyny.py` and a targeted assertion that `_tree_insert_row` emits `ROW::...` and `MACHINE_STATUS::...` without any `SCHEDULE::...` tag, both succeeded; ran `pytest tests/test_widok_hali_machines_view.py test_logika_zlecenia_i_maszyny.py` where the machine hall view tests passed but an unrelated pre-existing `KeyError: 'status'` in `test_wczytanie_wielu_zlecen_filtracja` caused a failure, and a full `pytest` run was started as required but did not complete due to existing suite issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a939fa20c8323a0097bbd81b4af16)