### PR TITLE
Dodaj fallback pełnego edytora narzędzi dla Dyspozycji

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -581,9 +581,78 @@ def _external_find_tool_by_id(tool_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _external_find_tool_path(tool: Mapping[str, Any]) -> str:
+    """Zwraca ścieżkę pliku narzędzia dla pełnego edytora."""
+    path = str(tool.get("_path") or tool.get("path") or tool.get("plik") or "").strip()
+    if path:
+        return path
+
+    tool_id = _external_get_tool_id(tool)
+    if not tool_id:
+        return ""
+
+    candidates: list[Path] = []
+    try:
+        base = Path(_resolve_tools_dir())
+        candidates.extend(
+            [
+                base / f"{tool_id}.json",
+                base / f"{tool_id.zfill(3)}.json"
+                if tool_id.isdigit()
+                else base / f"{tool_id}.json",
+            ]
+        )
+    except Exception:
+        pass
+
+    try:
+        for entry in iter_tools_json():
+            if isinstance(entry, tuple):
+                candidate_path = Path(str(entry[0]))
+            else:
+                candidate_path = Path(str(entry))
+            if candidate_path.stem in _external_tool_id_variants(tool_id):
+                candidates.append(candidate_path)
+    except Exception:
+        pass
+
+    for candidate in candidates:
+        try:
+            if candidate.exists():
+                return str(candidate)
+        except Exception:
+            continue
+    return ""
+
+
 def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> bool:
     """Otwiera pełny edytor narzędzia podpięty do głównej listy narzędzi."""
-    return open_tool_editor_by_id(master, tool_id)
+    try:
+        return open_tool_editor_by_id(master, tool_id)
+    except Exception as exc:
+        if "Moduł Narzędzia nie został jeszcze otwarty" not in str(exc):
+            raise
+
+    tool = _external_find_tool_by_id(tool_id)
+    if not tool:
+        return False
+
+    tool_path = _external_find_tool_path(tool)
+
+    editor = globals().get("open_tool_editor")
+    if callable(editor):
+        try:
+            editor(master, tool, tool_path=tool_path, editing=True)
+        except TypeError:
+            try:
+                editor(master, tool, tool_path, True)
+            except TypeError:
+                editor(master, tool)
+        return True
+
+    raise RuntimeError(
+        "Nie znaleziono funkcji open_tool_editor dla pełnego edytora narzędzia."
+    )
 
 
 logger = getLogger(__name__)


### PR DESCRIPTION
### Motivation
- Umożliwić otwieranie pełnego edytora narzędzia z kontekstu zewnętrznego (np. modułu Dyspozycji) również gdy panel Narzędzia nie został jeszcze załadowany.
- Odnalezienie ścieżki pliku narzędzia powinno być odporne na różne kształty rekordu (pole `_path`, `path`, `plik`) i warianty numeracji (np. `42` / `042`).

### Description
- Dodano funkcję `_external_find_tool_path(tool: Mapping[str, Any]) -> str`, która zwraca ścieżkę pliku narzędzia na podstawie pól rekordu lub przez sprawdzenie katalogu narzędzi (`_resolve_tools_dir()`) i wyników `iter_tools_json()`, obsługując warianty numeryczne ID. 
- Zmieniono `open_tool_from_external_context(master, tool_id)` aby najpierw próbować standardowego `open_tool_editor_by_id`, a jeśli moduł Narzędzia nie jest załadowany, wykonać fallback: odnaleźć rekord narzędzia, ustalić `tool_path` i wywołać globalną funkcję `open_tool_editor` w kilku wspieranych sygnaturach (`tool_path=...`, pozycyjnie, lub minimalnie). 
- Zachowano kompatybilność z istniejącymi sygnaturami edytora oraz zabezpieczono operacje przed błędami IO/iteracji przez ochronne `try/except`.

### Testing
- `python -m py_compile gui_narzedzia.py && git diff --check` zakończono pomyślnie (tylko istniejące ostrzeżenia składniowe niezwiązane z tą zmianą). 
- Ukierunkowany skrypt Python sprawdził odnajdywanie pliku `042.json` dla ID `42` oraz poprawne wywołanie fallbacku `open_tool_editor` z `tool_path` i `editing=True`, i zakończył się pomyślnie. 
- Uruchomiono wybrane testy modułu narzędzia: `pytest tests/test_gui_narzedzia_numbering.py tests/test_gui_narzedzia_tasks_mixed.py tests/test_gui_narzedzia_task_order.py` — `7 passed`.
- Przeprowadzono pełne `pytest`, które uruchomiono zgodnie z zasadami repozytorium, jednak przebieg przerwano po wykryciu niezwiązanych z tą zmianą problemów środowiskowych i wcześniejszych błędów testowych (m.in. testy logowania próbujące otworzyć Tk bez `$DISPLAY` oraz błąd w `test_gui_narzedzia_config.py`); do momentu przerwania raportowało `5 failed, 35 passed, 5 skipped` i proces został zatrzymany ze względu na długie oczekiwanie w części `multiprocessing`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6943fdd48323a698dc88926be0e5)