### PR TITLE
Log missing tool task configuration instead of showing warning

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -5915,12 +5915,9 @@ def panel_narzedzia(root, frame, login=None, rola=None):
                 f"status={status_clean} → {len(defaults)} zadań"
             )
             if not defaults:
-                _notify_missing_configuration(
-                    "tasks",
-                    (
-                        "Brak zdefiniowanych zadań dla wybranego statusu. "
-                        "Dodaj zadania w module Ustawienia → Narzędzia."
-                    ),
+                print(
+                    "[WM-DBG][NARZ][WARN] Brakuje ustawień dla zadania "
+                    f"{status_clean!r}. Uzupełnij je w module Ustawienia — Narzędzia."
                 )
             added = False
             for title in defaults:


### PR DESCRIPTION
### Motivation
- Avoid interrupting the user with a modal dialog when no default tasks are defined for a selected tool status and instead surface a non-blocking diagnostic message. 
- Make the missing-configuration message include the actual status to simplify diagnosis and configuration fixes in Settings → Tools.

### Description
- In `gui_narzedzia.py` replaced the call that triggered a modal missing-configuration notification in `_add_default_tasks_for_status` with a debug `print` that logs the missing-task configuration and the `status_clean` value. 
- The new message uses the format `"[WM-DBG][NARZ][WARN] Brakuje ustawień dla zadania {status!r}..."` so the selected status is included in the output.

### Testing
- Ran `python -m py_compile gui_narzedzia.py` to check syntax; it passed (pre-existing `SyntaxWarning`s unrelated to this change remain). 
- Ran `pytest -q test_gui_narzedzia_tasks.py` and it passed (`2 passed`).
- Ran `pytest -q test_gui_narzedzia_tasks.py test_gui_narzedzia_config.py` and observed one failing test (`test_load_config_logs`) that is unrelated to this change and points to the `_load_config` logging expectations. 
- A full `pytest` run surfaced other pre-existing, unrelated failures in other modules; those were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ebe294f8c8323a44b2a26b3ee7a91)