### PR TITLE
Fix external tool loading fallback

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -506,15 +506,68 @@ def _external_get_tool_id(tool: Mapping[str, Any]) -> str:
     return str(tool.get("id") or tool.get("nr") or tool.get("numer") or "").strip()
 
 
+def _external_load_tools_rows() -> list[Mapping[str, Any]]:
+    """
+    Ładuje narzędzia dla wejścia z Dyspozycji.
+
+    Ma być odporne na różne sygnatury load_tools_rows_with_fallback()
+    i nie może wymagać wcześniej otwartego modułu Narzędzia.
+    """
+    attempts = []
+
+    try:
+        cfg = get_config()
+        attempts.append(lambda: load_tools_rows_with_fallback(cfg, resolve_rel))
+    except Exception:
+        pass
+
+    attempts.append(lambda: load_tools_rows_with_fallback())
+
+    for attempt in attempts:
+        try:
+            result = attempt()
+        except Exception:
+            continue
+
+        if isinstance(result, tuple):
+            rows = result[0] if result else []
+        else:
+            rows = result
+
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, Mapping)]
+
+    rows: list[Mapping[str, Any]] = []
+    try:
+        for entry in iter_tools_json():
+            if isinstance(entry, tuple):
+                path, data = entry
+            else:
+                path = entry
+                try:
+                    data = _safe_read_json(str(path), {})
+                except Exception:
+                    data = {}
+            if isinstance(data, Mapping):
+                row = dict(data)
+                row.setdefault("_path", str(path))
+                if not _external_get_tool_id(row):
+                    stem = Path(str(path)).stem
+                    row.setdefault("id", stem)
+                    row.setdefault("nr", stem)
+                    row.setdefault("numer", stem)
+                rows.append(row)
+    except Exception:
+        pass
+
+    return rows
+
+
 def _external_find_tool_by_id(tool_id: str) -> dict[str, Any] | None:
     """Znajduje narzędzie po ID bez wymagania otwartego modułu Narzędzia."""
     variants = _external_tool_id_variants(tool_id)
 
-    try:
-        cfg = get_config()
-        rows, _primary = load_tools_rows_with_fallback(cfg, resolve_rel)
-    except Exception:
-        rows = []
+    rows = _external_load_tools_rows()
 
     for row in rows or []:
         if not isinstance(row, Mapping):


### PR DESCRIPTION
### Motivation
- Ensure tools opened from the Dyspozycje context can be found even when the full Narzędzia module is not loaded or when helper functions have different signatures.
- Make the loader tolerant to both the configured `load_tools_rows_with_fallback(cfg, resolve_rel)` signature and a parameterless `load_tools_rows_with_fallback()` fallback used in other environments.
- Provide a robust fallback that works with the repository helper `iter_tools_json()` regardless of whether it yields `(path, doc)` tuples or path-only entries.

### Description
- Added `_external_load_tools_rows()` which tries multiple strategies to obtain tool rows and normalizes different return shapes from `load_tools_rows_with_fallback()` into a list of `Mapping` rows.
- Implemented a JSON fallback that iterates `iter_tools_json()` and accepts both `(path, document)` and path-only entries, using `_safe_read_json()` when only a path is provided.
- Derive missing tool identifiers (`id`, `nr`, `numer`) from the JSON filename stem when the document omits them so external lookups can match numeric variants like `42` / `042`.
- Updated `_external_find_tool_by_id()` to use `_external_load_tools_rows()` for resolution and continue to match normalized numeric ID variants.

### Testing
- Ran `python -m py_compile gui_narzedzia.py` which succeeded (existing `SyntaxWarning`s unrelated to this change were observed).
- Executed targeted UI tests with `pytest -q test_gui_narzedzia_enter.py test_gui_narzedzia_files.py test_gui_narzedzia_qr.py test_gui_narzedzia_tasks.py` which passed (`8 passed`).
- Added and ran small Python assertions exercising the different loader/iterator shapes (configured loader, tuple iterator, path-only iterator) and numeric ID normalization, which passed.
- Ran the full test suite under a 120s timeout, which did not complete: the run reported pre-existing failures in `test_gui_logowanie.py` and `test_gui_narzedzia_config.py` and then timed out before finishing the whole suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8071d98083238d97436bda4b0653)