### PR TITLE
Handle destroyed tool editor parents safely

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -4064,6 +4064,24 @@ _OPEN_TOOL_EDITOR_BY_ID: Callable[[str], bool] | None = None
 _OPEN_TOOL_EDITOR_OWNER: tk.Misc | None = None
 
 
+def _safe_tool_editor_parent(master: tk.Misc | None) -> tk.Misc | None:
+    """Zwraca żywego parenta dla Toplevel albo None, gdy master jest martwy."""
+    if master is None:
+        return None
+    try:
+        if hasattr(master, "winfo_exists") and not master.winfo_exists():
+            return None
+    except Exception:
+        return None
+    try:
+        top = master.winfo_toplevel()
+        if hasattr(top, "winfo_exists") and top.winfo_exists():
+            return top
+    except Exception:
+        return None
+    return master
+
+
 def _tool_editor_opener_alive() -> bool:
     opener = globals().get("_OPEN_TOOL_EDITOR_BY_ID")
     owner = globals().get("_OPEN_TOOL_EDITOR_OWNER")
@@ -4109,7 +4127,13 @@ def open_tool_editor_by_id(
     if _OPEN_TOOL_EDITOR_BY_ID is None:
         print("[WM-DBG][DYSPO->NARZ] Brak aktywnego callbacka edytora, tworzę moduł Narzędzia w Toplevel")
         try:
-            win = tk.Toplevel(master) if master is not None else tk.Toplevel()
+            parent = _safe_tool_editor_parent(master)
+            print(f"[WM-DBG][DYSPO->NARZ] safe parent={parent!r}")
+            try:
+                win = tk.Toplevel(parent) if parent is not None else tk.Toplevel()
+            except tk.TclError as exc:
+                print(f"[WM-DBG][DYSPO->NARZ][WARN] parent Toplevel failed: {exc}; retry without parent")
+                win = tk.Toplevel()
             win.title("Narzędzia")
             win.geometry("1400x850")
             win.resizable(True, True)


### PR DESCRIPTION
### Motivation
- Prevent crashes or TclErrors when creating a `tk.Toplevel` from a master that has been destroyed or is otherwise invalid. 
- Make the tools-editor window creation more robust by resolving a live top-level parent and falling back to creating a toplevel without a parent when needed.

### Description
- Add `_safe_tool_editor_parent(master)` which returns a live top-level parent or `None` when the provided master is dead or raises while queried. 
- Use the helper inside `open_tool_editor_by_id()` and log the resolved parent for debugging. 
- If creating `tk.Toplevel(parent)` raises `tk.TclError`, retry creating a `tk.Toplevel()` with no parent and emit a warning log.

### Testing
- Verified file compiles with `python -m py_compile gui_narzedzia.py`, with two pre-existing `SyntaxWarning`s reported but no compile errors. 
- Executed inline Python assertions validating `_safe_tool_editor_parent()` behavior for a live master, a dead master, and a master that raises; assertions passed. 
- Ran targeted GUI tests with `pytest test_gui_narzedzia_config.py test_gui_narzedzia_enter.py test_gui_narzedzia_files.py test_gui_narzedzia_qr.py test_gui_narzedzia_tasks.py` which produced `10 passed, 1 failed`; the single failure is an unrelated pre-existing assertion in `test_gui_narzedzia_config.py::test_load_config_logs`. 
- A full `pytest` run was started (collected 286 tests) but was stopped after the suite stalled; failures observed were not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea9513188832391192223d052d0e5)