### PR TITLE
Dodaj dane dyspozycji do kart narzędzi i maszyn

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -146,7 +146,11 @@ def _cards_output_dir() -> Path:
     return base
 
 
-def _print_tool_card_from_dyspo(master: tk.Widget, object_id: str) -> None:
+def _print_tool_card_from_dyspo(
+    master: tk.Widget,
+    object_id: str,
+    dyspozycja: dict[str, Any] | None = None,
+) -> None:
     tool_id = str(object_id or "").strip()
     if not tool_id:
         messagebox.showwarning("Dyspozycje", "Brak numeru narzędzia.", parent=master)
@@ -161,7 +165,12 @@ def _print_tool_card_from_dyspo(master: tk.Widget, object_id: str) -> None:
         return
     try:
         from tool_card_pdf import generate_tool_card
-        generate_tool_card(tool, _cards_output_dir(), open_after=True)
+        generate_tool_card(
+            tool,
+            _cards_output_dir(),
+            dyspozycja=dyspozycja,
+            open_after=True,
+        )
     except Exception as exc:
         messagebox.showerror(
             "Dyspozycje",
@@ -170,7 +179,11 @@ def _print_tool_card_from_dyspo(master: tk.Widget, object_id: str) -> None:
         )
 
 
-def _print_machine_card_from_dyspo(master: tk.Widget, object_id: str) -> None:
+def _print_machine_card_from_dyspo(
+    master: tk.Widget,
+    object_id: str,
+    dyspozycja: dict[str, Any] | None = None,
+) -> None:
     machine_id = str(object_id or "").strip()
     if not machine_id:
         messagebox.showwarning("Dyspozycje", "Brak numeru maszyny.", parent=master)
@@ -185,7 +198,12 @@ def _print_machine_card_from_dyspo(master: tk.Widget, object_id: str) -> None:
         return
     try:
         from machine_card_pdf import generate_machine_card
-        generate_machine_card(machine, _cards_output_dir(), open_after=True)
+        generate_machine_card(
+            machine,
+            _cards_output_dir(),
+            dyspozycja=dyspozycja,
+            open_after=True,
+        )
     except Exception as exc:
         messagebox.showerror(
             "Dyspozycje",
@@ -404,6 +422,17 @@ def open_dyspozycje_creator(
     all_labels: list[str] = []
     source_module = {"value": ""}
 
+    def _current_dyspozycja_for_print() -> dict[str, Any]:
+        return {
+            "opis": txt_desc.get("1.0", "end").strip(),
+            "termin": var_deadline.get().strip(),
+            "przypisane_do": (
+                "" if var_all.get() else var_assigned.get().strip()
+            ),
+            "priorytet": var_priority.get().strip(),
+            "autor": str(autor or ctx.get("autor") or "").strip(),
+        }
+
     def _clear_object_card() -> None:
         for child in object_card.winfo_children():
             child.destroy()
@@ -443,6 +472,7 @@ def open_dyspozycje_creator(
         command=lambda: _print_tool_card_from_dyspo(
             win,
             options_map.get(var_object_display.get().strip(), ""),
+            _current_dyspozycja_for_print(),
         ),
     )
     btn_open_machine = ttk.Button(
@@ -461,6 +491,7 @@ def open_dyspozycje_creator(
         command=lambda: _print_machine_card_from_dyspo(
             win,
             options_map.get(var_object_display.get().strip(), ""),
+            _current_dyspozycja_for_print(),
         ),
     )
 
@@ -635,7 +666,9 @@ def open_dyspozycje_creator(
             "tytul": title,
             "opis": txt_desc.get("1.0", "end").strip(),
             "autor": str(autor or ctx.get("autor") or "").strip(),
-            "przypisane_do": "" if var_all.get() else var_assigned.get().strip(),
+            "przypisane_do": (
+                "" if var_all.get() else var_assigned.get().strip()
+            ),
             "dla_wszystkich": bool(var_all.get()),
             "termin": var_deadline.get().strip(),
             "priorytet": var_priority.get().strip(),

--- a/machine_card_pdf.py
+++ b/machine_card_pdf.py
@@ -139,7 +139,11 @@ def _format_list(value: Any) -> str:
     return str(value)
 
 
-def _generate_pdf_reportlab(machine: dict[str, Any], output_path: Path) -> Path:
+def _generate_pdf_reportlab(
+    machine: dict[str, Any],
+    output_path: Path,
+    dyspozycja: dict[str, Any] | None = None,
+) -> Path:
     from reportlab.lib.pagesizes import A4
     from reportlab.lib.units import mm
     from reportlab.pdfgen import canvas
@@ -184,6 +188,26 @@ def _generate_pdf_reportlab(machine: dict[str, Any], output_path: Path) -> Path:
         c.setFont(font_regular, 10)
         y = _draw_wrapped_line(c, value or "—", left + 120, y, 80)
         y -= 4
+
+    if dyspozycja:
+        y -= 12
+        c.setFont(font_bold, 12)
+        c.drawString(left, y, "DANE DYSPOZYCJI")
+        y -= 22
+
+        rows_dysp = [
+            ("Opis", str(dyspozycja.get("opis", ""))),
+            ("Termin", str(dyspozycja.get("termin", ""))),
+            ("Przypisane do", str(dyspozycja.get("przypisane_do", ""))),
+            ("Priorytet", str(dyspozycja.get("priorytet", ""))),
+            ("Autor", str(dyspozycja.get("autor", ""))),
+        ]
+        for label, value in rows_dysp:
+            c.setFont(font_bold, 10)
+            c.drawString(left, y, f"{label}:")
+            c.setFont(font_regular, 10)
+            y = _draw_wrapped_line(c, value or "—", left + 120, y, 80)
+            y -= 4
 
     y -= 12
     c.setFont(font_bold, 12)
@@ -246,7 +270,11 @@ def _generate_pdf_reportlab(machine: dict[str, Any], output_path: Path) -> Path:
     return output_path
 
 
-def _generate_html_fallback(machine: dict[str, Any], output_path: Path) -> Path:
+def _generate_html_fallback(
+    machine: dict[str, Any],
+    output_path: Path,
+    dyspozycja: dict[str, Any] | None = None,
+) -> Path:
     html_path = output_path.with_suffix(".html")
     nr = html.escape(_machine_number(machine))
     rows = [
@@ -262,6 +290,24 @@ def _generate_html_fallback(machine: dict[str, Any], output_path: Path) -> Path:
         f"<tr><th>{html.escape(label)}</th><td>{html.escape(value or '—')}</td></tr>"
         for label, value in rows
     )
+    dysp_html = ""
+    if dyspozycja:
+        rows_dysp = [
+            ("Opis", str(dyspozycja.get("opis", ""))),
+            ("Termin", str(dyspozycja.get("termin", ""))),
+            ("Przypisane do", str(dyspozycja.get("przypisane_do", ""))),
+            ("Priorytet", str(dyspozycja.get("priorytet", ""))),
+            ("Autor", str(dyspozycja.get("autor", ""))),
+        ]
+        rows_dysp_html = "\n".join(
+            f"<tr><th>{html.escape(label)}</th><td>{html.escape(value or '—')}</td></tr>"
+            for label, value in rows_dysp
+        )
+        dysp_html = f"""
+<h2>DANE DYSPOZYCJI</h2>
+<table>{rows_dysp_html}</table>
+"""
+
     content = f"""<!doctype html>
 <html lang="pl">
 <head>
@@ -290,6 +336,7 @@ h2 {{ font-size: 17px; margin-top: 22px; }}
 <hr>
 <h2>DANE MASZYNY</h2>
 <table>{rows_html}</table>
+{dysp_html}
 <h2>UWAGI</h2>
 <div class="line"></div>
 <div class="line"></div>
@@ -310,6 +357,7 @@ def generate_machine_card(
     machine: dict[str, Any],
     output_dir: str | Path,
     *,
+    dyspozycja: dict[str, Any] | None = None,
     open_after: bool = True,
 ) -> Path:
     output_base = Path(output_dir)
@@ -320,9 +368,13 @@ def generate_machine_card(
     output_path = output_base / f"karta_maszyny_{nr}_{stamp}.pdf"
 
     try:
-        generated = _generate_pdf_reportlab(machine, output_path)
+        generated = _generate_pdf_reportlab(
+            machine, output_path, dyspozycja=dyspozycja
+        )
     except Exception:
-        generated = _generate_html_fallback(machine, output_path)
+        generated = _generate_html_fallback(
+            machine, output_path, dyspozycja=dyspozycja
+        )
 
     if open_after:
         _open_file(generated)

--- a/tool_card_pdf.py
+++ b/tool_card_pdf.py
@@ -145,7 +145,11 @@ def _register_reportlab_unicode_fonts() -> tuple[str, str]:
     return ("Helvetica", "Helvetica-Bold")
 
 
-def _generate_pdf_reportlab(tool: dict[str, Any], output_path: Path) -> Path:
+def _generate_pdf_reportlab(
+    tool: dict[str, Any],
+    output_path: Path,
+    dyspozycja: dict[str, Any] | None = None,
+) -> Path:
     from reportlab.lib.pagesizes import A4
     from reportlab.lib.units import mm
     from reportlab.pdfgen import canvas
@@ -189,6 +193,26 @@ def _generate_pdf_reportlab(tool: dict[str, Any], output_path: Path) -> Path:
         c.setFont(font_regular, 10)
         c.drawString(left + 95, y, value or "—")
         y -= 18
+
+    if dyspozycja:
+        y -= 12
+        c.setFont(font_bold, 12)
+        c.drawString(left, y, "DANE DYSPOZYCJI")
+        y -= 22
+
+        rows_dysp = [
+            ("Opis", str(dyspozycja.get("opis", ""))),
+            ("Termin", str(dyspozycja.get("termin", ""))),
+            ("Przypisane do", str(dyspozycja.get("przypisane_do", ""))),
+            ("Priorytet", str(dyspozycja.get("priorytet", ""))),
+            ("Autor", str(dyspozycja.get("autor", ""))),
+        ]
+        for label, value in rows_dysp:
+            c.setFont(font_bold, 10)
+            c.drawString(left, y, f"{label}:")
+            c.setFont(font_regular, 10)
+            y = _draw_wrapped_line(c, value or "—", left + 95, y, 90)
+            y -= 4
 
     y -= 12
     c.setFont(font_bold, 12)
@@ -245,7 +269,11 @@ def _generate_pdf_reportlab(tool: dict[str, Any], output_path: Path) -> Path:
     return output_path
 
 
-def _generate_html_fallback(tool: dict[str, Any], output_path: Path) -> Path:
+def _generate_html_fallback(
+    tool: dict[str, Any],
+    output_path: Path,
+    dyspozycja: dict[str, Any] | None = None,
+) -> Path:
     html_path = output_path.with_suffix(".html")
     nr = html.escape(_tool_number(tool))
     rows = [
@@ -274,6 +302,24 @@ def _generate_html_fallback(tool: dict[str, Any], output_path: Path) -> Path:
         + "</li>"
         for idx, task in enumerate(tasks, start=1)
     )
+
+    dysp_html = ""
+    if dyspozycja:
+        rows_dysp = [
+            ("Opis", str(dyspozycja.get("opis", ""))),
+            ("Termin", str(dyspozycja.get("termin", ""))),
+            ("Przypisane do", str(dyspozycja.get("przypisane_do", ""))),
+            ("Priorytet", str(dyspozycja.get("priorytet", ""))),
+            ("Autor", str(dyspozycja.get("autor", ""))),
+        ]
+        rows_dysp_html = "\n".join(
+            f"<tr><th>{html.escape(label)}</th><td>{html.escape(value or '—')}</td></tr>"
+            for label, value in rows_dysp
+        )
+        dysp_html = f"""
+<h2>DANE DYSPOZYCJI</h2>
+<table>{rows_dysp_html}</table>
+"""
 
     content = f"""<!doctype html>
 <html lang="pl">
@@ -304,6 +350,7 @@ li {{ margin: 8px 0; font-size: 14px; }}
 <hr>
 <h2>DANE NARZĘDZIA</h2>
 <table>{rows_html}</table>
+{dysp_html}
 <h2>ZADANIA DO WYKONANIA</h2>
 <ol>{tasks_html}</ol>
 <h2>UWAGI</h2>
@@ -326,6 +373,7 @@ def generate_tool_card(
     tool: dict[str, Any],
     output_dir: str | Path,
     *,
+    dyspozycja: dict[str, Any] | None = None,
     open_after: bool = True,
 ) -> Path:
     output_base = Path(output_dir)
@@ -336,9 +384,13 @@ def generate_tool_card(
     output_path = output_base / f"karta_narzedzia_{nr}_{stamp}.pdf"
 
     try:
-        generated = _generate_pdf_reportlab(tool, output_path)
+        generated = _generate_pdf_reportlab(
+            tool, output_path, dyspozycja=dyspozycja
+        )
     except Exception:
-        generated = _generate_html_fallback(tool, output_path)
+        generated = _generate_html_fallback(
+            tool, output_path, dyspozycja=dyspozycja
+        )
 
     if open_after:
         _open_file(generated)


### PR DESCRIPTION
### Motivation
- Umożliwić dołączenie bieżących danych dyspozycji (opis, termin, przypisane do, priorytet, autor) do drukowanych kart narzędzi i maszyn tak, aby wydruki odzwierciedlały kontekst kreatora dyspozycji.

### Description
- Dodano opcjonalny argument `dyspozycja: dict[str, Any] | None` do generatorów kart w `tool_card_pdf.py` i `machine_card_pdf.py` oraz przekazanie tego argumentu do obu ścieżek (ReportLab PDF i fallback HTML). 
- Wygenerowane karty PDF (ReportLab) zawierają nową sekcję `DANE DYSPOZYCJI`, która renderuje pola: `Opis`, `Termin`, `Przypisane do`, `Priorytet`, `Autor` przy zachowaniu łamania linii; analogiczna tabela jest dodana do awaryjnego HTML. 
- W GUI kreatora dyspozycji (`gui_dyspozycje_creator.py`) dodano funkcję zbierającą aktualne wartości formularza oraz przekazującą je do wywołań drukowania kart (`_print_tool_card_from_dyspo` i `_print_machine_card_from_dyspo`). 
- Zmieniono implementację tak, aby zachować pełną kompatybilność wsteczną — argument `dyspozycja` jest opcjonalny i starsze wywołania nadal działają bez zmian.

### Testing
- Uruchomiono `python -m compileall -q gui_dyspozycje_creator.py tool_card_pdf.py machine_card_pdf.py` i kompilacja zakończyła się pomyślnie. 
- Sprawdzono generowanie HTML-fallback poprzez izolowany skrypt, który potwierdził obecność sekcji `<h2>DANE DYSPOZYCJI</h2>` oraz poprawne escapowanie treści (testowany lokalnie — OK). 
- Sprawdzono generowanie plików kart wywołujących `generate_tool_card` i `generate_machine_card` z przekazanym `dyspozycja` i potwierdzono, że pliki PDF/HTML zostały utworzone i mają rozmiar większy niż 0 bajtów (izolowany test — OK). 
- Pełny zestaw testów `pytest` uruchomiono z limitem czasu i nie zakończył się w limicie (testy GUI niezwiązane z tą zmianą zgłaszały błędy przed przerwaniem); zmiany nie powodują regresji w izolowanych scenariuszach generowania kart.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb90d306c83238e2b69528a4eb6b2)