### PR TITLE
Popraw okno edycji historii maszyn

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2525,6 +2525,8 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
         def __init__(self, master: tk.Misc, row: dict | None, on_ok):
             super().__init__(master)
             self.title("Edycja maszyny")
+            self.geometry("1180x760")
+            self.minsize(980, 680)
             self.resizable(False, False)
             self.transient(master)
             self.grab_set()
@@ -2626,7 +2628,7 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
             )
             hist_cols = ("status", "start", "stop", "czas", "kto", "opis")
             hist_tree = ttk.Treeview(
-                hist_box, columns=hist_cols, show="headings", height=5
+                hist_box, columns=hist_cols, show="headings", height=4
             )
             hist_setup = {
                 "status": ("Status", 140, "w"),
@@ -2642,9 +2644,27 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
             hist_tree.pack(fill="both", expand=True, padx=6, pady=6)
 
             history_source = dict(self._row)
-            _ensure_status_current(history_source, actor=self._actor)
-            for values in _machine_status_history_rows(history_source):
-                hist_tree.insert("", "end", values=values)
+            has_history = isinstance(
+                history_source.get("status_history"), list
+            ) and bool(history_source.get("status_history"))
+            has_current = isinstance(history_source.get("status_current"), dict)
+            if has_history or has_current:
+                for values in _machine_status_history_rows(history_source):
+                    hist_tree.insert("", "end", values=values)
+            else:
+                hist_tree.insert(
+                    "",
+                    "end",
+                    values=(
+                        "—",
+                        "—",
+                        "—",
+                        "—",
+                        "—",
+                        "Brak historii. Pierwszy wpis powstanie przy zmianie "
+                        "statusu.",
+                    ),
+                )
 
             btns = ttk.Frame(frm)
             btns.grid(row=10, column=0, columnspan=2, pady=(10, 0))


### PR DESCRIPTION
### Motivation
- Ulepszyć czytelność i użyteczność okna edycji maszyny poprzez dopasowanie rozmiaru okna i lepsze zachowanie tabeli historii statusów.
- Uniknąć pokazywania pozornego, pustego „bieżącego” wpisu historii wyłącznie w celach podglądu, gdy brak jest rzeczywistej historii.

### Description
- Zmieniono plik `gui_maszyny.py` tak, by okno edycji (`MachineEditDialog`) ustawiało początkowy rozmiar `1180x760` oraz minimalny rozmiar `980x680` przy inicjalizacji dialogu za pomocą `geometry` i `minsize`.
- Zmniejszono wysokość widoku drzewa historii z `height=5` do `height=4` w definicji `ttk.Treeview` dla pola „Historia statusów”.
- Zamiast zawsze wymuszać generowanie „aktualnego” wpisu dla podglądu, dodano kontrolę, która sprawdza obecność `status_history` (lista) lub `status_current` (słownik) i tylko wtedy wstawia wiersze z `_machine_status_history_rows`; gdy brak historii, wstawiany jest czytelny komunikat zastępczy w tabeli.

### Testing
- Uruchomiono `pytest tests/test_gui_maszyny_status_history.py` i wszystkie testy przeszły pomyślnie (`7 passed`).
- Sprawdzono składnię modułu przez `python -m py_compile gui_maszyny.py`, co zakończyło się pomyślnie.
- Uruchomiono `git diff --check`, które nie wykazało problemów.
- Pełny zestaw testów uruchomiony z limitem czasowym (`timeout 30s pytest`) nie zakończył się w limicie i przed przerwaniem wykazał niepowiązane z tą zmianą niepowodzenia w `test_gui_logowanie.py` oraz `test_gui_narzedzia_config.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1abf1f8ea88323b76d69e21131d8ae)