### PR TITLE
Zabezpieczenie odczytu tła w edytorze narzędzia

### DIFF
--- a/gui_tool_editor.py
+++ b/gui_tool_editor.py
@@ -234,11 +234,15 @@ class ToolEditorDialog(tk.Toplevel):
         )
         self.btn_save.pack()
         # Kropka stanu zapisu (zielona = zapisane, czerwona = niezapisane) – tk.Label (pewne w każdym motywie)
+        try:
+            btns_bg = btns.cget("background")
+        except tk.TclError:
+            btns_bg = None
         self.lbl_save_state = tk.Label(
             btns,
             text="●",
             fg="#44cc44", # start = clean
-            bg=btns.cget("background"),
+            bg=btns_bg if btns_bg else "#1f1f1f",
             font=("Segoe UI", 12, "bold"),
         )
         self.lbl_save_state.pack(side="right", padx=(0, 6))


### PR DESCRIPTION
### Motivation
- Naprawić błąd „unknown option "-background"” podczas otwierania okna „Edycja narzędzia”, który wynikał z wywołania `btns.cget('background')` na `ttk.Frame` powodującego `tk.TclError`.
- Wprowadzić minimalną, lokalną poprawkę w `gui_tool_editor.py` bez refaktoryzacji edytora, zmian JSON-ów, dyspozycji ani logiki maszyn.

### Description
- Dodano bezpieczne odczytanie tła otaczającej ramki: wynik `btns.cget("background")` jest teraz otoczony `try/except tk.TclError` i przypisywany do `btns_bg`.
- Jeżeli `btns.cget("background")` zgłasza `TclError` lub zwraca brak wartości, etykieta stanu zapisu (`self.lbl_save_state`) otrzymuje ciemny fallback kolor `#1f1f1f` zamiast bezpośredniego wywołania powodującego wyjątek.
- Zmiana ograniczona do jednego pliku: `gui_tool_editor.py` i zachowuje istniejące style oraz mechanikę przycisku zapisu.

### Testing
- Uruchomiono kompilację sprawdzającą: `python -m py_compile gui_tool_editor.py gui_dyspozycje_creator.py` i zakończyła się sukcesem.
- Przeprowadzono statyczne wyszukiwanie wystąpień konfiguracji `background/bg` oraz sprawdzenie dyfu, które wykazało jedynie `wip.configure(bg="#212121")` na zwykłym `tk.Toplevel` (który obsługuje `bg`).
- `pytest` został uruchomiony zgodnie z zasadami repozytorium, ale zestaw testów GUI zgłosił błędy i w tym środowisku wykonał się niestabilnie, dlatego pełne przejście GUI testów oraz ręczny test graficzny nie były możliwe z powodu braku serwera X (`DISPLAY` jest pusty).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6b0e547083238e5ba21b251f6221)