### PR TITLE
Fix stale tool editor callback handling

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -4061,6 +4061,20 @@ def _phase_for_status(tool_mode: str, status_text: str) -> str | None:
 
 # ===================== UI GŁÓWNY =====================
 _OPEN_TOOL_EDITOR_BY_ID: Callable[[str], bool] | None = None
+_OPEN_TOOL_EDITOR_OWNER: tk.Misc | None = None
+
+
+def _tool_editor_opener_alive() -> bool:
+    opener = globals().get("_OPEN_TOOL_EDITOR_BY_ID")
+    owner = globals().get("_OPEN_TOOL_EDITOR_OWNER")
+    if not callable(opener):
+        return False
+    if owner is None:
+        return False
+    try:
+        return bool(owner.winfo_exists())
+    except Exception:
+        return False
 
 
 def open_tool_editor_by_id(
@@ -4070,9 +4084,27 @@ def open_tool_editor_by_id(
     current_role: str | None = None,
 ) -> bool:
     """Otwórz narzędzie przez edytor podpięty do głównej listy narzędzi."""
+    global _OPEN_TOOL_EDITOR_BY_ID, _OPEN_TOOL_EDITOR_OWNER
+
     print(f"[WM-DBG][DYSPO->NARZ] open_tool_editor_by_id tool_id={tool_id!r}")
     print(f"[WM-DBG][DYSPO->NARZ] opener callable={callable(_OPEN_TOOL_EDITOR_BY_ID)}")
     print(f"[WM-DBG][DYSPO->NARZ] master={master!r}")
+
+    normalized = str(tool_id or "").strip()
+    if not normalized:
+        return False
+
+    if _tool_editor_opener_alive():
+        try:
+            opened = _OPEN_TOOL_EDITOR_BY_ID(normalized)  # type: ignore[misc]
+        except Exception as exc:
+            print(f"[WM-DBG][DYSPO->NARZ][ERR] opener failed: {exc}")
+            opened = False
+        if opened:
+            return True
+
+    _OPEN_TOOL_EDITOR_BY_ID = None
+    _OPEN_TOOL_EDITOR_OWNER = None
 
     if _OPEN_TOOL_EDITOR_BY_ID is None:
         print("[WM-DBG][DYSPO->NARZ] Brak aktywnego callbacka edytora, tworzę moduł Narzędzia w Toplevel")
@@ -4089,6 +4121,15 @@ def open_tool_editor_by_id(
 
             frame = ttk.Frame(win, style="WM.TFrame")
             frame.pack(fill="both", expand=True)
+
+            def _clear_external_opener_on_close() -> None:
+                global _OPEN_TOOL_EDITOR_BY_ID, _OPEN_TOOL_EDITOR_OWNER
+                if _OPEN_TOOL_EDITOR_OWNER is win:
+                    _OPEN_TOOL_EDITOR_BY_ID = None
+                    _OPEN_TOOL_EDITOR_OWNER = None
+                win.destroy()
+
+            win.protocol("WM_DELETE_WINDOW", _clear_external_opener_on_close)
 
             panel_narzedzia(
                 win,
@@ -4113,7 +4154,7 @@ def open_tool_editor_by_id(
                 "Nie udało się automatycznie otworzyć modułu Narzędzia dla edycji narzędzia."
             ) from exc
 
-    return _OPEN_TOOL_EDITOR_BY_ID(str(tool_id or "").strip())
+    return False
 
 
 def panel_narzedzia(root, frame, login=None, rola=None):
@@ -4300,8 +4341,12 @@ def panel_narzedzia(root, frame, login=None, rola=None):
             return False
         return False
 
-    global _OPEN_TOOL_EDITOR_BY_ID
+    global _OPEN_TOOL_EDITOR_BY_ID, _OPEN_TOOL_EDITOR_OWNER
     _OPEN_TOOL_EDITOR_BY_ID = _open_tool_by_id
+    try:
+        _OPEN_TOOL_EDITOR_OWNER = frame.winfo_toplevel()
+    except Exception:
+        _OPEN_TOOL_EDITOR_OWNER = root
     print("[WM-DBG][DYSPO->NARZ] zarejestrowano _OPEN_TOOL_EDITOR_BY_ID = _open_tool_by_id")
 
     class _ToolsViewFallback:


### PR DESCRIPTION
### Motivation
- The tools editor opener callback could remain registered after its owning Tk window was closed, causing attempts to call a stale callback or reference a destroyed owner.
- Tests use lightweight widget stubs that may not implement `winfo_toplevel()`, which caused regressions when storing the owner without a safe fallback.

### Description
- Added `_OPEN_TOOL_EDITOR_OWNER` and helper `_tool_editor_opener_alive()` to track and verify the Tk owner associated with the registered opener callback.
- Updated `open_tool_editor_by_id()` to reject empty `tool_id`, attempt to reuse the registered callback only while its owner exists, clear stale/failed callbacks, and fall back to creating a new Toplevel editor when needed.
- Added a window-close handler (`WM_DELETE_WINDOW`) for the created tools window that clears the external callback and owner before destroying the window.
- When registering the opener in `panel_narzedzia()` the code now tries `frame.winfo_toplevel()` and falls back to `root` on exception to remain compatible with test stubs that lack `winfo_toplevel()`.

### Testing
- Ran `pytest test_gui_narzedzia_enter.py test_gui_narzedzia_files.py -q` which passed (`5 passed`).
- Ran `pytest test_gui_narzedzia_enter.py test_gui_narzedzia_files.py test_gui_narzedzia_config.py` which passed locally for the modified areas (`7 passed, 1 failed`) where the single remaining failure is an existing, unrelated assertion in `test_load_config_logs`.
- Performed static compilation with `python -m py_compile gui_narzedzia.py` which succeeded; the interpreter reported two pre-existing `SyntaxWarning` notices unrelated to this change.
- Ran a wider `pytest` run which was interrupted due to unrelated environment/display-dependent failures (existing GUI tests requiring a display) and multiprocessing timeouts; the failures observed were not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e8a5b5768832391f2aec8fbbe3e36)