### PR TITLE
Uprość okno edycji maszyny

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2673,8 +2673,8 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
         def __init__(self, master: tk.Misc, row: dict | None, on_ok):
             super().__init__(master)
             self.title("Edycja maszyny")
-            self.geometry("1180x760")
-            self.minsize(980, 680)
+            self.geometry("920x520")
+            self.minsize(820, 480)
             self.resizable(False, False)
             self.transient(master)
             self.grab_set()
@@ -2714,8 +2714,6 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
 
             self.e_x = row_entry(5, "x (px):", "x")
             self.e_y = row_entry(6, "y (px):", "y")
-
-            _build_edit_footer(frm, self._row, lambda: None)
 
             selected_review_months = set(
                 _normalize_review_months(
@@ -2770,52 +2768,8 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
                 text="Wpisz kilka osób po przecinku, np. Edwin, Marek, Dawid.",
             ).grid(row=2, column=1, sticky="w", padx=6, pady=(0, 6))
 
-            hist_box = ttk.LabelFrame(frm, text="Historia statusów")
-            hist_box.grid(
-                row=9, column=0, columnspan=2, sticky="nsew", pady=(10, 4)
-            )
-            hist_cols = ("status", "start", "stop", "czas", "kto", "opis")
-            hist_tree = ttk.Treeview(
-                hist_box, columns=hist_cols, show="headings", height=4
-            )
-            hist_setup = {
-                "status": ("Status", 140, "w"),
-                "start": ("Start", 130, "center"),
-                "stop": ("Stop", 130, "center"),
-                "czas": ("Czas", 100, "center"),
-                "kto": ("Kto", 100, "w"),
-                "opis": ("Opis", 360, "w"),
-            }
-            for col, (label, width, anchor) in hist_setup.items():
-                hist_tree.heading(col, text=label)
-                hist_tree.column(col, width=width, anchor=anchor)
-            hist_tree.pack(fill="both", expand=True, padx=6, pady=6)
-
-            history_source = dict(self._row)
-            has_history = isinstance(
-                history_source.get("status_history"), list
-            ) and bool(history_source.get("status_history"))
-            has_current = isinstance(history_source.get("status_current"), dict)
-            if has_history or has_current:
-                for values in _machine_status_history_rows(history_source):
-                    hist_tree.insert("", "end", values=values)
-            else:
-                hist_tree.insert(
-                    "",
-                    "end",
-                    values=(
-                        "—",
-                        "—",
-                        "—",
-                        "—",
-                        "—",
-                        "Brak historii. Pierwszy wpis powstanie przy zmianie "
-                        "statusu.",
-                    ),
-                )
-
             btns = ttk.Frame(frm)
-            btns.grid(row=10, column=0, columnspan=2, pady=(10, 0))
+            btns.grid(row=9, column=0, columnspan=2, pady=(14, 0))
             ttk.Button(btns, text="Anuluj", command=self.destroy).pack(side="right", padx=6)
             ttk.Button(
                 btns,


### PR DESCRIPTION
### Motivation
- Uprościć i zmniejszyć dialog „Edycja maszyny”, usuwając niepotrzebne elementy interfejsu i dopasować układ do mniejszych okien. 
- Przenieść przyciski zapisu/anulowania bliżej pól przeglądów cyklicznych, aby poprawić czytelność formularza.

### Description
- Zmieniono domyślny rozmiar okna z `1180x760` na `920x520` oraz minimalny rozmiar z `980x680` na `820x480` w klasie `MachineEditDialog` w `gui_maszyny.py`.
- Usunięto wywołanie ` _build_edit_footer(frm, self._row, lambda: None)` z formularza edycji.
- Usunięto sekcję tworzącą ramkę i `Treeview` dla „Historia statusów” oraz powiązany kod wstawiania wierszy.
- Przesunięto ramkę z przyciskami do wiersza `9` i ustawiono górny odstęp `pady=(14, 0)` aby przyciski znajdowały się bezpośrednio pod blokiem przeglądów cyklicznych.

### Testing
- Uruchomiono `python -m py_compile gui_maszyny.py` i sprawdzono poprawność składni, co zakończyło się powodzeniem.
- Uruchomiono testy jednostkowe specyficzne dla modułu maszyn: `pytest tests/test_gui_maszyny_status_history.py tests/test_widok_hali_machines_view.py`, które zakończyły się wynikiem `11 passed`.
- Dodatkowe uruchomienie `pytest tests/test_gui_maszyny_status_history.py tests/test_widok_hali_machines_view.py test_logika_zlecenia_i_maszyny.py` zwróciło `13 passed, 1 skipped, 1 failed` gdzie niepowodzenie (`KeyError: 'status'`) dotyczy istniejącego, niezwiązanego z tą zmianą testu `test_wczytanie_wielu_zlecen_filtracja`.
- Pełny zestaw `pytest` został uruchomiony w ramach weryfikacji i ujawnił istniejące, niezwiązane z tą zmianą błędy w innych modułach GUI; te problemy nie wynikają z wprowadzonych modyfikacji.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d3a807c9883239ee8bb5c8adb6ada)