### PR TITLE
Keep machine edit actions visible in a fixed footer

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2838,14 +2838,21 @@ def _open_machines_panel(
                 ),
             ).grid(row=2, column=1, sticky="w", padx=6, pady=(0, 6))
 
-            btns = ttk.Frame(frm)
-            btns.grid(row=10, column=0, columnspan=2, pady=(14, 0))
-            ttk.Button(btns, text="Anuluj", command=self.destroy).pack(side="right", padx=6)
+            footer = ttk.Frame(self, padding=(12, 8))
+            footer.pack(side="bottom", fill="x")
+            ttk.Button(footer, text="Zamknij", command=self.destroy).pack(
+                side="right", padx=(6, 0)
+            )
+            ttk.Button(footer, text="Anuluj", command=self.destroy).pack(
+                side="right", padx=(6, 0)
+            )
             ttk.Button(
-                btns,
+                footer,
                 text="Zapisz",
-                command=lambda: self._ok(int_or_none(self.e_x.get()), int_or_none(self.e_y.get())),
-            ).pack(side="right", padx=6)
+                command=lambda: self._ok(
+                    int_or_none(self.e_x.get()), int_or_none(self.e_y.get())
+                ),
+            ).pack(side="right")
             self.bind(
                 "<Return>",
                 lambda *_: self._ok(int_or_none(self.e_x.get()), int_or_none(self.e_y.get())),


### PR DESCRIPTION
### Motivation
- Ensure the action buttons in the "Edycja maszyny" dialog (Zapisz / Anuluj / Zamknij) remain visible and accessible at the bottom of the window even when the form content is large and scrolls. 
- Avoid placing action buttons inside the form grid so they are not clipped by the expandable/scrollable area of the dialog. 

### Description
- Move the dialog action buttons out of the form grid into a dedicated footer attached directly to the dialog `Toplevel` and packed with `pack(side="bottom", fill="x")` so they stay fixed. 
- Create `footer = ttk.Frame(self, padding=(12, 8))` and add right-aligned `Zapisz`, `Anuluj` and `Zamknij` buttons that reuse existing handlers (`self._ok` and `self.destroy`). 
- Keep the main form frame as `frm = ttk.Frame(self)` packed with `frm.pack(fill="both", expand=True, padx=12, pady=12)` so the footer is outside the expandable area. 
- Remove the previous inline `btns` frame that used the grid layout inside the form. 

### Testing
- `python -m py_compile gui_maszyny.py` completed successfully. 
- `pytest tests/test_gui_maszyny_status_history.py` ran and all tests passed (7 passed). 
- Full `pytest` was executed but reported unrelated existing GUI test failures (5 failing tests) caused by environment issues (Tkinter display / messagebox errors) and not by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7eaa259c832389e176c39095805f)