### PR TITLE
Plan Monitor: rozpoznawanie polskich aliasów nagłówków i ręczne mapowanie kolumn (np. B)

### DIFF
--- a/PlanMonitor/gui.py
+++ b/PlanMonitor/gui.py
@@ -233,7 +233,7 @@ class SettingsDialog(tk.Toplevel):
             ("Interwał sprawdzania (sekundy)", "check_interval_seconds"),
             ("Słowa kluczowe działu (po przecinku)", "department_keywords"),
             ("Kolumna: nr zlecenia", "order"),
-            ("Kolumna: symbol / opis", "symbol"),
+            ("Kolumna: symbol / opis (np. B)", "symbol"),
             ("Kolumna: ilość", "quantity"),
             ("Kolumna: termin", "deadline"),
         )

--- a/PlanMonitor/main.py
+++ b/PlanMonitor/main.py
@@ -43,11 +43,17 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
 }
 COLUMN_ALIASES = {
-    "order": ("nr zlecenia", "numer zlecenia", "zlecenie", "order"),
-    "symbol": ("symbol", "opis", "produkt", "nazwa"),
-    "quantity": ("ilosc", "ilość", "szt", "quantity"),
-    "deadline": ("termin", "data", "deadline"),
+    "order": ("order", "nr zlecenia", "numer zlecenia", "nr zlec",
+              "nr zlec.", "zlecenie"),
+    "symbol": ("symbol", "opis", "nazwa", "pozycja", "wyrób", "detal",
+               "produkt"),
+    "quantity": ("quantity", "ilość", "ilosc", "szt", "szt."),
+    "deadline": ("date", "termin", "data", "data wysyłki", "data wysylki",
+                 "deadline"),
+    "process": ("process", "proces", "status"),
 }
+REQUIRED_COLUMNS = ("order", "symbol", "quantity", "deadline")
+OPTIONAL_COLUMNS = ("process",)
 CHANGE_LABELS = {
     "new": "NOWE",
     "removed": "USUNIĘTE",
@@ -138,16 +144,36 @@ def normalize_header(value: Any) -> str:
     return re.sub(r"\s+", " ", normalize_text(value).lower()).strip()
 
 
+def excel_column_index(reference: Any) -> int | None:
+    """Convert an Excel column reference such as ``B`` or ``AA`` to an index."""
+    normalized = normalize_text(reference).upper()
+    if not re.fullmatch(r"[A-Z]+", normalized):
+        return None
+    index = 0
+    for character in normalized:
+        index = index * 26 + ord(character) - ord("A") + 1
+    return index - 1
+
+
 def resolve_mapping(
     columns: Iterable[Any], configured: dict[str, str]
 ) -> dict[str, str]:
     """Resolve configured columns or infer common Polish/English titles."""
-    available = {normalize_header(column): str(column) for column in columns}
+    columns = [str(column) for column in columns]
+    available = {normalize_header(column): column for column in columns}
     mapping: dict[str, str] = {}
-    for field, aliases in COLUMN_ALIASES.items():
+    for field in REQUIRED_COLUMNS:
+        aliases = COLUMN_ALIASES[field]
         selected = configured.get(field, "")
-        if selected and selected in columns:
-            mapping[field] = selected
+        if field == "deadline":
+            selected = selected or configured.get("date", "")
+        selected_header = normalize_header(selected)
+        if selected_header in available:
+            mapping[field] = available[selected_header]
+            continue
+        selected_index = excel_column_index(selected)
+        if selected_index is not None and selected_index < len(columns):
+            mapping[field] = columns[selected_index]
             continue
         match = next(
             (original for normalized, original in available.items()
@@ -159,6 +185,14 @@ def resolve_mapping(
                 f"Nie znaleziono kolumny: {field}. Ustaw mapowanie kolumn."
             )
         mapping[field] = match
+    for field in OPTIONAL_COLUMNS:
+        match = next(
+            (original for normalized, original in available.items()
+             if normalized in COLUMN_ALIASES[field]),
+            "",
+        )
+        if match:
+            mapping[field] = match
     return mapping
 
 

--- a/tests/test_plan_monitor.py
+++ b/tests/test_plan_monitor.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from PlanMonitor.main import (PlanMonitor, append_dispositions, compare_plans,
                               export_changes, load_config, read_plan,
-                              save_config)
+                              resolve_mapping, save_config)
 
 
 def row(order="306", symbol="1.670.93 REMS", quantity=336,
@@ -88,3 +88,29 @@ def test_export_csv_and_txt(tmp_path):
         encoding="utf-8-sig"
     )
     assert "NOWE" in (tmp_path / "report.txt").read_text(encoding="utf-8")
+
+
+def test_read_plan_recognizes_polish_column_aliases(tmp_path):
+    plan = tmp_path / "plan.xlsx"
+    pd.DataFrame({
+        "Nr zlec.": [306.0],
+        "Detal": [" 1.670.93 REMS "],
+        "Szt.": ["450,5"],
+        "Data wysyłki": [pd.Timestamp("2026-06-13")],
+        "Proces": ["Produkcja"],
+    }).to_excel(plan, index=False)
+
+    assert read_plan(plan) == [row(quantity=450.5, deadline="2026-06-13")]
+    assert resolve_mapping(pd.read_excel(plan).columns, {})["process"] == "Proces"
+
+
+def test_read_plan_accepts_excel_letter_for_manual_symbol_mapping(tmp_path):
+    plan = tmp_path / "plan.xlsx"
+    pd.DataFrame({
+        "Nr zlec.": [306.0],
+        "Unnamed: 1": [" 1.670.93 REMS "],
+        "Ilość": [336],
+        "Data wysyłki": [pd.Timestamp("2026-06-11")],
+    }).to_excel(plan, index=False)
+
+    assert read_plan(plan, {"symbol": "B"}) == [row()]


### PR DESCRIPTION
### Motivation
- Użytkownik dostarcza pliki Excela z nagłówkami w języku polskim (np. `Nr zlec.`, `Ilość`, `Data wysyłki`) i program zgłasza błąd "Nie znaleziono kolumny: order"; celem jest nie wymagać technicznych nazw kolumn i umożliwić mapowanie kolumn bez typowego nagłówka.

### Description
- Rozszerzono listę aliasów kolumn w `PlanMonitor/main.py` o polskie i angielskie warianty dla `order`, `symbol`, `quantity`, `deadline` oraz dodano opcjonalne aliasy dla `process` (pole nie jest wymagane). 
- Dodano funkcję `excel_column_index()` oraz rozszerzono `resolve_mapping()` tak, aby akceptować ręczne mapowanie po literze kolumny Excel (np. `B`) oraz rozpoznawać skonfigurowane aliasy/nagłówki (w tym akceptację `date` jako aliasu deadline). 
- Uzupełniono GUI (`PlanMonitor/gui.py`) o drobną podpowiedź „(np. B)” przy polu mapowania symbolu, aby pokazać możliwość ręcznego mapowania po literze kolumny. 
- Dodano testy regresyjne w `tests/test_plan_monitor.py` sprawdzające rozpoznawanie polskich aliasów i ręczne mapowanie symbolu przez literę kolumny.
- Zmiany ograniczono wyłącznie do warstwy odczytu/mapowania kolumn i nie modyfikowano dalszej logiki eksportu/porównywania planu.

### Testing
- Uruchomiono modułowe testy Plan Monitor: `pytest tests/test_plan_monitor.py` — 6 tests passed. 
- Przeprowadzono proste sprawdzenia sanity: `python -m compileall PlanMonitor` (OK) i `git diff --check` (brak problemów syntaktycznych w zmodyfikowanych plikach). 
- Próba uruchomienia pełnego zestawu `pytest` ujawniła istniejące, niezwiązane z tą zmianą, błędy w testach GUI (`test_gui_logowanie.py`, `test_gui_narzedzia_config.py`) i przebieg testów zakończył się przedwcześnie/timeoutem; te nie zostały modyfikowane w tej zmianie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4928b9c08323bd681e140304a68d)