### PR TITLE
Dodaj fallback importu loggera w gui_tool_editor.py

### DIFF
--- a/gui_tool_editor.py
+++ b/gui_tool_editor.py
@@ -4,6 +4,7 @@
 # Logi: [WM-DBG] / [INFO] / [ERROR]
 # Język: PL (UI i komentarze)
 # Linia max ~100 znaków
+import logging
 import json
 import os
 from pathlib import Path
@@ -17,7 +18,12 @@ except Exception:
     def apply_theme(_root):
         # Fallback, gdy motyw nie jest dostępny – brak awarii okna
         pass
-from logger import get_logger
+try:
+    from logger import get_logger
+except Exception:
+    def get_logger(name):
+        return logging.getLogger(name)
+
 from config_manager import ConfigManager
 from logika_zadan import (
     get_collections,


### PR DESCRIPTION
### Motivation
- Naprawić błąd „cannot import name 'get_logger' from 'logger'” przy otwieraniu edytora narzędzia, gdy moduł `logger.py` nie udostępnia funkcji `get_logger`.
- Zaimplementować minimalny, nieinwazyjny fallback w `gui_tool_editor.py` bez zmiany logiki dyspozycji, struktury JSON ani refaktoryzacji modułu narzędzi.

### Description
- Dodano import standardowego modułu `logging` i owinęto `from logger import get_logger` w `try/except` w `gui_tool_editor.py`.
- W przypadku wyjątku zdefiniowano lokalną funkcję `get_logger(name)` zwracającą `logging.getLogger(name)` jako fallback.
- Nie zmieniono pozostałej logiki modułu, struktur danych ani obsługi dyspozycji.

### Testing
- Uruchomiono składniowy test Pythona `python3 -m py_compile gui_tool_editor.py gui_dyspozycje_creator.py`, który zakończył się pomyślnie.
- Wykonano bezpośredni import modułu za pomocą `python3 -c 'import gui_tool_editor'`, który potwierdził załadowanie modułu i użycie standardowego `Logger` jako fallbacku.
- Uruchomiono `pytest`, który zebrał `286` testów (4 skipped); uruchomienie wykazało istniejące niepowodzenia w części testów GUI i przestało się dalej raportować w tym środowisku, dlatego pełne przejście całego zestawu testów nie zostało osiągnięte w tej sesji.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d699642d883239a53edfd5245903c)