### PR TITLE
Open full tool editor from dispatches; reduce dyspozycje_store debug spam

### DIFF
--- a/dyspozycje_store.py
+++ b/dyspozycje_store.py
@@ -31,6 +31,10 @@ except Exception:  # pragma: no cover
     wm_root_paths = None  # type: ignore
 
 
+_DYSP_DEBUG_STORE = False
+_DYSP_LEGACY_WARNED = False
+
+
 DISP_FILE_NAME = "dyspozycje.json"
 DISP_DIR_NAME = "dyspozycje"
 DISP_ALLOWED_TYPES = {
@@ -57,26 +61,29 @@ def _runtime_cfg_manager():
         if start_mod is not None:
             mgr = getattr(start_mod, "CONFIG_MANAGER", None)
             if mgr is not None:
-                try:
-                    print(
-                        "[WM-DBG][DYSP][STORE] runtime manager=start.CONFIG_MANAGER "
-                        f"{type(mgr).__name__}"
-                    )
-                except Exception:
-                    pass
+                if _DYSP_DEBUG_STORE:
+                    try:
+                        print(
+                            "[WM-DBG][DYSP][STORE] "
+                            "runtime manager=start.CONFIG_MANAGER "
+                            f"{type(mgr).__name__}"
+                        )
+                    except Exception:
+                        pass
                 return mgr
     except Exception:
         pass
     if ConfigManager is not None:
         try:
             mgr = ConfigManager()
-            try:
-                print(
-                    "[WM-DBG][DYSP][STORE] runtime manager=ConfigManager() "
-                    f"{type(mgr).__name__}"
-                )
-            except Exception:
-                pass
+            if _DYSP_DEBUG_STORE:
+                try:
+                    print(
+                        "[WM-DBG][DYSP][STORE] runtime manager=ConfigManager() "
+                        f"{type(mgr).__name__}"
+                    )
+                except Exception:
+                    pass
             return mgr
         except Exception:
             pass
@@ -88,10 +95,11 @@ def _data_root() -> Path:
     if mgr is not None:
         try:
             path = Path(mgr.path_data())
-            try:
-                print(f"[WM-DBG][DYSP][STORE] data_root={path}")
-            except Exception:
-                pass
+            if _DYSP_DEBUG_STORE:
+                try:
+                    print(f"[WM-DBG][DYSP][STORE] data_root={path}")
+                except Exception:
+                    pass
             return path
         except Exception:
             pass
@@ -107,10 +115,11 @@ def _anchor_root() -> Path:
                 continue
             try:
                 path = Path(method())
-                try:
-                    print(f"[WM-DBG][DYSP][STORE] anchor_root={path}")
-                except Exception:
-                    pass
+                if _DYSP_DEBUG_STORE:
+                    try:
+                        print(f"[WM-DBG][DYSP][STORE] anchor_root={path}")
+                    except Exception:
+                        pass
                 return path
             except Exception:
                 continue
@@ -135,6 +144,8 @@ def _active_dyspozycje_path() -> Path:
 
 
 def _migrate_legacy_if_needed(target: Path) -> None:
+    global _DYSP_LEGACY_WARNED
+
     legacy_candidates = [
         _legacy_root_dyspozycje_path(),
         _legacy_dyspozycje_path(),
@@ -153,37 +164,39 @@ def _migrate_legacy_if_needed(target: Path) -> None:
         if not legacy.exists():
             continue
         if target.exists():
-            try:
+            if not _DYSP_LEGACY_WARNED:
                 print(
                     "[WM-DBG][DYSP][STORE][WARN] legacy dyspozycje exists "
                     f"but active is data dyspozycje: {legacy}"
                 )
-            except Exception:
-                pass
+                _DYSP_LEGACY_WARNED = True
             continue
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, target)
-            print(
-                "[WM-DBG][DYSP][STORE] migrated legacy dyspozycje: "
-                f"{legacy} -> {target}"
-            )
+            if _DYSP_DEBUG_STORE:
+                print(
+                    "[WM-DBG][DYSP][STORE] migrated legacy dyspozycje: "
+                    f"{legacy} -> {target}"
+                )
             return
         except Exception as exc:
-            try:
-                print(f"[WM-DBG][DYSP][STORE] migration failed: {exc}")
-            except Exception:
-                pass
+            if _DYSP_DEBUG_STORE:
+                try:
+                    print(f"[WM-DBG][DYSP][STORE] migration failed: {exc}")
+                except Exception:
+                    pass
 
 
 def get_dyspozycje_path() -> Path:
     path = _active_dyspozycje_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     _migrate_legacy_if_needed(path)
-    try:
-        print(f"[WM-DBG][DYSP][STORE] dyspozycje_path={path}")
-    except Exception:
-        pass
+    if _DYSP_DEBUG_STORE:
+        try:
+            print(f"[WM-DBG][DYSP][STORE] dyspozycje_path={path}")
+        except Exception:
+            pass
     return path
 
 

--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -4056,9 +4056,34 @@ def open_tool_editor_by_id(
     current_role: str | None = None,
 ) -> bool:
     """Otwórz narzędzie przez edytor podpięty do głównej listy narzędzi."""
-    del master, current_user, current_role
+    del current_user, current_role
+
     if _OPEN_TOOL_EDITOR_BY_ID is None:
-        raise RuntimeError("Moduł Narzędzia nie został jeszcze otwarty.")
+        try:
+            win = tk.Toplevel(master) if master is not None else tk.Toplevel()
+            win.title("Narzędzia")
+            win.geometry("1400x850")
+            win.resizable(True, True)
+            try:
+                apply_theme(win)
+                ensure_theme_applied(win)
+            except Exception:
+                pass
+
+            frame = ttk.Frame(win, style="WM.TFrame")
+            frame.pack(fill="both", expand=True)
+
+            panel_narzedzia(win, frame, login=None, rola=None)
+            win.after(
+                300,
+                lambda: open_tool_editor_by_id(win, tool_id),
+            )
+            return True
+        except Exception as exc:
+            raise RuntimeError(
+                "Nie udało się automatycznie otworzyć modułu Narzędzia dla edycji narzędzia."
+            ) from exc
+
     return _OPEN_TOOL_EDITOR_BY_ID(str(tool_id or "").strip())
 
 
@@ -4245,6 +4270,9 @@ def panel_narzedzia(root, frame, login=None, rola=None):
         except Exception:
             return False
         return False
+
+    global _OPEN_TOOL_EDITOR_BY_ID
+    _OPEN_TOOL_EDITOR_BY_ID = _open_tool_by_id
 
     class _ToolsViewFallback:
         def _refresh_all(self) -> None:
@@ -7062,8 +7090,6 @@ def panel_narzedzia(root, frame, login=None, rola=None):
     btn_add.configure(command=choose_mode_and_add)
     if tools_view is not None:
         tools_view.bind_open_detail(_open_tool_by_id)
-    global _OPEN_TOOL_EDITOR_BY_ID
-    _OPEN_TOOL_EDITOR_BY_ID = _open_tool_by_id
     refresh_list()
 
 __all__ = [


### PR DESCRIPTION
### Motivation
- Clicking “Otwórz edytor narzędzia” from a dispatch of type `narzedzie` must open the full tool editor even if the Narzędzia module was not previously opened. 
- The dispatch store prints repetitive `[WM-DBG][DYSP][STORE]` messages and repeats a legacy warning; these should be quiet by default and the legacy warning should be shown at most once per process.

### Description
- In `gui_narzedzia.py` updated `open_tool_editor_by_id` to bootstrap a `Toplevel` window, initialize `panel_narzedzia(...)` and schedule a re-call to `open_tool_editor_by_id` after 300 ms when `_OPEN_TOOL_EDITOR_BY_ID` is not yet registered, so a cold dispatch opens the full editor automatically.
- In `panel_narzedzia(...)` register the nested `_open_tool_by_id` callback immediately after its definition by setting the global `_OPEN_TOOL_EDITOR_BY_ID = _open_tool_by_id`, ensuring external callers use the existing full-editor path.
- In `dyspozycje_store.py` added `_DYSP_DEBUG_STORE = False` and `_DYSP_LEGACY_WARNED = False` flags and wrapped verbose debug `print` calls behind `_DYSP_DEBUG_STORE`, and modified the legacy-store warning to print only once by using `_DYSP_LEGACY_WARNED`.
- Kept existing editor flow intact (calls to the nested `open_tool_dialog` remain unchanged) and avoided any forbidden APIs or refactors per instructions.

### Testing
- Ran syntax check with `python -m py_compile gui_narzedzia.py gui_dyspozycje_creator.py dyspozycje_store.py` and it passed (syntax OK). 
- Executed an inline Python regression check (mocking `Toplevel`, `ttk.Frame`, theme calls and `panel_narzedzia` registration) which validated that a cold `open_tool_editor_by_id(None, '007')` returns `True`, schedules the `after` callback with a 300 ms delay and the callback invokes the registered opener; this check passed.
- Ran a focused `pytest` subset for Narzędzia-related tests; result: the selected tests reported `16 passed, 3 skipped, 1 failed` where the single failure (`test_gui_narzedzia_config.py::test_load_config_logs`) is unrelated to these changes (it expects a specific logged message from a simulated `open` failure).
- Full test run hit existing unrelated timeouts/known GUI environment limitations in this non-interactive container; no regressions introduced by the patch were observed in the regression checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7da49d408323a1a4989bcf8cc070)