### PR TITLE
Fix Plan Monitor handling of empty Excel dates

### DIFF
--- a/PlanMonitor/main.py
+++ b/PlanMonitor/main.py
@@ -126,17 +126,26 @@ def normalize_quantity(value: Any) -> int | float | str:
     return int(number) if number.is_integer() else number
 
 
+def safe_date(value: Any) -> str:
+    """Format a spreadsheet date safely, including empty pandas values."""
+    if value is None or pd.isna(value):
+        return ""
+    if hasattr(value, "strftime"):
+        return value.strftime("%Y-%m-%d")
+    return str(value).strip()
+
+
 def normalize_deadline(value: Any) -> str:
     """Represent dates consistently in ISO format when possible."""
-    if value is None or (isinstance(value, float) and math.isnan(value)):
+    if value is None or pd.isna(value):
         return ""
     if isinstance(value, (datetime, date, pd.Timestamp)):
-        return value.strftime("%Y-%m-%d")
+        return safe_date(value)
     text = normalize_text(value)
     if not text:
         return ""
     parsed = pd.to_datetime(text, dayfirst=True, errors="coerce")
-    return parsed.strftime("%Y-%m-%d") if not pd.isna(parsed) else text
+    return safe_date(parsed) if not pd.isna(parsed) else text
 
 
 def normalize_header(value: Any) -> str:

--- a/tests/test_plan_monitor.py
+++ b/tests/test_plan_monitor.py
@@ -1,13 +1,14 @@
 """Tests for the independent Plan Monitor engine."""
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 
 from PlanMonitor.main import (PlanMonitor, append_dispositions, compare_plans,
                               export_changes, load_config, read_plan,
-                              resolve_mapping, save_config)
+                              resolve_mapping, safe_date, save_config)
 
 
 def row(order="306", symbol="1.670.93 REMS", quantity=336,
@@ -47,6 +48,27 @@ def test_read_plan_normalizes_excel_and_infers_columns(tmp_path):
     }).to_excel(plan, index=False)
 
     assert read_plan(plan) == [row(quantity=450.5, deadline="2026-06-13")]
+
+
+def test_safe_date_handles_empty_text_and_datetime_values():
+    assert safe_date(None) == ""
+    assert safe_date(pd.NaT) == ""
+    assert safe_date(float("nan")) == ""
+    assert safe_date(" 10 cze ") == "10 cze"
+    assert safe_date(datetime(2026, 6, 10)) == "2026-06-10"
+    assert safe_date(pd.Timestamp("2026-06-10")) == "2026-06-10"
+
+
+def test_read_plan_accepts_empty_excel_deadline(tmp_path):
+    plan = tmp_path / "plan.xlsx"
+    pd.DataFrame({
+        "Nr zlecenia": [306.0],
+        "Symbol": ["1.670.93 REMS"],
+        "Ilość": [336],
+        "Termin": [pd.NaT],
+    }).to_excel(plan, index=False)
+
+    assert read_plan(plan) == [row(deadline="")]
 
 
 def test_check_saves_snapshot_history_and_disposition(tmp_path):


### PR DESCRIPTION
### Motivation
- Fix crash when Plan Monitor attempts to call `strftime()` on empty/NaT Excel date cells which raised `NaTType does not support strftime`.
- Make date normalization resilient to `None`, pandas `NaT`/NaN, plain text like "10 cze", and `datetime`/`pd.Timestamp` values.

### Description
- Add a `safe_date(value: Any) -> str` helper in `PlanMonitor/main.py` that returns `""` for `None`/`pd.isna(...)`, uses `strftime("%Y-%m-%d")` for datetime-like objects, and otherwise returns trimmed text.
- Update `normalize_deadline` in `PlanMonitor/main.py` to use `safe_date` and replace explicit `math.isnan` checks with `pd.isna` where appropriate.
- Add regression tests in `tests/test_plan_monitor.py` that import `safe_date` and cover `None`, `pd.NaT`, `NaN`, text, `datetime`, `pd.Timestamp`, and an Excel row with an empty `Termin` cell.
- Only date-formatting robustness was changed; other program logic was left intact (files modified: `PlanMonitor/main.py`, `tests/test_plan_monitor.py`).

### Testing
- Ran `pytest tests/test_plan_monitor.py -q` and the focused Plan Monitor tests passed: `8 passed`.
- Compiled the modified modules with `python -m py_compile PlanMonitor/main.py tests/test_plan_monitor.py` which succeeded.
- Performed repository checks such as `git diff --check` and committed the changes; commit created with message "Fix Plan Monitor empty Excel dates".
- Note: running the full project test suite in this environment did not complete within the session limit and exposed unrelated GUI test failures outside the scope of this change, while the targeted Plan Monitor tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4d38a8bc8323b4bf5e6c806babe4)