### PR TITLE
Umożliw automatyczne otwieranie edytora narzędzi

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -673,21 +673,7 @@ def open_tool_from_external_context(master: tk.Misc | None, tool_id: str) -> boo
     Otwiera pełny edytor narzędzia z modułu Narzędzia.
     """
     print(f"[WM-DBG][DYSPO->NARZ] open_tool_from_external_context tool_id={tool_id!r}")
-    print(f"[WM-DBG][DYSPO->NARZ] _OPEN_TOOL_EDITOR_BY_ID callable={callable(_OPEN_TOOL_EDITOR_BY_ID)}")
-    print(f"[WM-DBG][DYSPO->NARZ] moduł Narzędzia aktywny={_active_tool_editor_available()}")
-    tool = _external_find_tool_by_id(tool_id)
-    if not tool:
-        return False
-
-    opener = globals().get("_ACTIVE_TOOL_EDITOR_OPENER")
-    if callable(opener) and _active_tool_editor_available():
-        opener(tool)
-        return True
-
-    raise RuntimeError(
-        "Pełny edytor narzędzia jest dostępny dopiero po otwarciu modułu Narzędzia. "
-        "Otwórz moduł Narzędzia raz, potem wróć do Dyspozycji."
-    )
+    return open_tool_editor_by_id(master, tool_id)
 
 
 logger = getLogger(__name__)
@@ -4084,8 +4070,6 @@ def open_tool_editor_by_id(
     current_role: str | None = None,
 ) -> bool:
     """Otwórz narzędzie przez edytor podpięty do głównej listy narzędzi."""
-    del current_user, current_role
-
     print(f"[WM-DBG][DYSPO->NARZ] open_tool_editor_by_id tool_id={tool_id!r}")
     print(f"[WM-DBG][DYSPO->NARZ] opener callable={callable(_OPEN_TOOL_EDITOR_BY_ID)}")
     print(f"[WM-DBG][DYSPO->NARZ] master={master!r}")
@@ -4106,12 +4090,22 @@ def open_tool_editor_by_id(
             frame = ttk.Frame(win, style="WM.TFrame")
             frame.pack(fill="both", expand=True)
 
-            panel_narzedzia(win, frame, login=None, rola=None)
+            panel_narzedzia(
+                win,
+                frame,
+                login=current_user or None,
+                rola=current_role,
+            )
             print(f"[WM-DBG][DYSPO->NARZ] panel_narzedzia zbudowany, opener callable={callable(_OPEN_TOOL_EDITOR_BY_ID)}")
             print(f"[WM-DBG][DYSPO->NARZ] planuję ponowne otwarcie tool_id={tool_id!r} za 300ms")
             win.after(
                 300,
-                lambda: open_tool_editor_by_id(win, tool_id),
+                lambda: open_tool_editor_by_id(
+                    win,
+                    tool_id,
+                    current_user=current_user,
+                    current_role=current_role,
+                ),
             )
             return True
         except Exception as exc:


### PR DESCRIPTION
### Motivation
- Umożliwić otwieranie pełnego edytora narzędzi z zewnętrznego kontekstu (np. Dyspozycji) bez potrzeby wcześniejszego ręcznego otwierania modułu Narzędzia.
- Zachować kontekst bieżącego użytkownika i jego rolę podczas automatycznego tworzenia okna modułu, żeby edytor otwierał się z właściwymi danymi sesji.

### Description
- Zastąpiono dotychczasową logikę w `open_tool_from_external_context` prostym delegowaniem do `open_tool_editor_by_id` w `gui_narzedzia.py`.
- Usunięto zależność od `_ACTIVE_TOOL_EDITOR_OPENER` i lokalnego wyszukiwania narzędzia w helperze, aby umożliwić automatyczne uruchomienie modułu Narzędzia.
- W `open_tool_editor_by_id` usunięto kasowanie kontekstu i przekazywane są teraz `current_user` oraz `current_role` do `panel_narzedzia` oraz do opóźnionego ponownego wywołania otwarcia edytora.
- Modyfikacje dotyczą wyłącznie pliku `gui_narzedzia.py` (ok. 13 insertions, 19 deletions).

### Testing
- `python -m py_compile gui_narzedzia.py` — plik się kompiluje, interpreter zgłosił istniejące `SyntaxWarning` dotyczące `return` w blokach `finally`.
- `pytest test_gui_narzedzia_enter.py test_gui_narzedzia_tasks.py` — testy docelowe przeszły pomyślnie (`3 passed`).
- Uruchomiono pełny `pytest` zgodnie z wytycznymi repozytorium, przebieg uruchomił się lecz wcześniej zgłosił niepowodzenia w `test_gui_logowanie.py` i `test_gui_narzedzia_config.py` i zakończył się przed ukończeniem całego zestawu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e88726e888323b372e4c8b02b891a)