### PR TITLE
Otwieraj szczegóły narzędzi bezpośrednio z Dyspozycji

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -28,16 +28,19 @@ except Exception:  # pragma: no cover
 
 
 def _try_open_tool_editor(master: tk.Widget, object_id: str) -> None:
-    """Otwiera istniejący edytor narzędzia dla obiektu z dyspozycji."""
+    """Otwiera normalny widok narzędzia używany przez moduł Narzędzia."""
     tool_id = str(object_id or "").strip()
     if not tool_id:
         messagebox.showwarning("Dyspozycje", "Brak numeru narzędzia.", parent=master)
         return
 
     try:
-        from gui_narzedzia import open_tool_editor_by_id
+        from gui_narzedzia import open_tool_from_external_context
 
-        opened = open_tool_editor_by_id(master.winfo_toplevel(), tool_id)
+        opened = open_tool_from_external_context(
+            master.winfo_toplevel(),
+            tool_id,
+        )
         if not opened:
             messagebox.showwarning(
                 "Dyspozycje",

--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -491,6 +491,67 @@ from utils.gui_helpers import clear_frame
 from utils import error_dialogs
 import logger as app_logger
 
+
+def _external_tool_id_variants(tool_id: str) -> set[str]:
+    """Warianty ID narzędzia do porównania: 42 / 042."""
+    raw = str(tool_id or "").strip()
+    variants = {raw}
+    if raw.isdigit():
+        variants.add(raw.zfill(3))
+        variants.add(str(int(raw)))
+    return {item for item in variants if item}
+
+
+def _external_get_tool_id(tool: Mapping[str, Any]) -> str:
+    return str(tool.get("id") or tool.get("nr") or tool.get("numer") or "").strip()
+
+
+def _external_find_tool_by_id(tool_id: str) -> dict[str, Any] | None:
+    """Znajduje narzędzie po ID bez wymagania otwartego modułu Narzędzia."""
+    variants = _external_tool_id_variants(tool_id)
+
+    try:
+        cfg = get_config()
+        rows, _primary = load_tools_rows_with_fallback(cfg, resolve_rel)
+    except Exception:
+        rows = []
+
+    for row in rows or []:
+        if not isinstance(row, Mapping):
+            continue
+        row_id = _external_get_tool_id(row)
+        if row_id in variants:
+            return dict(row)
+        if row_id.isdigit() and str(int(row_id)) in variants:
+            return dict(row)
+
+    return None
+
+
+def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> bool:
+    """
+    Publiczny helper dla Dyspozycji.
+
+    Otwiera ten sam widok szczegółów narzędzia, którego używa lista narzędzi,
+    bez wymogu wcześniejszego otwarcia modułu Narzędzia.
+    """
+    tool = _external_find_tool_by_id(tool_id)
+    if not tool:
+        return False
+
+    try:
+        from tools_templates import load_default_templates
+
+        templates = load_default_templates()
+    except Exception:
+        templates = []
+
+    from narzedzia_ui.detail_view import open_tool_detail
+
+    open_tool_detail(master, tool, templates=templates)
+    return True
+
+
 logger = getLogger(__name__)
 if not hasattr(logger, "log_akcja"):
     setattr(logger, "log_akcja", getattr(app_logger, "log_akcja", lambda *args, **kwargs: None))
@@ -6894,6 +6955,7 @@ def panel_narzedzia(root, frame, login=None, rola=None):
 __all__ = [
     "panel_narzedzia",
     "open_tool_editor_by_id",
+    "open_tool_from_external_context",
     "_profiles_usernames",
     "_current_user",
     "_selected_task",


### PR DESCRIPTION
### Motivation
- Umożliwić otwieranie widoku szczegółów narzędzia z modułu Dyspozycje bez wymogu wcześniejszego uruchomienia panelu Narzędzia.
- Obsłużyć warianty identyfikatorów narzędzi (np. `42` vs `042`) oraz wyszukiwanie wpisów narzędziowych poza cache GUI.

### Description
- Zmieniono `_try_open_tool_editor` w `gui_dyspozycje_creator.py`, aby używał nowego publicznego helpera `open_tool_from_external_context` zamiast `open_tool_editor_by_id`.
- Dodano w `gui_narzedzia.py` funkcje pomocnicze `_external_tool_id_variants`, `_external_get_tool_id` i `_external_find_tool_by_id` do elastycznego porównywania i wyszukiwania narzędzi.
- Dodano `open_tool_from_external_context(master, tool_id)` w `gui_narzedzia.py`, które ładuje domyślne szablony i wywołuje istniejący lekki widok `open_tool_detail` z `narzedzia_ui.detail_view` bez potrzeby inicjalizacji panelu Narzędzia.
- Eksportowano nowy helper w `__all__` modułu `gui_narzedzia.py` tak, aby był dostępny z zewnętrznych modułów.

### Testing
- Uruchomiono składnię kompilacji: `python -m py_compile gui_dyspozycje_creator.py gui_narzedzia.py` and it succeeded. 
- Wykonano ręczny smoke test helpera przez prosty skrypt Pythonowy imitujący loader i widok szczegółów, zatwierdzający zachowanie `open_tool_from_external_context` dla `42`/`042` oraz brak znalezienia dla nieistniejącego ID. 
- Uruchomiono `pytest tests/test_gui_narzedzia_numbering.py tests/test_gui_narzedzia_missing_data.py` which reported `3 passed, 3 skipped`.
- Pełny `pytest` został także uruchomiony zgodnie z repo instrukcjami, jednak nie zakończył pełnego przebiegu z powodu wcześniej istniejących błędów w niezwiązanych testach (`test_gui_logowanie.py`, `test_gui_narzedzia_config.py`) i przerwania wykonania.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d71b1150c8323b9c22a8555e1645d)