### PR TITLE
Open full tool editor from Dispositions

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -582,27 +582,8 @@ def _external_find_tool_by_id(tool_id: str) -> dict[str, Any] | None:
 
 
 def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> bool:
-    """
-    Publiczny helper dla Dyspozycji.
-
-    Otwiera ten sam widok szczegółów narzędzia, którego używa lista narzędzi,
-    bez wymogu wcześniejszego otwarcia modułu Narzędzia.
-    """
-    tool = _external_find_tool_by_id(tool_id)
-    if not tool:
-        return False
-
-    try:
-        from tools_templates import load_default_templates
-
-        templates = load_default_templates()
-    except Exception:
-        templates = []
-
-    from narzedzia_ui.detail_view import open_tool_detail
-
-    open_tool_detail(master, tool, templates=templates)
-    return True
+    """Otwiera pełny edytor narzędzia podpięty do głównej listy narzędzi."""
+    return open_tool_editor_by_id(master, tool_id)
 
 
 logger = getLogger(__name__)


### PR DESCRIPTION
### Motivation
- Fix the Dyspozycje helper that opened only the read-only tool detail view so it instead opens the identical full Tool editor used by the Tools module.

### Description
- Change `open_tool_from_external_context(master, tool_id)` to delegate to `open_tool_editor_by_id(master, tool_id)` and remove the previous use of `narzedzia_ui.detail_view.open_tool_detail`, without modifying JSON, history, tasks, dispositions or machines.

### Testing
- Ran full `pytest` as required; the run exposed unrelated environment-dependent failures (Tk/Tkinter requiring `$DISPLAY`) and one preexisting tools-config assertion, indicating failures are not caused by this change.
- Ran `pytest test_gui_narzedzia_enter.py` which passed.
- Ran `python -m py_compile gui_narzedzia.py` and a direct Python delegation assertion which confirmed `open_tool_from_external_context` forwards to `open_tool_editor_by_id`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1daaf0c4688323a906336e788a7d30)