### PR TITLE
Improve Plan Monitor Excel parsing for complex production plans

### DIFF
--- a/PlanMonitor/README.md
+++ b/PlanMonitor/README.md
@@ -1,7 +1,8 @@
 # Plan Monitor
 
-Samodzielna aplikacja testowa do monitorowania jednego sieciowego pliku planu
-produkcji. Nie importuje ani nie wykorzystuje kodu Warsztat Menager.
+Samodzielna aplikacja do monitorowania jednego sieciowego pliku planu
+produkcji. Nie importuje ani nie wykorzystuje kodu Warsztat Menager i nie
+generuje dyspozycji WM.
 
 ## Uruchomienie
 
@@ -10,17 +11,25 @@ python -m PlanMonitor.main
 ```
 
 Przy pierwszym uruchomieniu aplikacja poprosi o wskazanie pliku `xls`, `xlsx`
-lub `xlsm`. Ustawienia, ręczne mapowanie kolumn oraz słowa kluczowe działu można
-później zmienić przyciskiem **Ustawienia**.
+lub `xlsm`. Ustawienia, ręczne mapowanie liter kolumn, arkusz, zakres danych
+oraz słowa kluczowe działu można później zmienić przyciskiem **Ustawienia**.
 
-Dla starych plików `.xls` biblioteka pandas wymaga opcjonalnego silnika `xlrd`.
+Pliki `xlsx` i `xlsm` są analizowane bezpośrednio przez `openpyxl`: parser
+skanuje wielowierszowe nagłówki, czyta cały używany zakres arkusza, dziedziczy
+numer zlecenia oraz termin w grupie i nie zatrzymuje się na pustym wierszu.
+Dla starych plików `.xls` pozostaje fallback przez pandas, który wymaga
+opcjonalnego silnika `xlrd`.
+
+Po każdym odczycie ekran główny pokazuje liczbę przeskanowanych wierszy, liczbę
+pozycji i użyte kolumny. Przycisk **Podgląd odczytanych pozycji** wyświetla do
+100 pierwszych rekordów parsera. Szczegółowa diagnostyka trafia również do
+logu.
 
 ## Dane aplikacji
 
 - `config.json` — lokalna konfiguracja użytkownika,
-- `snapshots/current_snapshot.json` — ostatni pełny stan planu,
+- `snapshots/current_snapshot.json` — ostatni pełny stan planu i metadane parsera,
 - `reports/history.jsonl` — historia zmian, jeden obiekt JSON na linię,
-- `data/pending_dispositions.json` — przygotowane przyszłe dyspozycje WM,
 - `logs/plan_monitor.log` — log działania aplikacji.
 
 ## Budowanie EXE

--- a/PlanMonitor/config.json
+++ b/PlanMonitor/config.json
@@ -2,10 +2,15 @@
   "plan_file": "",
   "check_interval_seconds": 60,
   "department_keywords": [],
+  "sheet_name": null,
+  "header_scan_rows": 15,
+  "data_start_row": null,
+  "data_end_row": null,
   "column_mapping": {
     "order": "",
     "symbol": "",
     "quantity": "",
-    "deadline": ""
+    "date": "",
+    "process": ""
   }
 }

--- a/PlanMonitor/gui.py
+++ b/PlanMonitor/gui.py
@@ -11,10 +11,10 @@ from tkinter import filedialog, messagebox, ttk
 from typing import Any
 
 try:
-    from .main import (APP_DIR, CHANGE_LABELS, SUPPORTED_EXTENSIONS, PlanMonitor,
+    from .main import (SUPPORTED_EXTENSIONS, PlanMonitor,
                        display_row, export_changes, load_history, save_config)
 except ImportError:
-    from main import (APP_DIR, CHANGE_LABELS, SUPPORTED_EXTENSIONS, PlanMonitor,
+    from main import (SUPPORTED_EXTENSIONS, PlanMonitor,
                       display_row, export_changes, load_history, save_config)
 
 BG = "#171b22"
@@ -64,6 +64,10 @@ class MonitorApp(tk.Tk):
             "Status": tk.StringVar(value="Oczekiwanie na konfigurację"),
             "Ostatnie sprawdzenie": tk.StringVar(value="—"),
             "Ostatnia zmiana pliku": tk.StringVar(value="—"),
+            "Odczytano pozycji": tk.StringVar(value="0"),
+            "Przeskanowano wierszy": tk.StringVar(value="0"),
+            "Kolumny": tk.StringVar(value="—"),
+            "Ostatni błąd": tk.StringVar(value="—"),
         }
         for row, (label, variable) in enumerate(self.status_vars.items()):
             tk.Label(status, text=f"{label}:", width=23, anchor="w",
@@ -78,6 +82,7 @@ class MonitorApp(tk.Tk):
         for text, command in (
             ("Sprawdź teraz", lambda: self._check_async(force=True)),
             ("Pokaż zmiany", self._show_latest),
+            ("Podgląd odczytanych pozycji", self._show_preview),
             ("Historia zmian", self._show_history),
             ("Ustawienia", self._open_settings),
             ("Eksportuj raport", self._export),
@@ -159,9 +164,23 @@ class MonitorApp(tk.Tk):
             )
         if result.status == "error":
             self.status_vars["Status"].set("Błąd dostępu do pliku")
+            self.status_vars["Ostatni błąd"].set(result.error or result.message)
             messagebox.showwarning("Plan Monitor", result.message)
             return
         self.status_vars["Status"].set("Monitorowanie aktywne")
+        self.status_vars["Ostatni błąd"].set("—")
+        parser = result.parser or {}
+        mapping = parser.get("column_mapping", {})
+        self.status_vars["Odczytano pozycji"].set(
+            str(parser.get("records_count", len(result.rows)))
+        )
+        self.status_vars["Przeskanowano wierszy"].set(
+            str(parser.get("rows_scanned", 0))
+        )
+        self.status_vars["Kolumny"].set("/".join(
+            mapping.get(field, "-")
+            for field in ("order", "symbol", "quantity", "date", "process")
+        ))
         if result.changes:
             self.last_changes = result.changes
             self._render(self.last_changes)
@@ -176,7 +195,8 @@ class MonitorApp(tk.Tk):
         counts = Counter(change["type"] for change in changes)
         self.summary.set(
             f'Nowe: {counts["new"]}  |  Ilość: {counts["quantity_changed"]}'
-            f'  |  Terminy: {counts["deadline_changed"]}'
+            f'  |  Terminy: {counts["date_changed"]}'
+            f'  |  Proces: {counts["process_changed"]}'
             f'  |  Usunięte: {counts["removed"]}'
         )
 
@@ -196,11 +216,42 @@ class MonitorApp(tk.Tk):
             filetypes=[("CSV", "*.csv"), ("TXT", "*.txt")],
         )
         if path:
-            export_changes(self.last_changes, path)
+            export_changes(self.last_changes, path, self.monitor.last_parser)
             messagebox.showinfo("Plan Monitor", "Raport został zapisany.")
+
+    def _show_preview(self) -> None:
+        PreviewDialog(self, self.monitor.last_rows,
+                      self.monitor.config.get("department_keywords", []))
 
     def _open_settings(self) -> None:
         SettingsDialog(self, self.monitor)
+
+
+class PreviewDialog(tk.Toplevel):
+    """Show up to one hundred normalized records from the latest parse."""
+
+    def __init__(self, parent: MonitorApp, rows: list[dict[str, Any]],
+                 keywords: list[str]) -> None:
+        super().__init__(parent)
+        self.title("Podgląd odczytanych pozycji")
+        self.geometry("1100x520")
+        columns = ("order", "symbol", "quantity", "date", "process", "department")
+        table = ttk.Treeview(self, columns=columns, show="headings")
+        headings = ("Nr zlecenia", "Symbol / opis", "Ilość", "Termin", "Proces",
+                    "Dotyczy działu")
+        widths = (110, 330, 90, 130, 180, 140)
+        for column, heading, width in zip(columns, headings, widths):
+            table.heading(column, text=heading)
+            table.column(column, width=width, anchor="w")
+        for row in rows[:100]:
+            haystack = f'{row.get("symbol", "")} {row.get("order", "")}'.upper()
+            related = any(word.strip().upper() in haystack for word in keywords
+                          if word.strip())
+            table.insert("", "end", values=(row.get("order", ""),
+                         row.get("symbol", ""), row.get("quantity"),
+                         row.get("date", ""), row.get("process", ""),
+                         "TAK" if related else "NIE"))
+        table.pack(fill="both", expand=True, padx=12, pady=12)
 
 
 class SettingsDialog(tk.Toplevel):
@@ -211,7 +262,7 @@ class SettingsDialog(tk.Toplevel):
         self.parent = parent
         self.monitor = monitor
         self.title("Ustawienia Plan Monitor")
-        self.geometry("620x430")
+        self.geometry("700x700")
         self.configure(bg=BG)
         config = monitor.config
         mapping = config["column_mapping"]
@@ -223,19 +274,35 @@ class SettingsDialog(tk.Toplevel):
             "department_keywords": tk.StringVar(
                 value=", ".join(config.get("department_keywords", []))
             ),
+            "sheet_name": tk.StringVar(value=config.get("sheet_name") or ""),
+            "header_scan_rows": tk.StringVar(
+                value=str(config.get("header_scan_rows", 15))
+            ),
+            "data_start_row": tk.StringVar(
+                value=str(config.get("data_start_row") or "")
+            ),
+            "data_end_row": tk.StringVar(
+                value=str(config.get("data_end_row") or "")
+            ),
             "order": tk.StringVar(value=mapping.get("order", "")),
             "symbol": tk.StringVar(value=mapping.get("symbol", "")),
             "quantity": tk.StringVar(value=mapping.get("quantity", "")),
-            "deadline": tk.StringVar(value=mapping.get("deadline", "")),
+            "date": tk.StringVar(value=mapping.get("date", "")),
+            "process": tk.StringVar(value=mapping.get("process", "")),
         }
         labels = (
             ("Plik planu", "plan_file"),
             ("Interwał sprawdzania (sekundy)", "check_interval_seconds"),
             ("Słowa kluczowe działu (po przecinku)", "department_keywords"),
+            ("Nazwa arkusza (puste = aktywny)", "sheet_name"),
+            ("Liczba skanowanych wierszy nagłówka", "header_scan_rows"),
+            ("Pierwszy wiersz danych (opcjonalnie)", "data_start_row"),
+            ("Ostatni wiersz danych (opcjonalnie)", "data_end_row"),
             ("Kolumna: nr zlecenia", "order"),
             ("Kolumna: symbol / opis (np. B)", "symbol"),
             ("Kolumna: ilość", "quantity"),
-            ("Kolumna: termin", "deadline"),
+            ("Kolumna: data / termin", "date"),
+            ("Kolumna: proces", "process"),
         )
         for row, (label, key) in enumerate(labels):
             tk.Label(self, text=label, bg=BG, fg=TEXT, anchor="w").grid(
@@ -258,15 +325,28 @@ class SettingsDialog(tk.Toplevel):
         if path and Path(path).suffix.lower() in SUPPORTED_EXTENSIONS:
             self.values["plan_file"].set(path)
 
+    def _optional_int(self, key: str) -> int | None:
+        value = self.values[key].get().strip()
+        return max(1, int(value)) if value else None
+
     def _save(self) -> None:
         try:
             interval = max(1, int(self.values["check_interval_seconds"].get()))
+            header_scan_rows = max(1, int(self.values["header_scan_rows"].get()))
+            data_start_row = self._optional_int("data_start_row")
+            data_end_row = self._optional_int("data_end_row")
         except ValueError:
-            messagebox.showerror("Plan Monitor", "Interwał musi być liczbą.")
+            messagebox.showerror(
+                "Plan Monitor", "Interwał i numery wierszy muszą być liczbami."
+            )
             return
         config = {
             "plan_file": self.values["plan_file"].get().strip(),
             "check_interval_seconds": interval,
+            "sheet_name": self.values["sheet_name"].get().strip() or None,
+            "header_scan_rows": header_scan_rows,
+            "data_start_row": data_start_row,
+            "data_end_row": data_end_row,
             "department_keywords": [
                 item.strip() for item in
                 self.values["department_keywords"].get().split(",")
@@ -274,7 +354,7 @@ class SettingsDialog(tk.Toplevel):
             ],
             "column_mapping": {
                 key: self.values[key].get().strip()
-                for key in ("order", "symbol", "quantity", "deadline")
+                for key in ("order", "symbol", "quantity", "date", "process")
             },
         }
         save_config(config, self.monitor.config_path)

--- a/PlanMonitor/main.py
+++ b/PlanMonitor/main.py
@@ -1,6 +1,6 @@
 """Independent Excel production plan monitoring engine.
 
-This module deliberately does not import any Warsztat Menager code.  It can be
+This module deliberately does not import any Warsztat Menager code. It can be
 copied together with ``gui.py`` and packaged as a standalone application.
 """
 
@@ -9,16 +9,17 @@ from __future__ import annotations
 import csv
 import json
 import logging
-import math
 import os
 import re
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
 import pandas as pd
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 
 APP_DIR = (
     Path(sys.executable).resolve().parent
@@ -28,38 +29,47 @@ APP_DIR = (
 CONFIG_PATH = APP_DIR / "config.json"
 SNAPSHOT_PATH = APP_DIR / "snapshots" / "current_snapshot.json"
 HISTORY_PATH = APP_DIR / "reports" / "history.jsonl"
-DISPOSITIONS_PATH = APP_DIR / "data" / "pending_dispositions.json"
 LOG_PATH = APP_DIR / "logs" / "plan_monitor.log"
 SUPPORTED_EXTENSIONS = {".xls", ".xlsx", ".xlsm"}
+FIELDS = ("order", "symbol", "quantity", "date", "process")
 DEFAULT_CONFIG: dict[str, Any] = {
     "plan_file": "",
     "check_interval_seconds": 60,
     "department_keywords": [],
-    "column_mapping": {
-        "order": "",
-        "symbol": "",
-        "quantity": "",
-        "deadline": "",
-    },
+    "sheet_name": None,
+    "header_scan_rows": 15,
+    "data_start_row": None,
+    "data_end_row": None,
+    "column_mapping": {field: "" for field in FIELDS},
 }
 COLUMN_ALIASES = {
-    "order": ("order", "nr zlecenia", "numer zlecenia", "nr zlec",
-              "nr zlec.", "zlecenie"),
-    "symbol": ("symbol", "opis", "nazwa", "pozycja", "wyrób", "detal",
-               "produkt"),
-    "quantity": ("quantity", "ilość", "ilosc", "szt", "szt."),
-    "deadline": ("date", "termin", "data", "data wysyłki", "data wysylki",
-                 "deadline"),
-    "process": ("process", "proces", "status"),
+    "order": ("nr zlec", "nr zlec.", "nr zlecenia", "numer zlecenia",
+              "zlecenie", "order", "nr"),
+    "symbol": ("symbol", "opis", "nazwa", "wyrób", "wyrob", "detal",
+               "pozycja", "asortyment", "produkt"),
+    "quantity": ("ilość", "ilosc", "ilość szt", "szt", "szt.",
+                 "quantity"),
+    "date": ("data wysyłki", "data wysylki", "data", "termin", "wysyłka",
+             "wysylka", "deadline"),
+    "process": ("proces", "status", "operacja", "process"),
 }
-REQUIRED_COLUMNS = ("order", "symbol", "quantity", "deadline")
-OPTIONAL_COLUMNS = ("process",)
+DEFAULT_COLUMN_MAPPING = {
+    "order": "A",
+    "symbol": "B",
+    "quantity": "C",
+    "date": "D",
+    "process": "E",
+}
+HEADER_VALUES = {
+    alias for aliases in COLUMN_ALIASES.values() for alias in aliases
+} | {"tydzień", "tydzien", "pon", "wt", "śr", "sr", "czw", "pt", "sob",
+     "nd"}
 CHANGE_LABELS = {
     "new": "NOWE",
     "removed": "USUNIĘTE",
     "quantity_changed": "ILOŚĆ",
-    "deadline_changed": "TERMIN",
-    "description_changed": "OPIS",
+    "date_changed": "TERMIN",
+    "process_changed": "PROCES",
 }
 
 
@@ -70,7 +80,7 @@ def ensure_directories(base_dir: Path = APP_DIR) -> None:
 
 
 def setup_logging(log_path: Path = LOG_PATH) -> None:
-    """Configure rotating-unnecessary, simple UTF-8 file logging."""
+    """Configure simple UTF-8 file logging."""
     ensure_directories(log_path.parent.parent)
     if not any(
         isinstance(handler, logging.FileHandler)
@@ -87,13 +97,18 @@ def setup_logging(log_path: Path = LOG_PATH) -> None:
 
 def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:
     """Load configuration, filling newly introduced options with defaults."""
+    config = json.loads(json.dumps(DEFAULT_CONFIG))
     if not path.exists():
-        return json.loads(json.dumps(DEFAULT_CONFIG))
+        return config
     with path.open("r", encoding="utf-8") as file:
         loaded = json.load(file)
-    config = json.loads(json.dumps(DEFAULT_CONFIG))
     config.update(loaded)
-    config["column_mapping"].update(loaded.get("column_mapping", {}))
+    mapping = dict(DEFAULT_CONFIG["column_mapping"])
+    mapping.update(loaded.get("column_mapping", {}))
+    if "deadline" in mapping and not mapping.get("date"):
+        mapping["date"] = mapping["deadline"]
+    mapping.pop("deadline", None)
+    config["column_mapping"] = mapping
     return config
 
 
@@ -105,52 +120,67 @@ def save_config(config: dict[str, Any], path: Path = CONFIG_PATH) -> None:
         file.write("\n")
 
 
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
 def normalize_text(value: Any) -> str:
-    """Convert spreadsheet values into stable, stripped text."""
-    if value is None or (isinstance(value, float) and math.isnan(value)):
+    """Return whitespace-normalized text while retaining Polish characters."""
+    if _is_empty(value):
         return ""
     if isinstance(value, float) and value.is_integer():
-        return str(int(value))
-    return str(value).strip()
+        value = int(value)
+    return re.sub(r"\s+", " ", str(value)).strip()
 
 
-def normalize_quantity(value: Any) -> int | float | str:
-    """Keep quantities comparable while preserving non-numeric spreadsheet data."""
-    text = normalize_text(value).replace(" ", "").replace(",", ".")
+def normalize_order(value: Any) -> str:
+    """Return a stable order number without a spreadsheet ``.0`` suffix."""
+    return normalize_text(value)
+
+
+def normalize_quantity(value: Any) -> int | float | None:
+    """Parse a quantity such as ``450 szt``; return ``None`` if unavailable."""
+    text = normalize_text(value)
     if not text:
-        return ""
-    try:
-        number = float(text)
-    except ValueError:
-        return normalize_text(value)
+        return None
+    match = re.search(r"[-+]?\d[\d\s]*(?:[.,]\d+)?", text)
+    if not match:
+        return None
+    number = float(match.group(0).replace(" ", "").replace(",", "."))
     return int(number) if number.is_integer() else number
 
 
 def safe_date(value: Any) -> str:
     """Format a spreadsheet date safely, including empty pandas values."""
-    if value is None or pd.isna(value):
-        return ""
-    if hasattr(value, "strftime"):
-        return value.strftime("%Y-%m-%d")
-    return str(value).strip()
-
-
-def normalize_deadline(value: Any) -> str:
-    """Represent dates consistently in ISO format when possible."""
-    if value is None or pd.isna(value):
+    if _is_empty(value):
         return ""
     if isinstance(value, (datetime, date, pd.Timestamp)):
-        return safe_date(value)
-    text = normalize_text(value)
-    if not text:
-        return ""
-    parsed = pd.to_datetime(text, dayfirst=True, errors="coerce")
-    return safe_date(parsed) if not pd.isna(parsed) else text
+        return value.strftime("%Y-%m-%d")
+    return normalize_text(value)
+
+
+def normalize_date(value: Any) -> str:
+    """Normalize real Excel dates and preserve textual dates such as ``10 cze``."""
+    return safe_date(value)
+
+
+# Backward-compatible name used by older callers.
+normalize_deadline = normalize_date
+
+
+def normalize_process(value: Any) -> str:
+    """Return a whitespace-normalized process description."""
+    return normalize_text(value)
 
 
 def normalize_header(value: Any) -> str:
-    """Normalize a column title for alias matching."""
-    return re.sub(r"\s+", " ", normalize_text(value).lower()).strip()
+    """Normalize a possible spreadsheet header for alias matching."""
+    return normalize_text(value).lower()
 
 
 def excel_column_index(reference: Any) -> int | None:
@@ -164,74 +194,269 @@ def excel_column_index(reference: Any) -> int | None:
     return index - 1
 
 
+def _column_letter(reference: Any) -> str | None:
+    index = excel_column_index(reference)
+    return get_column_letter(index + 1) if index is not None else None
+
+
 def resolve_mapping(
-    columns: Iterable[Any], configured: dict[str, str]
+    columns: Iterable[Any], configured: dict[str, str] | None = None
 ) -> dict[str, str]:
-    """Resolve configured columns or infer common Polish/English titles."""
-    columns = [str(column) for column in columns]
-    available = {normalize_header(column): column for column in columns}
-    mapping: dict[str, str] = {}
-    for field in REQUIRED_COLUMNS:
-        aliases = COLUMN_ALIASES[field]
-        selected = configured.get(field, "")
-        if field == "deadline":
-            selected = selected or configured.get("date", "")
-        selected_header = normalize_header(selected)
-        if selected_header in available:
-            mapping[field] = available[selected_header]
-            continue
-        selected_index = excel_column_index(selected)
-        if selected_index is not None and selected_index < len(columns):
-            mapping[field] = columns[selected_index]
-            continue
-        match = next(
-            (original for normalized, original in available.items()
-             if normalized in aliases),
-            "",
-        )
-        if not match:
-            raise ValueError(
-                f"Nie znaleziono kolumny: {field}. Ustaw mapowanie kolumn."
-            )
-        mapping[field] = match
-    for field in OPTIONAL_COLUMNS:
-        match = next(
-            (original for normalized, original in available.items()
-             if normalized in COLUMN_ALIASES[field]),
-            "",
-        )
-        if match:
-            mapping[field] = match
-    return mapping
+    """Resolve a one-row header iterable for backward-compatible callers."""
+    columns = list(columns)
+    configured = configured or {}
+    rows = [columns]
+    return detect_column_mapping(rows, configured)
 
 
-def read_plan(
-    path: str | Path, mapping: dict[str, str] | None = None
-) -> list[dict[str, Any]]:
-    """Read the first worksheet and return normalized production positions."""
+def detect_column_mapping(
+    header_rows: Iterable[Iterable[Any]],
+    configured: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Detect column letters across multiple header rows, honoring overrides."""
+    configured = configured or {}
+    detected: dict[str, str] = {}
+    for field_name in FIELDS:
+        manual = configured.get(field_name, "")
+        if field_name == "date":
+            manual = manual or configured.get("deadline", "")
+        letter = _column_letter(manual)
+        if letter:
+            detected[field_name] = letter
+
+    for values in header_rows:
+        for column_index, value in enumerate(values, start=1):
+            normalized = normalize_header(value)
+            if not normalized:
+                continue
+            for field_name, aliases in COLUMN_ALIASES.items():
+                if field_name not in detected and normalized in aliases:
+                    detected[field_name] = get_column_letter(column_index)
+
+    for field_name, letter in DEFAULT_COLUMN_MAPPING.items():
+        detected.setdefault(field_name, letter)
+    return detected
+
+
+def _is_header_symbol(symbol: str) -> bool:
+    return normalize_header(symbol).rstrip(":") in HEADER_VALUES
+
+
+def _records_from_mapping(records: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    return list(records.values())
+
+
+@dataclass
+class ParserDiagnostics:
+    """Facts reported after parsing a worksheet."""
+
+    sheet: str = ""
+    rows_scanned: int = 0
+    records_count: int = 0
+    column_mapping: dict[str, str] = field(default_factory=dict)
+    skipped_empty: int = 0
+    skipped_header: int = 0
+    skipped_without_symbol: int = 0
+    skipped_non_production: int = 0
+    no_order: int = 0
+    sample: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ParseResult:
+    """Normalized records together with parser diagnostics."""
+
+    rows: list[dict[str, Any]]
+    diagnostics: ParserDiagnostics
+
+
+def _log_diagnostics(diagnostics: ParserDiagnostics) -> None:
+    mapping = " ".join(
+        f"{field}={diagnostics.column_mapping.get(field, '-')}"
+        for field in FIELDS
+    )
+    logging.info("[PLAN][PARSE] sheet=%s rows_scanned=%s", diagnostics.sheet,
+                 diagnostics.rows_scanned)
+    logging.info("[PLAN][PARSE] mapping %s", mapping)
+    logging.info(
+        "[PLAN][PARSE] records=%s skipped_empty=%s skipped_header=%s "
+        "skipped_without_symbol=%s skipped_non_production=%s no_order=%s",
+        diagnostics.records_count, diagnostics.skipped_empty,
+        diagnostics.skipped_header, diagnostics.skipped_without_symbol,
+        diagnostics.skipped_non_production, diagnostics.no_order,
+    )
+    for row in diagnostics.sample:
+        logging.info("[PLAN][PARSE] sample: %s | %s | %s | %s", row["order"],
+                     row["symbol"], row["quantity"], row["date"])
+
+
+def _openpyxl_plan(path: Path, config: dict[str, Any]) -> ParseResult:
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    requested_sheet = normalize_text(config.get("sheet_name"))
+    if requested_sheet:
+        if requested_sheet not in workbook.sheetnames:
+            raise ValueError(f"Nie znaleziono arkusza: {requested_sheet}")
+        worksheet = workbook[requested_sheet]
+    else:
+        worksheet = workbook.active or workbook.worksheets[0]
+
+    max_row = worksheet.max_row
+    scan_rows = max(1, int(config.get("header_scan_rows") or 15))
+    header_values = list(
+        worksheet.iter_rows(min_row=1, max_row=min(scan_rows, max_row),
+                            values_only=True)
+    )
+    mapping = detect_column_mapping(header_values, config.get("column_mapping"))
+    indexes = {field: excel_column_index(letter) for field, letter in mapping.items()}
+    start_row = max(1, int(config.get("data_start_row") or 1))
+    end_row = min(max_row, int(config.get("data_end_row") or max_row))
+    diagnostics = ParserDiagnostics(sheet=worksheet.title, column_mapping=mapping)
+    rows: list[dict[str, Any]] = []
+    last_order = ""
+    last_date = ""
+
+    for values in worksheet.iter_rows(min_row=start_row, max_row=end_row,
+                                      values_only=True):
+        diagnostics.rows_scanned += 1
+        values = tuple(values)
+        if not any(normalize_text(value) for value in values):
+            diagnostics.skipped_empty += 1
+            continue
+
+        def value_for(field: str) -> Any:
+            index = indexes.get(field)
+            return values[index] if index is not None and index < len(values) else None
+
+        explicit_order = normalize_order(value_for("order"))
+        symbol = normalize_text(value_for("symbol"))
+        quantity = normalize_quantity(value_for("quantity"))
+        explicit_date = normalize_date(value_for("date"))
+        process = normalize_process(value_for("process"))
+
+        if not symbol:
+            diagnostics.skipped_without_symbol += 1
+            continue
+        if _is_header_symbol(symbol):
+            diagnostics.skipped_header += 1
+            continue
+        if len(symbol) < 3:
+            diagnostics.skipped_non_production += 1
+            continue
+
+        order = explicit_order or last_order
+        if quantity is None and not order:
+            diagnostics.skipped_non_production += 1
+            continue
+        if explicit_order and explicit_order != last_order:
+            last_date = ""
+        row_date = explicit_date or last_date
+        row = {
+            "order": order,
+            "symbol": symbol,
+            "quantity": quantity,
+            "date": row_date,
+            "process": process,
+        }
+        rows.append(row)
+        if explicit_order:
+            last_order = explicit_order
+        if explicit_date:
+            last_date = explicit_date
+        if not order:
+            diagnostics.no_order += 1
+
+    workbook.close()
+    diagnostics.records_count = len(rows)
+    diagnostics.sample = rows[:5]
+    _log_diagnostics(diagnostics)
+    return ParseResult(rows, diagnostics)
+
+
+def _pandas_xls_plan(path: Path, config: dict[str, Any]) -> ParseResult:
+    """Fallback parser for legacy XLS files where openpyxl cannot be used."""
+    sheet_name = config.get("sheet_name") or 0
+    frame = pd.read_excel(path, sheet_name=sheet_name, header=None)
+    values = frame.where(pd.notna(frame), None).values.tolist()
+    scan_rows = max(1, int(config.get("header_scan_rows") or 15))
+    mapping = detect_column_mapping(values[:scan_rows], config.get("column_mapping"))
+    indexes = {field: excel_column_index(letter) for field, letter in mapping.items()}
+    start_row = max(1, int(config.get("data_start_row") or 1))
+    end_row = min(len(values), int(config.get("data_end_row") or len(values)))
+    diagnostics = ParserDiagnostics(sheet=str(sheet_name), column_mapping=mapping)
+    rows: list[dict[str, Any]] = []
+    last_order = ""
+    last_date = ""
+    for values_row in values[start_row - 1:end_row]:
+        diagnostics.rows_scanned += 1
+        if not any(normalize_text(value) for value in values_row):
+            diagnostics.skipped_empty += 1
+            continue
+        def get(field_name: str) -> Any:
+            index = indexes[field_name]
+            return values_row[index] if index < len(values_row) else None
+        explicit_order = normalize_order(get("order"))
+        symbol = normalize_text(get("symbol"))
+        quantity = normalize_quantity(get("quantity"))
+        explicit_date = normalize_date(get("date"))
+        process = normalize_process(get("process"))
+        if not symbol:
+            diagnostics.skipped_without_symbol += 1
+            continue
+        if _is_header_symbol(symbol):
+            diagnostics.skipped_header += 1
+            continue
+        if len(symbol) < 3:
+            diagnostics.skipped_non_production += 1
+            continue
+        order = explicit_order or last_order
+        if quantity is None and not order:
+            diagnostics.skipped_non_production += 1
+            continue
+        if explicit_order and explicit_order != last_order:
+            last_date = ""
+        row = {"order": order, "symbol": symbol, "quantity": quantity,
+               "date": explicit_date or last_date, "process": process}
+        rows.append(row)
+        last_order = explicit_order or last_order
+        last_date = explicit_date or last_date
+        if not order:
+            diagnostics.no_order += 1
+    diagnostics.records_count = len(rows)
+    diagnostics.sample = rows[:5]
+    _log_diagnostics(diagnostics)
+    return ParseResult(rows, diagnostics)
+
+
+def parse_plan(path: str | Path, config: dict[str, Any] | None = None) -> ParseResult:
+    """Parse the complete selected worksheet and return diagnostics."""
     plan_path = Path(path)
     if plan_path.suffix.lower() not in SUPPORTED_EXTENSIONS:
         raise ValueError("Obsługiwane formaty planu: xls, xlsx, xlsm.")
-    frame = pd.read_excel(plan_path)
-    resolved = resolve_mapping(frame.columns, mapping or {})
-    rows: list[dict[str, Any]] = []
-    for _, source in frame.iterrows():
-        row = {
-            "order": normalize_text(source[resolved["order"]]),
-            "symbol": normalize_text(source[resolved["symbol"]]),
-            "quantity": normalize_quantity(source[resolved["quantity"]]),
-            "deadline": normalize_deadline(source[resolved["deadline"]]),
-        }
-        if any(row.values()):
-            rows.append(row)
-    return rows
+    options = json.loads(json.dumps(DEFAULT_CONFIG))
+    if config:
+        options.update(config)
+        options["column_mapping"] = config.get("column_mapping", config)
+    if plan_path.suffix.lower() == ".xls":
+        return _pandas_xls_plan(plan_path, options)
+    return _openpyxl_plan(plan_path, options)
+
+
+def read_plan(path: str | Path, mapping: dict[str, str] | None = None,
+              **options: Any) -> list[dict[str, Any]]:
+    """Backward-compatible convenience wrapper returning normalized rows only."""
+    config = dict(options)
+    config["column_mapping"] = mapping or {}
+    return parse_plan(path, config).rows
 
 
 def position_key(row: dict[str, Any]) -> str:
-    """Build the requested order+symbol key, falling back to symbol+deadline."""
-    if row.get("order"):
-        return f'{row["order"]}|{row.get("symbol", "")}'
-    return f'{row.get("symbol", "")}|{row.get("deadline", "")}'
+    """Build a stable order+symbol key, falling back to symbol+date."""
+    order = normalize_order(row.get("order"))
+    symbol = normalize_text(row.get("symbol"))
+    row_date = normalize_date(row.get("date", row.get("deadline")))
+    if order:
+        return f"{order}|{symbol}"
+    return f"NO_ORDER|{symbol}|{row_date}"
 
 
 def concerns_department(row: dict[str, Any], keywords: Iterable[str]) -> bool:
@@ -241,82 +466,51 @@ def concerns_department(row: dict[str, Any], keywords: Iterable[str]) -> bool:
                if keyword.strip())
 
 
-def _change(
-    change_type: str,
-    row: dict[str, Any],
-    old: Any,
-    new: Any,
-    keywords: Iterable[str],
-    timestamp: str,
-) -> dict[str, Any]:
-    return {
-        "timestamp": timestamp,
-        "type": change_type,
-        "order": row.get("order", ""),
-        "symbol": row.get("symbol", ""),
-        "old": old,
-        "new": new,
-        "department_related": concerns_department(row, keywords),
-    }
+def _change(change_type: str, row: dict[str, Any], old: Any, new: Any,
+            keywords: Iterable[str], timestamp: str) -> dict[str, Any]:
+    return {"timestamp": timestamp, "type": change_type,
+            "order": row.get("order", ""), "symbol": row.get("symbol", ""),
+            "old": old, "new": new,
+            "department_related": concerns_department(row, keywords)}
 
 
-def compare_plans(
-    previous: list[dict[str, Any]],
-    current: list[dict[str, Any]],
-    keywords: Iterable[str] = (),
-    timestamp: str | None = None,
-) -> list[dict[str, Any]]:
-    """Return granular changes between two snapshots.
+def _canonical_row(row: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(row)
+    canonical["date"] = normalize_date(row.get("date", row.get("deadline")))
+    canonical.pop("deadline", None)
+    canonical.setdefault("process", "")
+    return canonical
 
-    Description changes are reconciled by a unique order number before the
-    requested order+symbol key is used, so renames are not reported as a
-    misleading remove/add pair.
-    """
+
+def compare_plans(previous: list[dict[str, Any]], current: list[dict[str, Any]],
+                  keywords: Iterable[str] = (), timestamp: str | None = None
+                  ) -> list[dict[str, Any]]:
+    """Return new, removed and field-level changes between complete snapshots."""
     timestamp = timestamp or datetime.now().isoformat(timespec="seconds")
-    old_by_key = {position_key(row): row for row in previous}
-    new_by_key = {position_key(row): row for row in current}
-    removed = {key: row for key, row in old_by_key.items()
-               if key not in new_by_key}
-    added = {key: row for key, row in new_by_key.items()
-             if key not in old_by_key}
+    old_by_key = {position_key(row): _canonical_row(row) for row in previous}
+    new_by_key = {position_key(row): _canonical_row(row) for row in current}
     changes: list[dict[str, Any]] = []
-
-    old_orders = {row["order"]: (key, row) for key, row in removed.items()
-                  if row.get("order")}
-    new_orders = {row["order"]: (key, row) for key, row in added.items()
-                  if row.get("order")}
-    for order in sorted(old_orders.keys() & new_orders.keys()):
-        old_key, old_row = old_orders[order]
-        new_key, new_row = new_orders[order]
-        changes.append(_change("description_changed", new_row,
-                               old_row["symbol"], new_row["symbol"],
-                               keywords, timestamp))
-        removed.pop(old_key)
-        added.pop(new_key)
-        _append_field_changes(changes, old_row, new_row, keywords, timestamp)
-
     for key in sorted(old_by_key.keys() & new_by_key.keys()):
         _append_field_changes(changes, old_by_key[key], new_by_key[key],
                               keywords, timestamp)
-    for row in added.values():
+    for key in sorted(new_by_key.keys() - old_by_key.keys()):
+        row = new_by_key[key]
         changes.append(_change("new", row, "", row, keywords, timestamp))
-    for row in removed.values():
+    for key in sorted(old_by_key.keys() - new_by_key.keys()):
+        row = old_by_key[key]
         changes.append(_change("removed", row, row, "", keywords, timestamp))
     return changes
 
 
-def _append_field_changes(
-    changes: list[dict[str, Any]],
-    old_row: dict[str, Any],
-    new_row: dict[str, Any],
-    keywords: Iterable[str],
-    timestamp: str,
-) -> None:
-    for field, change_type in (("quantity", "quantity_changed"),
-                               ("deadline", "deadline_changed")):
-        if old_row.get(field) != new_row.get(field):
-            changes.append(_change(change_type, new_row, old_row.get(field),
-                                   new_row.get(field), keywords, timestamp))
+def _append_field_changes(changes: list[dict[str, Any]],
+                          old_row: dict[str, Any], new_row: dict[str, Any],
+                          keywords: Iterable[str], timestamp: str) -> None:
+    for field_name, change_type in (("quantity", "quantity_changed"),
+                                    ("date", "date_changed"),
+                                    ("process", "process_changed")):
+        if old_row.get(field_name) != new_row.get(field_name):
+            changes.append(_change(change_type, new_row, old_row.get(field_name),
+                                   new_row.get(field_name), keywords, timestamp))
 
 
 def load_snapshot(path: Path = SNAPSHOT_PATH) -> dict[str, Any] | None:
@@ -327,20 +521,32 @@ def load_snapshot(path: Path = SNAPSHOT_PATH) -> dict[str, Any] | None:
         return json.load(file)
 
 
-def save_snapshot(
-    rows: list[dict[str, Any]], metadata: dict[str, Any],
-    path: Path = SNAPSHOT_PATH,
-) -> None:
-    """Persist the complete normalized plan and source file metadata."""
+def snapshot_rows(snapshot: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Load records from current snapshots and the legacy rows-list format."""
+    if not snapshot:
+        return []
+    if isinstance(snapshot.get("records"), dict):
+        return _records_from_mapping(snapshot["records"])
+    return snapshot.get("rows", [])
+
+
+def save_snapshot(rows: list[dict[str, Any]], metadata: dict[str, Any],
+                  path: Path = SNAPSHOT_PATH) -> None:
+    """Persist all normalized records and parser metadata as UTF-8 JSON."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"source": metadata, "rows": rows}
+    payload = {
+        "created_at": metadata.get("read_at", datetime.now().isoformat(timespec="seconds")),
+        "source_file": metadata.get("plan_file", ""),
+        "sheet": metadata.get("sheet", ""),
+        "parser": metadata.get("parser", {}),
+        "records": {position_key(row): row for row in rows},
+    }
     with path.open("w", encoding="utf-8") as file:
         json.dump(payload, file, ensure_ascii=False, indent=2)
         file.write("\n")
 
 
-def append_history(changes: Iterable[dict[str, Any]],
-                   path: Path = HISTORY_PATH) -> None:
+def append_history(changes: Iterable[dict[str, Any]], path: Path = HISTORY_PATH) -> None:
     """Append one JSON object per detected change."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as file:
@@ -356,45 +562,37 @@ def load_history(path: Path = HISTORY_PATH) -> list[dict[str, Any]]:
         return [json.loads(line) for line in file if line.strip()]
 
 
-def disposition_for(row: dict[str, Any]) -> dict[str, Any]:
-    """Create the future WM-compatible execution order payload."""
-    return {
-        "typ": "zlecenie_wykonania",
-        "nr_zlecenia": row.get("order", ""),
-        "symbol": row.get("symbol", ""),
-        "ilosc": row.get("quantity", 0),
-        "termin": row.get("deadline", ""),
-    }
+def format_parser_summary(parser: dict[str, Any] | ParserDiagnostics | None) -> list[str]:
+    """Return report lines describing the latest worksheet parse."""
+    if isinstance(parser, ParserDiagnostics):
+        parser = asdict(parser)
+    parser = parser or {}
+    mapping = parser.get("column_mapping", {})
+    columns = "/".join(mapping.get(field, "-") for field in FIELDS)
+    return [f'Przeskanowano wierszy: {parser.get("rows_scanned", 0)}',
+            f'Znaleziono pozycji: {parser.get("records_count", 0)}',
+            f"Użyte kolumny: {columns}"]
 
 
-def append_dispositions(changes: Iterable[dict[str, Any]],
-                        path: Path = DISPOSITIONS_PATH) -> None:
-    """Save pending future dispositions generated from every new position."""
-    existing: list[dict[str, Any]] = []
-    if path.exists():
-        with path.open("r", encoding="utf-8") as file:
-            existing = json.load(file)
-    existing.extend(disposition_for(change["new"]) for change in changes
-                    if change["type"] == "new")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as file:
-        json.dump(existing, file, ensure_ascii=False, indent=2)
-        file.write("\n")
-
-
-def export_changes(changes: list[dict[str, Any]], path: str | Path) -> None:
-    """Export visible changes to TXT or CSV according to the selected suffix."""
+def export_changes(changes: list[dict[str, Any]], path: str | Path,
+                   parser: dict[str, Any] | ParserDiagnostics | None = None) -> None:
+    """Export parser summary and visible changes to TXT or CSV."""
     export_path = Path(path)
     rows = [display_row(change) for change in changes]
     headers = ["Data", "Typ zmiany", "Nr zlecenia", "Symbol",
                "Stara wartość", "Nowa wartość", "Dotyczy działu"]
+    summary = format_parser_summary(parser)
     if export_path.suffix.lower() == ".csv":
         with export_path.open("w", encoding="utf-8-sig", newline="") as file:
             writer = csv.writer(file, delimiter=";")
+            for line in summary:
+                writer.writerow([line])
+            writer.writerow([])
             writer.writerow(headers)
             writer.writerows(rows)
     elif export_path.suffix.lower() == ".txt":
         with export_path.open("w", encoding="utf-8") as file:
+            file.write("\n".join(summary) + "\n\n")
             file.write(" | ".join(headers) + "\n")
             file.write("-" * 120 + "\n")
             for row in rows:
@@ -405,22 +603,15 @@ def export_changes(changes: list[dict[str, Any]], path: str | Path) -> None:
 
 def display_row(change: dict[str, Any]) -> tuple[Any, ...]:
     """Convert a history entry into GUI/export table columns."""
-    old = change.get("old", "")
-    new = change.get("new", "")
+    old, new = change.get("old", ""), change.get("new", "")
     if isinstance(old, dict):
         old = old.get("quantity", "")
     if isinstance(new, dict):
         new = new.get("quantity", "")
-    return (
-        change.get("timestamp", ""),
-        CHANGE_LABELS.get(change.get("type", ""), change.get("type", "")),
-        change.get("order", ""),
-        change.get("symbol", ""),
-        old,
-        new,
-        "DOTYCZY DZIAŁU" if change.get("department_related")
-        else "POZA DZIAŁEM",
-    )
+    return (change.get("timestamp", ""),
+            CHANGE_LABELS.get(change.get("type", ""), change.get("type", "")),
+            change.get("order", ""), change.get("symbol", ""), old, new,
+            "DOTYCZY DZIAŁU" if change.get("department_related") else "POZA DZIAŁEM")
 
 
 @dataclass
@@ -432,73 +623,82 @@ class CheckResult:
     file_modified_at: str = ""
     changes: list[dict[str, Any]] | None = None
     message: str = ""
+    parser: dict[str, Any] = field(default_factory=dict)
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    error: str = ""
 
 
 class PlanMonitor:
     """Stateful, GUI-independent production plan checker."""
 
-    def __init__(
-        self,
-        config_path: Path = CONFIG_PATH,
-        snapshot_path: Path = SNAPSHOT_PATH,
-        history_path: Path = HISTORY_PATH,
-        dispositions_path: Path = DISPOSITIONS_PATH,
-        reader: Callable[[str | Path, dict[str, str]],
-                         list[dict[str, Any]]] = read_plan,
-    ) -> None:
+    def __init__(self, config_path: Path = CONFIG_PATH,
+                 snapshot_path: Path = SNAPSHOT_PATH,
+                 history_path: Path = HISTORY_PATH,
+                 dispositions_path: Path | None = None,
+                 reader: Callable[..., Any] | None = None) -> None:
         self.config_path = config_path
         self.snapshot_path = snapshot_path
         self.history_path = history_path
-        self.dispositions_path = dispositions_path
         self.reader = reader
         self.config = load_config(config_path)
         self.last_signature: tuple[float, int] | None = None
+        self.last_parser: dict[str, Any] = {}
+        self.last_rows: list[dict[str, Any]] = []
 
     def reload_config(self) -> None:
         """Reload settings edited in the GUI."""
         self.config = load_config(self.config_path)
+
+    def _read(self, plan_file: str) -> ParseResult:
+        if self.reader is None:
+            return parse_plan(plan_file, self.config)
+        result = self.reader(plan_file, self.config.get("column_mapping", {}))
+        if isinstance(result, ParseResult):
+            return result
+        rows = list(result)
+        diagnostics = ParserDiagnostics(records_count=len(rows), sample=rows[:5])
+        return ParseResult(rows, diagnostics)
 
     def check(self, force: bool = False) -> CheckResult:
         """Check metadata and process a changed source file without raising."""
         checked_at = datetime.now().strftime("%H:%M:%S")
         plan_file = self.config.get("plan_file", "")
         if not plan_file:
-            return CheckResult("error", checked_at,
-                               message="Nie wybrano pliku planu.")
+            return CheckResult("error", checked_at, message="Nie wybrano pliku planu.",
+                               error="Nie wybrano pliku planu.")
         try:
             stat = os.stat(plan_file)
             signature = (stat.st_mtime, stat.st_size)
-            modified_at = datetime.fromtimestamp(stat.st_mtime).strftime(
-                "%H:%M:%S"
-            )
+            modified_at = datetime.fromtimestamp(stat.st_mtime).strftime("%H:%M:%S")
             snapshot = load_snapshot(self.snapshot_path)
             if not force and snapshot and signature == self.last_signature:
                 return CheckResult("unchanged", checked_at, modified_at, [],
-                                   "Plik nie zmienił się od ostatniego odczytu.")
-            rows = self.reader(plan_file, self.config["column_mapping"])
-            previous = snapshot.get("rows", []) if snapshot else []
+                                   "Plik nie zmienił się od ostatniego odczytu.",
+                                   self.last_parser, self.last_rows)
+            parsed = self._read(plan_file)
+            rows = parsed.rows
+            parser = asdict(parsed.diagnostics)
+            previous = snapshot_rows(snapshot)
             changes = compare_plans(previous, rows,
-                                    self.config["department_keywords"])
-            metadata = {
-                "plan_file": plan_file,
-                "modified_at": stat.st_mtime,
-                "size": stat.st_size,
-                "read_at": datetime.now().isoformat(timespec="seconds"),
-            }
+                                    self.config.get("department_keywords", []))
+            metadata = {"plan_file": plan_file,
+                        "read_at": datetime.now().isoformat(timespec="seconds"),
+                        "sheet": parsed.diagnostics.sheet, "parser": parser}
             save_snapshot(rows, metadata, self.snapshot_path)
             if changes:
                 append_history(changes, self.history_path)
-                append_dispositions(changes, self.dispositions_path)
             self.last_signature = signature
-            logging.info("Odczytano plan: %s; wykryto zmian: %s",
-                         plan_file, len(changes))
-            return CheckResult("changed" if changes else "unchanged",
-                               checked_at, modified_at, changes,
-                               notification_message(changes))
+            self.last_parser = parser
+            self.last_rows = rows
+            logging.info("Odczytano plan: %s; wykryto zmian: %s", plan_file,
+                         len(changes))
+            return CheckResult("changed" if changes else "unchanged", checked_at,
+                               modified_at, changes, notification_message(changes),
+                               parser, rows)
         except Exception as error:  # Keep network failures away from the GUI.
             logging.exception("Nie udało się odczytać planu: %s", plan_file)
-            return CheckResult("error", checked_at,
-                               message=f"Błąd odczytu pliku: {error}")
+            message = f"Błąd odczytu pliku: {error}"
+            return CheckResult("error", checked_at, message=message, error=message)
 
 
 def notification_message(changes: list[dict[str, Any]]) -> str:
@@ -506,8 +706,7 @@ def notification_message(changes: list[dict[str, Any]]) -> str:
     if not changes:
         return "Brak zmian w planie"
     related = sum(bool(change.get("department_related")) for change in changes)
-    return (f"Wykryto {len(changes)} zmiany. "
-            f"{related} dotyczą Twojego działu.")
+    return f"Wykryto {len(changes)} zmiany. {related} dotyczą Twojego działu."
 
 
 def main() -> None:

--- a/tests/test_plan_monitor.py
+++ b/tests/test_plan_monitor.py
@@ -2,137 +2,168 @@
 
 import json
 from datetime import datetime
-from pathlib import Path
 
 import pandas as pd
+from openpyxl import Workbook
 
-from PlanMonitor.main import (PlanMonitor, append_dispositions, compare_plans,
-                              export_changes, load_config, read_plan,
-                              resolve_mapping, safe_date, save_config)
+from PlanMonitor.main import (PlanMonitor, compare_plans, export_changes,
+                              load_config, normalize_quantity, parse_plan,
+                              position_key, read_plan, resolve_mapping,
+                              safe_date, save_config)
 
 
 def row(order="306", symbol="1.670.93 REMS", quantity=336,
-        deadline="2026-06-11"):
+        date="2026-06-11", process=""):
     return {"order": order, "symbol": symbol, "quantity": quantity,
-            "deadline": deadline}
+            "date": date, "process": process}
 
 
-def test_compare_detects_all_requested_change_types():
-    previous = [row(), row("501", "02.090 FAM", 200, "2026-06-12"),
-                row("700", "OLD NT", 2, "2026-06-10")]
-    current = [row(quantity=450, deadline="2026-06-13"),
-               row("501", "02.091 FAM", 200, "2026-06-12"),
-               row("800", "NEW MARPOL", 3, "2026-06-14")]
-
-    changes = compare_plans(previous, current, ["REMS", "NT", "FAM"])
-
-    assert {change["type"] for change in changes} == {
-        "new", "removed", "quantity_changed", "deadline_changed",
-        "description_changed",
-    }
-    assert next(change for change in changes
-                if change["type"] == "quantity_changed")["new"] == 450
-    assert next(change for change in changes
-                if change["type"] == "description_changed")["old"] == (
-                    "02.090 FAM"
-                )
+def make_realistic_plan(path):
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Plan produkcji"
+    sheet.append(["PLAN PRODUKCJI", None, None, "Czerwiec"])
+    sheet.append(["Nr zlec.", None, "Ilość szt", "Data wysyłki", "Proces",
+                  "Tydzień", "Pon", "Wt"])
+    sheet.append([None, None, None, None, None, "24", "10", "11"])
+    sheet.append([306, "00.055 REMS", "450 szt", "10 cze", "zgrzane"])
+    sheet.append([None, "1.670.93 REMS - RAL1003", 336, None, "lakiernia"])
+    sheet.append([None, None, None, None, None])
+    sheet.append([None, "2.510.120 REMS", 20, None, "pakowanie"])
+    sheet.append([None, "Pon", None, None, None])
+    sheet.append([500, "NT detal", 12, datetime(2026, 6, 12), "produkcja"])
+    workbook.save(path)
 
 
-def test_read_plan_normalizes_excel_and_infers_columns(tmp_path):
+def test_parse_plan_scans_complete_sheet_and_inherits_group_values(tmp_path):
     plan = tmp_path / "plan.xlsx"
-    pd.DataFrame({
-        "Nr zlecenia": [306.0],
-        "Symbol": [" 1.670.93 REMS "],
-        "Ilość": ["450,5"],
-        "Termin": [pd.Timestamp("2026-06-13")],
-    }).to_excel(plan, index=False)
+    make_realistic_plan(plan)
 
-    assert read_plan(plan) == [row(quantity=450.5, deadline="2026-06-13")]
+    parsed = parse_plan(plan)
+
+    assert parsed.rows == [
+        row(symbol="00.055 REMS", quantity=450, date="10 cze", process="zgrzane"),
+        row(symbol="1.670.93 REMS - RAL1003", date="10 cze", process="lakiernia"),
+        row(symbol="2.510.120 REMS", quantity=20, date="10 cze", process="pakowanie"),
+        row("500", "NT detal", 12, "2026-06-12", "produkcja"),
+    ]
+    diagnostics = parsed.diagnostics
+    assert diagnostics.rows_scanned == 9
+    assert diagnostics.records_count == 4
+    assert diagnostics.skipped_empty == 1
+    assert diagnostics.skipped_header == 1
+    assert diagnostics.skipped_without_symbol >= 1
+    assert diagnostics.column_mapping == {
+        "order": "A", "symbol": "B", "quantity": "C", "date": "D",
+        "process": "E",
+    }
+    assert len(diagnostics.sample) == 4
 
 
-def test_safe_date_handles_empty_text_and_datetime_values():
+def test_blank_row_does_not_stop_parser(tmp_path):
+    plan = tmp_path / "plan.xlsx"
+    make_realistic_plan(plan)
+
+    assert read_plan(plan)[-1]["order"] == "500"
+
+
+def test_manual_mapping_and_selected_sheet_override_detection(tmp_path):
+    plan = tmp_path / "plan.xlsx"
+    workbook = Workbook()
+    workbook.active.title = "Nie ten"
+    sheet = workbook.create_sheet("Właściwy")
+    sheet.append(["opis bez klasycznego nagłówka", "x", "x", "x", "x"])
+    sheet.append(["REMS symbol", 700, "10 cze", "gotowe", 900])
+    workbook.save(plan)
+
+    parsed = parse_plan(plan, {"sheet_name": "Właściwy", "data_start_row": 2,
+                               "column_mapping": {"symbol": "A", "quantity": "B",
+                                                  "date": "C", "process": "D",
+                                                  "order": "E"}})
+
+    assert parsed.rows == [row("900", "REMS symbol", 700, "10 cze", "gotowe")]
+
+
+def test_safe_date_and_quantity_normalizers_handle_empty_values():
     assert safe_date(None) == ""
     assert safe_date(pd.NaT) == ""
     assert safe_date(float("nan")) == ""
-    assert safe_date(" 10 cze ") == "10 cze"
+    assert safe_date(" 10\ncze ") == "10 cze"
     assert safe_date(datetime(2026, 6, 10)) == "2026-06-10"
-    assert safe_date(pd.Timestamp("2026-06-10")) == "2026-06-10"
+    assert normalize_quantity(450.0) == 450
+    assert normalize_quantity("450 szt") == 450
+    assert normalize_quantity("") is None
+    assert normalize_quantity("brak") is None
 
 
-def test_read_plan_accepts_empty_excel_deadline(tmp_path):
-    plan = tmp_path / "plan.xlsx"
-    pd.DataFrame({
-        "Nr zlecenia": [306.0],
-        "Symbol": ["1.670.93 REMS"],
-        "Ilość": [336],
-        "Termin": [pd.NaT],
-    }).to_excel(plan, index=False)
+def test_compare_uses_stable_key_and_detects_quantity_date_and_process():
+    previous = [row(process="cięcie")]
+    current = [row(quantity=450, date="2026-06-13", process="pakowanie")]
 
-    assert read_plan(plan) == [row(deadline="")]
+    changes = compare_plans(previous, current)
+
+    assert {change["type"] for change in changes} == {
+        "quantity_changed", "date_changed", "process_changed",
+    }
+    assert not {"new", "removed"} & {change["type"] for change in changes}
 
 
-def test_check_saves_snapshot_history_and_disposition(tmp_path):
+def test_symbol_change_is_reported_as_removed_and_new():
+    changes = compare_plans([row()], [row(symbol="NOWY REMS")])
+
+    assert {change["type"] for change in changes} == {"new", "removed"}
+
+
+def test_no_order_key_includes_symbol_and_date():
+    assert position_key(row(order="", date="10 cze")) == (
+        "NO_ORDER|1.670.93 REMS|10 cze"
+    )
+
+
+def test_check_saves_all_records_and_parser_metadata_without_wm_output(tmp_path):
     config_path = tmp_path / "config.json"
     snapshot_path = tmp_path / "snapshots" / "current_snapshot.json"
     history_path = tmp_path / "reports" / "history.jsonl"
-    disposition_path = tmp_path / "data" / "pending_dispositions.json"
     plan_file = tmp_path / "plan.xlsx"
-    plan_file.write_text("placeholder", encoding="utf-8")
+    make_realistic_plan(plan_file)
     config = load_config(tmp_path / "missing.json")
     config["plan_file"] = str(plan_file)
     save_config(config, config_path)
-    monitor = PlanMonitor(config_path, snapshot_path, history_path,
-                          disposition_path, reader=lambda *_: [row()])
+    monitor = PlanMonitor(config_path, snapshot_path, history_path)
 
     result = monitor.check(force=True)
 
     assert result.status == "changed"
-    assert json.loads(snapshot_path.read_text(encoding="utf-8"))["rows"] == [
-        row()
-    ]
-    assert json.loads(history_path.read_text(encoding="utf-8"))["type"] == "new"
-    assert json.loads(disposition_path.read_text(encoding="utf-8")) == [{
-        "typ": "zlecenie_wykonania",
-        "nr_zlecenia": "306",
-        "symbol": "1.670.93 REMS",
-        "ilosc": 336,
-        "termin": "2026-06-11",
-    }]
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert snapshot["source_file"] == str(plan_file)
+    assert snapshot["sheet"] == "Plan produkcji"
+    assert snapshot["parser"]["records_count"] == 4
+    assert len(snapshot["records"]) == 4
+    assert not (tmp_path / "data" / "pending_dispositions.json").exists()
 
 
-def test_export_csv_and_txt(tmp_path):
+def test_export_csv_and_txt_include_parser_summary(tmp_path):
     changes = compare_plans([], [row()], ["REMS"], "2026-06-01T07:30:00")
+    parser = {"rows_scanned": 124, "records_count": 87,
+              "column_mapping": {"order": "A", "symbol": "B", "quantity": "C",
+                                 "date": "D", "process": "E"}}
 
-    export_changes(changes, tmp_path / "report.csv")
-    export_changes(changes, tmp_path / "report.txt")
+    export_changes(changes, tmp_path / "report.csv", parser)
+    export_changes(changes, tmp_path / "report.txt", parser)
 
-    assert "DOTYCZY DZIAŁU" in (tmp_path / "report.csv").read_text(
-        encoding="utf-8-sig"
-    )
-    assert "NOWE" in (tmp_path / "report.txt").read_text(encoding="utf-8")
-
-
-def test_read_plan_recognizes_polish_column_aliases(tmp_path):
-    plan = tmp_path / "plan.xlsx"
-    pd.DataFrame({
-        "Nr zlec.": [306.0],
-        "Detal": [" 1.670.93 REMS "],
-        "Szt.": ["450,5"],
-        "Data wysyłki": [pd.Timestamp("2026-06-13")],
-        "Proces": ["Produkcja"],
-    }).to_excel(plan, index=False)
-
-    assert read_plan(plan) == [row(quantity=450.5, deadline="2026-06-13")]
-    assert resolve_mapping(pd.read_excel(plan).columns, {})["process"] == "Proces"
+    csv_text = (tmp_path / "report.csv").read_text(encoding="utf-8-sig")
+    txt_text = (tmp_path / "report.txt").read_text(encoding="utf-8")
+    assert "Przeskanowano wierszy: 124" in csv_text
+    assert "Znaleziono pozycji: 87" in txt_text
+    assert "Użyte kolumny: A/B/C/D/E" in txt_text
+    assert "DOTYCZY DZIAŁU" in csv_text
+    assert "NOWE" in txt_text
 
 
-def test_read_plan_accepts_excel_letter_for_manual_symbol_mapping(tmp_path):
-    plan = tmp_path / "plan.xlsx"
-    pd.DataFrame({
-        "Nr zlec.": [306.0],
-        "Unnamed: 1": [" 1.670.93 REMS "],
-        "Ilość": [336],
-        "Data wysyłki": [pd.Timestamp("2026-06-11")],
-    }).to_excel(plan, index=False)
+def test_resolve_mapping_accepts_aliases_and_manual_letters():
+    columns = ["Nr zlecenia", "bez nagłówka", "Ilość", "Termin", "Operacja"]
 
-    assert read_plan(plan, {"symbol": "B"}) == [row()]
+    assert resolve_mapping(columns, {"symbol": "B"}) == {
+        "order": "A", "symbol": "B", "quantity": "C", "date": "D",
+        "process": "E",
+    }


### PR DESCRIPTION
### Motivation
- The existing Plan Monitor relied on a single-row pandas read and failed on real production files with multi-row headers, merged/grouped cells, empty rows and non-ideal column names. 
- The goal was to rebuild the Excel parser to read the whole worksheet reliably (not require perfect headers), provide diagnostics, keep the app standalone (no WM integration) and avoid schema/GUI churn beyond minimal status fields and preview.

### Description
- Replace the primary reader with an `openpyxl`-based parser (fallback to pandas for legacy `.xls`) that scans multi-row headers, detects column letters by aliases or manual Excel-letter mapping, and accepts `sheet_name`, `header_scan_rows`, `data_start_row` and `data_end_row` options. 
- Implement robust normalization and helpers (`normalize_text`, `normalize_order`, `normalize_quantity`, `normalize_date`, `normalize_process`) and logic to inherit grouped `order` and `date` values across rows and to skip header/non-production rows while scanning the full range. 
- Stabilize comparison keys with `order|symbol` (fallback to `NO_ORDER|symbol|date`), compare full snapshots (new/removed and field-level changes: quantity/date/process), save snapshots with parser metadata and records mapping, and include parser summary lines in CSV/TXT exports. 
- Minimal GUI changes: add parser diagnostics/status fields (rows scanned, records count, used columns, last error), settings for sheet/scan range/manual mapping, and a "Podgląd odczytanych pozycji" preview dialog that shows up to 100 parsed records; removed generation of WM dispositions from the monitor flow to keep it standalone. 

### Testing
- Ran the PlanMonitor unit tests with `pytest -q tests/test_plan_monitor.py` and they passed (`10 passed`).
- Ran static checks and compilation: `ruff` (checks passed) and `python -m py_compile` for updated modules (successful). 
- Performed wider `pytest -q -x` which stops on an unrelated GUI login test requiring a display (`$DISPLAY` not set) in the container; this failure is external to Plan Monitor and does not affect the updated parser tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5edb547c832389b083f5b0120b2b)