### PR TITLE
Add contextual object actions to dyspozycje editor

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any
@@ -25,6 +26,41 @@ try:
 except Exception:  # pragma: no cover
     load_profiles_users = None  # type: ignore
     resolve_profiles_path = None  # type: ignore
+
+
+def _try_open_tool_editor(master: tk.Widget, object_id: str) -> None:
+    """Otwiera istniejący edytor narzędzia dla obiektu z dyspozycji."""
+    tool_id = str(object_id or "").strip()
+    if not tool_id:
+        messagebox.showwarning("Dyspozycje", "Brak numeru narzędzia.", parent=master)
+        return
+
+    try:
+        from config_manager import ConfigManager
+        from gui_tool_editor import ToolEditorDialog
+
+        cfg = ConfigManager()
+        tool_path = Path(cfg.path_data("narzedzia")) / f"{tool_id}.json"
+        if not tool_path.exists():
+            alt = Path(cfg.path_data("narzedzia")) / f"{tool_id.zfill(3)}.json"
+            if alt.exists():
+                tool_path = alt
+
+        if not tool_path.exists():
+            messagebox.showwarning(
+                "Dyspozycje",
+                f"Nie znaleziono pliku narzędzia: {tool_id}",
+                parent=master,
+            )
+            return
+
+        ToolEditorDialog(master.winfo_toplevel(), str(tool_path))
+    except Exception as exc:
+        messagebox.showerror(
+            "Dyspozycje",
+            f"Nie udało się otworzyć edytora narzędzia:\n{exc}",
+            parent=master,
+        )
 
 
 def _load_user_logins() -> list[str]:
@@ -63,6 +99,28 @@ def _options_for_type(typ: str) -> tuple[str, str, list[tuple[str, str]]]:
     return ("", "Obiekt:", [])
 
 
+def _try_open_machine_usage(
+    master: tk.Widget, object_id: str, object_label: str = ""
+) -> None:
+    """Otwiera istniejący moduł maszyn z kontekstem wybranej maszyny."""
+    machine_id = str(object_id or "").strip()
+    label = str(object_label or "").strip()
+    if not machine_id and not label:
+        messagebox.showwarning("Dyspozycje", "Brak wybranej maszyny.", parent=master)
+        return
+
+    try:
+        from gui_maszyny import open_machine_usage
+
+        open_machine_usage(master.winfo_toplevel(), machine_id, label=label)
+    except Exception as exc:
+        messagebox.showerror(
+            "Dyspozycje",
+            f"Nie udało się otworzyć użytkowania maszyny:\n{exc}",
+            parent=master,
+        )
+
+
 def open_dyspozycje_creator(
     master: tk.Widget | None = None,
     *,
@@ -85,6 +143,7 @@ def open_dyspozycje_creator(
     frame = ttk.Frame(win, padding=12)
     frame.pack(fill="both", expand=True)
     frame.columnconfigure(1, weight=1)
+    frame.rowconfigure(9, weight=1)
 
     ttk.Label(
         frame,
@@ -159,9 +218,76 @@ def open_dyspozycje_creator(
     )
     cb_assigned.grid(row=8, column=1, sticky="w", pady=4)
 
+    object_panel = ttk.LabelFrame(frame, text="Powiązany obiekt dyspozycji")
+    object_panel.grid(row=9, column=0, columnspan=2, sticky="nsew", pady=(14, 0))
+    object_panel.columnconfigure(0, weight=1)
+
+    var_object_panel_info = tk.StringVar(
+        value="Wybierz typ i obiekt dyspozycji, aby zobaczyć powiązany element."
+    )
+    lbl_object_panel_info = ttk.Label(
+        object_panel,
+        textvariable=var_object_panel_info,
+        wraplength=900,
+        justify="left",
+    )
+    lbl_object_panel_info.grid(row=0, column=0, sticky="ew", padx=10, pady=(10, 6))
+
+    object_panel_buttons = ttk.Frame(object_panel)
+    object_panel_buttons.grid(row=1, column=0, sticky="w", padx=10, pady=(0, 10))
+
     options_map: dict[str, str] = {}
     all_labels: list[str] = []
     source_module = {"value": ""}
+
+    btn_open_tool = ttk.Button(
+        object_panel_buttons,
+        text="Otwórz edytor narzędzia",
+        command=lambda: _try_open_tool_editor(
+            win,
+            options_map.get(var_object_display.get().strip(), ""),
+        ),
+    )
+    btn_open_machine = ttk.Button(
+        object_panel_buttons,
+        text="Otwórz użytkowanie maszyny",
+        command=lambda: _try_open_machine_usage(
+            win,
+            options_map.get(var_object_display.get().strip(), ""),
+            var_object_display.get().strip(),
+        ),
+    )
+
+    if not edit_mode:
+        object_panel.grid_remove()
+
+    def _refresh_object_panel(*_args) -> None:
+        if not edit_mode:
+            return
+        typ = var_type.get().strip().lower()
+        selected_label = var_object_display.get().strip()
+        object_id = options_map.get(selected_label, "").strip()
+
+        for child in object_panel_buttons.winfo_children():
+            child.pack_forget()
+
+        if typ == "narzedzie":
+            var_object_panel_info.set(
+                "Narzędzie powiązane z dyspozycją: "
+                f"{selected_label or object_id or 'brak wyboru'}"
+            )
+            btn_open_tool.pack(side="left")
+        elif typ == "maszyna":
+            var_object_panel_info.set(
+                "Maszyna powiązana z dyspozycją: "
+                f"{selected_label or object_id or 'brak wyboru'}"
+            )
+            btn_open_machine.pack(side="left")
+        else:
+            var_object_panel_info.set(
+                "Dla tego typu dyspozycji nie ma jeszcze edytora "
+                "kontekstowego w dolnym panelu."
+            )
 
     def _toggle_assigned(*_args) -> None:
         if var_all.get():
@@ -200,6 +326,7 @@ def open_dyspozycje_creator(
         if not picked and labels:
             picked = labels[0]
         var_object_display.set(picked)
+        _refresh_object_panel()
 
     _toggle_assigned()
     var_all.trace_add("write", _toggle_assigned)
@@ -225,8 +352,11 @@ def open_dyspozycje_creator(
                 var_object_display.set(filtered[0])
         else:
             var_object_display.set("")
+        _refresh_object_panel()
 
     var_object_search.trace_add("write", _filter_objects)
+    cb_object.bind("<<ComboboxSelected>>", _refresh_object_panel)
+    _refresh_object_panel()
 
     btns = ttk.Frame(win, padding=(12, 0, 12, 12))
     btns.pack(fill="x")

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2083,7 +2083,13 @@ def _detect_real_source(rows_from_fallback: List[Dict], primary_path: str, cfg: 
     return primary_path
 
 
-def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
+def _open_machines_panel(
+    root: tk.Misc,
+    container: tk.Misc,
+    Renderer=None,
+    *,
+    initial_machine_id: str = "",
+):
     for child in container.winfo_children():
         child.destroy()
 
@@ -4025,10 +4031,34 @@ def _open_machines_panel(root: tk.Misc, container: tk.Misc, Renderer=None):
     _refresh_schedule_info()
     _recompute_visible_rows()
     _refresh_tree()
-    _populate_details(None)
+    initial_machine = _find_machine(initial_machine_id)
+    if initial_machine is None:
+        _populate_details(None)
+    else:
+        selected_id = str(
+            initial_machine.get("id") or initial_machine.get("nr_ewid") or ""
+        ).strip()
+        _set_selected_machine(selected_id)
+        _refresh_tree()
+        _open_machine_usage_window(initial_machine)
 
     logger.info("[Maszyny] Panel otwarty; rekordów: %d", len(rows_cache))
     return tree
+
+
+def open_machine_usage(
+    master: tk.Misc, machine_id: str, *, label: str = ""
+) -> tk.Toplevel:
+    """Otwórz panel maszyn oraz użytkowanie wskazanej maszyny."""
+    win = tk.Toplevel(master)
+    win.title(f"Użytkowanie maszyny – {label or machine_id}")
+    win.geometry("1200x800")
+    win.resizable(True, True)
+
+    container = ttk.Frame(win)
+    container.pack(fill="both", expand=True)
+    _open_machines_panel(win, container, initial_machine_id=machine_id)
+    return win
 
 
 def panel_maszyny(root, frame, login=None, rola=None):


### PR DESCRIPTION
### Motivation
- Umożliwić szybki dostęp z edytora dyspozycji do powiązanych zasobów (narzędzi i maszyn) aby przyspieszyć korekty i przegląd kontekstu podczas edycji istniejącej dyspozycji.
- Obsłużyć rozpoznawanie plików narzędzi o numeracji z dopełnieniem zer (np. `7` → `007.json`) dla lepszej kompatybilności z istniejącymi plikami danych.
- Zapewnić bezpieczny mechanizm otwierania panelu maszyn z kontekstem wybranej maszyny bez wprowadzania twardych zależności między modułami.

### Description
- Dodano dolny panel „Powiązany obiekt dyspozycji” widoczny w trybie edycji, który pokazuje opis powiązanego obiektu i udostępnia akcje kontekstowe (przycisk do edytora narzędzia i do użytkowania maszyny). 
- Dodano funkcję `_try_open_tool_editor` która otwiera `ToolEditorDialog` dla wskazanego narzędzia, z fallbackem do pliku z dopełnionym numerem (`zfill(3)`) gdy pierwszy plik nie istnieje. 
- Dodano funkcję `_try_open_machine_usage` w kreatorze dyspozycji, która deleguje do nowego publicznego punktu wejścia `open_machine_usage` w module maszyn. 
- Rozszerzono `gui_maszyny` o opcjonalny `initial_machine_id` w `_open_machines_panel` oraz dodano `open_machine_usage(master, machine_id, *, label)` które tworzy okno panelu maszyn i automatycznie wybiera/otwiera kontekst wskazanej maszyny.

### Testing
- `python -m py_compile gui_dyspozycje_creator.py gui_maszyny.py` succeeded without syntax errors. 
- `git diff --check` (whitespace/format checks) reported no issues. 
- Focused GUI module tests `tests/test_gui_maszyny_status_history.py` and `tests/test_widok_hali_machines_view.py` were executed and passed (`11 passed`).
- Targeted, mocked Python checks validated tool-file fallback, machine-context forwarding and panel initialization (all assertions passed); a full `pytest` run was also attempted but encountered pre-existing GUI test failures in headless CI (see note). 
- Note: some unrelated GUI tests (in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py`) fail in this headless environment due to attempts to open Tk windows without `$DISPLAY`; these failures predate and are not caused by the changes in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d66c712848323a514255408fb2fef)