### PR TITLE
Fix opening full tool editor from Dispatches

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -492,6 +492,10 @@ from utils import error_dialogs
 import logger as app_logger
 
 
+_ACTIVE_TOOL_EDITOR_OPENER = None
+_ACTIVE_TOOL_EDITOR_ROOT = None
+
+
 def _external_tool_id_variants(tool_id: str) -> set[str]:
     """Warianty ID narzędzia do porównania: 42 / 042."""
     raw = str(tool_id or "").strip()
@@ -625,33 +629,36 @@ def _external_find_tool_path(tool: Mapping[str, Any]) -> str:
     return ""
 
 
-def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> bool:
-    """Otwiera pełny edytor narzędzia podpięty do głównej listy narzędzi."""
+def _active_tool_editor_available() -> bool:
+    root = globals().get("_ACTIVE_TOOL_EDITOR_ROOT")
+    opener = globals().get("_ACTIVE_TOOL_EDITOR_OPENER")
+    if not callable(opener):
+        return False
     try:
-        return open_tool_editor_by_id(master, tool_id)
-    except Exception as exc:
-        if "Moduł Narzędzia nie został jeszcze otwarty" not in str(exc):
-            raise
+        if root is not None and hasattr(root, "winfo_exists"):
+            return bool(root.winfo_exists())
+    except Exception:
+        return False
+    return root is not None
 
+
+def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> bool:
+    """
+    Publiczny helper dla Dyspozycji.
+    Otwiera pełny edytor narzędzia z modułu Narzędzia.
+    """
     tool = _external_find_tool_by_id(tool_id)
     if not tool:
         return False
 
-    tool_path = _external_find_tool_path(tool)
-
-    editor = globals().get("open_tool_editor")
-    if callable(editor):
-        try:
-            editor(master, tool, tool_path=tool_path, editing=True)
-        except TypeError:
-            try:
-                editor(master, tool, tool_path, True)
-            except TypeError:
-                editor(master, tool)
+    opener = globals().get("_ACTIVE_TOOL_EDITOR_OPENER")
+    if callable(opener) and _active_tool_editor_available():
+        opener(tool)
         return True
 
     raise RuntimeError(
-        "Nie znaleziono funkcji open_tool_editor dla pełnego edytora narzędzia."
+        "Pełny edytor narzędzia jest dostępny dopiero po otwarciu modułu Narzędzia. "
+        "Otwórz moduł Narzędzia raz, potem wróć do Dyspozycji."
     )
 
 
@@ -7045,6 +7052,10 @@ def panel_narzedzia(root, frame, login=None, rola=None):
         dlg.bind("<Escape>", _kb_close)
         dlg.bind("<Control-w>", _kb_close)
         dlg.bind("<F5>", _kb_refresh)
+
+    global _ACTIVE_TOOL_EDITOR_OPENER, _ACTIVE_TOOL_EDITOR_ROOT
+    _ACTIVE_TOOL_EDITOR_ROOT = root
+    _ACTIVE_TOOL_EDITOR_OPENER = lambda tool: open_tool_dialog(tool)
 
     # ===================== BINDY / START =====================
     _dbg("Init panel_narzedzia – start listy")


### PR DESCRIPTION
### Motivation
- Dyspozycja typu „narzedzie” otwierała tylko podgląd zamiast pełnego edytora, ponieważ ścieżka awaryjna szukała nieistniejącej funkcji `open_tool_editor` lub używała podglądu; celem jest minimalne podpięcie istniejącego, pełnego dialogu z `panel_narzedzia` bez refaktoryzacji modułu.

### Description
- Dodano globalne referencje `_ACTIVE_TOOL_EDITOR_OPENER` i `_ACTIVE_TOOL_EDITOR_ROOT` w `gui_narzedzia.py` do rejestracji aktywnego otwieracza edytora narzędzia oraz jego `root`.
- Zastąpiono implementację `open_tool_from_external_context` tak, by znajdowała narzędzie przez `_external_find_tool_by_id` i wywoływała zarejestrowany opener jeśli jest dostępny, zamiast próbować odnaleźć `open_tool_editor` lub uruchamiać podgląd.
- Dodano pomocniczą funkcję `_active_tool_editor_available()` sprawdzającą, czy zarejestrowany opener i `root` są aktywne (np. `winfo_exists`).
- Po definicji zagnieżdżonej funkcji `open_tool_dialog(tool, mode=None)` zarejestrowano opener i root (w tym zakresie, gdzie dostępne są `root` i `open_tool_dialog`) jako `lambda tool: open_tool_dialog(tool)`, co pozwala Dyspozycjom otwierać istniejący pełny dialog „Edytuj – NOWE/STARE”.
- Usunięto/pominięto fallbacky próbujące używać `open_tool_editor`, `open_tool_detail` oraz `ToolEditorDialog` zgodnie z wymaganiem, bez zmian w JSON-ach ani logice zadań/statusów.

### Testing
- `python -m py_compile gui_narzedzia.py gui_dyspozycje_creator.py` — kontrola składni zakończona powodzeniem.
- `py -3.13 -m py_compile gui_narzedzia.py gui_dyspozycje_creator.py` — niedostępne w środowisku (`py: command not found`).
- Uruchomiono zestaw docelowych testów: `pytest test_gui_narzedzia_config.py test_gui_narzedzia_enter.py test_gui_narzedzia_files.py test_gui_narzedzia_qr.py test_gui_narzedzia_tasks.py` — wynik: `10 passed, 1 failed` i niepowodzenie jest istniejącym, niezwiązanym testem `test_gui_narzedzia_config.py::test_load_config_logs`.
- Wykonano dedykowany skrypt/mostek w Pythonie symulujący rejestrację openera i scenariusze (istniejące narzędzie, brak narzędzia, niedostępny moduł Narzędzia) i wszystkie asercje w tej kontroli przeszły pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7788e9908323a8dcc9725b488474)