### PR TITLE
Add PlanMonitor/start.bat (one-click launcher)

### DIFF
--- a/PlanMonitor/start.bat
+++ b/PlanMonitor/start.bat
@@ -1,0 +1,29 @@
+@echo off
+title Plan Monitor
+cd /d "%~dp0"
+
+echo ========================================
+echo  PLAN MONITOR - START
+echo ========================================
+echo.
+
+py -3.13 --version >nul 2>&1
+if errorlevel 1 (
+    echo Nie znaleziono Python 3.13 przez launcher py.
+    echo Sprobuj zainstalowac Python 3.13 albo uruchom recznie:
+    echo python main.py
+    echo.
+    pause
+    exit /b 1
+)
+
+echo Sprawdzam biblioteki...
+py -3.13 -m pip install pandas openpyxl xlrd
+
+echo.
+echo Uruchamiam Plan Monitor...
+py -3.13 main.py
+
+echo.
+echo Program zostal zamkniety.
+pause


### PR DESCRIPTION
### Motivation
- Ułatwić uruchamianie aplikacji Plan Monitor jednym kliknięciem oraz zapewnić wstępną weryfikację środowiska Python i zależności.

### Description
- Dodano plik `PlanMonitor/start.bat`, który ustawia katalog pracy na katalog skryptu, wyświetla startowy baner, sprawdza dostępność Pythona 3.13 przez `py -3.13 --version` i pokazuje instrukcję fallbacku gdy brak, instaluje wymagane biblioteki przez `py -3.13 -m pip install pandas openpyxl xlrd`, uruchamia `py -3.13 main.py` oraz zatrzymuje się na `pause` po zamknięciu programu.

### Testing
- Uruchomiono `pytest`, które zebrało 280 testów (4 pominięte) i wykazało niepowodzenia w testach GUI; przebieg testów został przerwany po zablokowaniu procesu i nie zakończył się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4444ed108323bcd0fb06f4815ba8)