### PR TITLE
Dodaj zdjęcia do historii statusów maszyn

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
+import shutil
 import subprocess
 import tkinter as tk
 from logging import getLogger
@@ -274,7 +275,9 @@ def _apply_machine_status_change(
     *,
     actor: str,
     note: str,
+    photos: Optional[List[str]] = None,
 ) -> bool:
+    photos = list(photos or [])
     old_status = _normalize_machine_status(machine.get("status"))
     new_status = _normalize_machine_status(new_status)
     if old_status == new_status:
@@ -315,9 +318,80 @@ def _apply_machine_status_change(
         "started_at": now,
         "changed_by": actor,
         "note": note or "",
-        "photos": [],
+        "photos": photos,
     }
     return True
+
+
+def _machine_attachment_root() -> str:
+    """Zwraca katalog ROOT/data/maszyny/attachments."""
+
+    try:
+        from core import root_paths as wm_root_paths
+
+        data_root = wm_root_paths.get_data_root()
+        if data_root:
+            return os.path.join(str(data_root), "maszyny", "attachments")
+    except Exception:
+        pass
+
+    try:
+        from config_manager import ConfigManager
+
+        data_root = ConfigManager().path_data()
+        if data_root:
+            return os.path.join(str(data_root), "maszyny", "attachments")
+    except Exception:
+        pass
+
+    return os.path.join("data", "maszyny", "attachments")
+
+
+def _safe_machine_file_part(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        text = "machine"
+    out = []
+    for ch in text:
+        if ch.isalnum() or ch in ("-", "_"):
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out).strip("_") or "machine"
+
+
+def _copy_machine_status_photos(
+    machine_id: object, source_paths: Iterable[str]
+) -> List[str]:
+    """Kopiuje zdjęcia statusu do ROOT/data/maszyny/attachments."""
+
+    copied: List[str] = []
+    valid_sources = [
+        str(path) for path in source_paths or [] if str(path or "").strip()
+    ]
+    if not valid_sources:
+        return copied
+
+    ts = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    machine_part = _safe_machine_file_part(machine_id)
+    target_dir = os.path.join(_machine_attachment_root(), machine_part, ts)
+    os.makedirs(target_dir, exist_ok=True)
+
+    for idx, src in enumerate(valid_sources, start=1):
+        if not os.path.exists(src):
+            continue
+        ext = os.path.splitext(src)[1].lower() or ".jpg"
+        filename = f"status_{idx:02d}{ext}"
+        dst = os.path.join(target_dir, filename)
+        try:
+            shutil.copy2(src, dst)
+            copied.append(dst)
+        except Exception:
+            logger.exception(
+                "[MASZYNY][STATUS_PHOTO] Nie udało się skopiować zdjęcia: %s",
+                src,
+            )
+    return copied
 
 
 def _machine_status_history_rows(machine: Dict[str, Any]) -> List[tuple]:
@@ -333,7 +407,11 @@ def _machine_status_history_rows(machine: Dict[str, Any]) -> List[tuple]:
             duration = _format_duration_minutes(item.get("duration_minutes"))
             who = str(item.get("closed_by") or item.get("changed_by") or "—")
             note = str(item.get("close_note") or item.get("note") or "")
-            rows.append((status, start, stop, duration, who, note))
+            photos = (
+                item.get("photos") if isinstance(item.get("photos"), list) else []
+            )
+            photo_txt = f" | zdjęcia: {len(photos)}" if photos else ""
+            rows.append((status, start, stop, duration, who, note + photo_txt))
 
     current = machine.get("status_current")
     if isinstance(current, dict):
@@ -346,7 +424,13 @@ def _machine_status_history_rows(machine: Dict[str, Any]) -> List[tuple]:
                 "w toku",
                 _format_duration_minutes(_duration_minutes(start_raw, now)),
                 str(current.get("changed_by") or "—"),
-                str(current.get("note") or ""),
+                str(current.get("note") or "")
+                + (
+                    f" | zdjęcia: {len(current.get('photos') or [])}"
+                    if isinstance(current.get("photos"), list)
+                    and current.get("photos")
+                    else ""
+                ),
             )
         )
     return rows
@@ -2526,8 +2610,33 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
                         parent=self,
                     )
                     return
+                status_photos: List[str] = []
+                try:
+                    wants_photos = messagebox.askyesno(
+                        "Zdjęcia serwisu / przeglądu",
+                        "Czy dodać zdjęcia do tej zmiany statusu?",
+                        parent=self,
+                    )
+                except Exception:
+                    wants_photos = False
+                if wants_photos:
+                    selected_photos = filedialog.askopenfilenames(
+                        parent=self,
+                        title="Wybierz zdjęcia do historii maszyny",
+                        filetypes=[
+                            ("Obrazy", "*.png *.jpg *.jpeg *.webp *.bmp"),
+                            ("Wszystkie pliki", "*.*"),
+                        ],
+                    )
+                    status_photos = _copy_machine_status_photos(
+                        row["id"], selected_photos
+                    )
                 _apply_machine_status_change(
-                    row, new_status, actor=self._actor, note=note.strip()
+                    row,
+                    new_status,
+                    actor=self._actor,
+                    note=note.strip(),
+                    photos=status_photos,
                 )
             else:
                 row["status"] = new_status

--- a/tests/test_gui_maszyny_status_history.py
+++ b/tests/test_gui_maszyny_status_history.py
@@ -60,7 +60,9 @@ def test_apply_machine_status_change_initializes_current_when_unchanged(monkeypa
 
 
 def test_machine_status_history_rows_include_closed_and_current(monkeypatch):
-    monkeypatch.setattr(gui_maszyny, "_machine_now_iso", lambda: "2026-05-30T12:00:00")
+    monkeypatch.setattr(
+        gui_maszyny, "_machine_now_iso", lambda: "2026-05-30T12:00:00"
+    )
     machine = {
         "status_history": [
             {
@@ -100,3 +102,67 @@ def test_machine_status_history_rows_include_closed_and_current(monkeypatch):
             "Gotowa do pracy",
         ),
     ]
+
+
+def test_apply_machine_status_change_stores_photos_for_new_period(monkeypatch):
+    monkeypatch.setattr(
+        gui_maszyny, "_machine_now_iso", lambda: "2026-05-30T13:00:00"
+    )
+    machine = {"status": "ok"}
+    photos = ["data/maszyny/attachments/M-1/status_01.jpg"]
+
+    changed = gui_maszyny._apply_machine_status_change(
+        machine, "alert", actor="anna", note="Przegląd", photos=photos
+    )
+
+    assert changed is True
+    assert machine["status_current"]["photos"] == photos
+
+
+def test_machine_status_history_rows_show_photo_count(monkeypatch):
+    monkeypatch.setattr(
+        gui_maszyny, "_machine_now_iso", lambda: "2026-05-30T12:00:00"
+    )
+    machine = {
+        "status_history": [
+            {
+                "status": "alert",
+                "started_at": "2026-05-30T08:00:00",
+                "ended_at": "2026-05-30T09:00:00",
+                "duration_minutes": 60,
+                "closed_by": "anna",
+                "close_note": "Przegląd wykonany",
+                "photos": ["one.jpg", "two.jpg"],
+            }
+        ],
+        "status_current": {
+            "status": "ok",
+            "started_at": "2026-05-30T09:00:00",
+            "changed_by": "anna",
+            "note": "Gotowa",
+            "photos": ["three.jpg"],
+        },
+    }
+
+    rows = gui_maszyny._machine_status_history_rows(machine)
+
+    assert rows[0][-1] == "Przegląd wykonany | zdjęcia: 2"
+    assert rows[1][-1] == "Gotowa | zdjęcia: 1"
+
+
+def test_copy_machine_status_photos_uses_attachment_directory(monkeypatch, tmp_path):
+    attachment_root = tmp_path / "attachments"
+    source = tmp_path / "Zdjęcie.JPG"
+    source.write_bytes(b"photo")
+    monkeypatch.setattr(
+        gui_maszyny, "_machine_attachment_root", lambda: str(attachment_root)
+    )
+
+    copied = gui_maszyny._copy_machine_status_photos("M 1/2", [str(source)])
+
+    assert len(copied) == 1
+    target = attachment_root / "M_1_2"
+    copied_path = gui_maszyny.os.path.relpath(copied[0], target)
+    assert gui_maszyny.os.path.basename(copied_path) == "status_01.jpg"
+    assert gui_maszyny.os.path.isfile(copied[0])
+    assert gui_maszyny.os.path.splitext(copied[0])[1] == ".jpg"


### PR DESCRIPTION
### Motivation
- Umożliwić dołączanie i przechowywanie zdjęć podczas zmiany statusu maszyny oraz wyświetlanie informacji o liczbie zdjęć w historii wpisów.
- Przechowywać skopiowane załączniki w spójnym katalogu danych aplikacji (`data/maszyny/attachments`) z bezpieczną nazwą podkatalogu dla maszyny.

### Description
- Rozszerzono ` _apply_machine_status_change` o opcjonalny parametr `photos` i zapis zdjęć w `status_current` bieżącego okresu. 
- Dodano funkcje pomocnicze: `_machine_attachment_root` (wyznacza katalog danych), `_safe_machine_file_part` (sanityzacja identyfikatora maszyny) oraz `_copy_machine_status_photos` (kopiuje wskazane pliki do `data/maszyny/attachments/<machine>/<timestamp>` i zwraca listę skopiowanych ścieżek). 
- W edytorze maszyny dodano pytanie o dołączenie zdjęć oraz wybór plików przez `filedialog`, po czym pliki są kopiowane przez `_copy_machine_status_photos` i przekazywane do zmiany statusu. 
- Zaktualizowano ` _machine_status_history_rows` tak, aby doklejać do opisu informacji o liczbie zdjęć dla zamkniętych okresów oraz bieżącego statusu. 
- Dodano regresyjne testy w `tests/test_gui_maszyny_status_history.py` sprawdzające zapis listy zdjęć, wyświetlanie licznika zdjęć w historii oraz kopiowanie plików do katalogu załączników.

### Testing
- Uruchomiono `pytest tests/test_gui_maszyny_status_history.py`, wszystkie testy modułu przeszły (`6 passed`).
- Sprawdzono kompilację plików testowanych poleceniem `python -m py_compile gui_maszyny.py tests/test_gui_maszyny_status_history.py`, które zakończyło się pomyślnie.
- Pełny `pytest` został uruchomiony; zakończył się niepowodzeniem z powodu istniejących, niezwiązanych z tą zmianą awarii w `test_gui_logowanie.py` i `test_gui_narzedzia_config.py` oraz zawieszenia w części wykorzystującej multiprocessing, więc nie wszystkie testy całego repo przeszły; zmiany dla modułu maszyn są przetestowane i zielone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aabe100908323b752b9b7b9bdef88)