### PR TITLE
Suppress initial task template configuration alerts

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -2967,6 +2967,7 @@ class _TaskTemplateUI:
         self._types: list[dict] = []
         self._statuses: list[dict] = []
         self._ui_updating = False
+        self._initial_render = True
         self.tasks_state: list[dict] = []
 
         self.var_collection = tk.StringVar()
@@ -2989,6 +2990,7 @@ class _TaskTemplateUI:
         self.lst.pack(fill="both", expand=True)
 
         self._render_collections_initial()
+        self._initial_render = False
 
     # ===================== helpers =====================
     @contextmanager
@@ -3064,7 +3066,7 @@ class _TaskTemplateUI:
             self._set_info("")
         else:
             self._set_info("Brak typów narzędzi w ustawieniach.")
-            if cid:
+            if cid and not self._initial_render:
                 _notify_missing_configuration(
                     "types",
                     (
@@ -3101,13 +3103,14 @@ class _TaskTemplateUI:
         else:
             if tid:
                 self._set_info("Brak statusów w ustawieniach dla wybranego typu.")
-                _notify_missing_configuration(
-                    "statuses",
-                    (
-                        "Brak zdefiniowanych statusów dla wybranego typu. "
-                        "Dodaj statusy w module Ustawienia → Narzędzia."
-                    ),
-                )
+                if not self._initial_render:
+                    _notify_missing_configuration(
+                        "statuses",
+                        (
+                            "Brak zdefiniowanych statusów dla wybranego typu. "
+                            "Dodaj statusy w module Ustawienia → Narzędzia."
+                        ),
+                    )
             else:
                 self._set_info("")
         with self._suspend_ui():
@@ -3161,13 +3164,14 @@ class _TaskTemplateUI:
             else:
                 if cid and tid and sid:
                     self._set_info("Brak zadań w ustawieniach dla wybranego statusu.")
-                    _notify_missing_configuration(
-                        "tasks",
-                        (
-                            "Brak zdefiniowanych zadań dla wybranego statusu. "
-                            "Dodaj zadania w module Ustawienia → Narzędzia."
-                        ),
-                    )
+                    if not self._initial_render:
+                        _notify_missing_configuration(
+                            "tasks",
+                            (
+                                "Brak zdefiniowanych zadań dla wybranego statusu. "
+                                "Dodaj zadania w module Ustawienia → Narzędzia."
+                            ),
+                        )
                 else:
                     self._set_info("")
                 self.lst.insert(tk.END, "-- brak zadań --")


### PR DESCRIPTION
### Motivation

- Avoid showing missing-configuration notifications while the task-template comboboxes are populated on first render to reduce noisy/irrelevant alerts during UI initialization.

### Description

- Added an `_initial_render` flag to ` _TaskTemplateUI` in `gui_narzedzia.py` and initialize it during construction. 
- Set `_initial_render = False` immediately after the initial call to `_render_collections_initial()` so only subsequent user-driven changes trigger alerts. 
- Wrapped `_notify_missing_configuration` calls for types, statuses and tasks with `if not self._initial_render:` so alerts are suppressed during the initial population. 
- The change is contained to `gui_narzedzia.py` (class `_TaskTemplateUI`) and preserves status-bar messages while suppressing modal/alert notifications until after initial render.

### Testing

- Ran `python -m py_compile gui_narzedzia.py`, which completed successfully and reported unrelated `SyntaxWarning` messages for existing `return` statements inside `finally` blocks at lines 7160 and 7166. 
- Ran targeted tests with `pytest -q test_gui_narzedzia_config.py test_gui_narzedzia_tasks.py`, where 4 tests passed and 1 unrelated existing test (`test_gui_narzedzia_config.py::test_load_config_logs`) failed because it expected a logged message containing "boom" that was not present. 
- Started the full test suite with `pytest`, which was interrupted after reporting many passing tests; failures observed before interruption were unrelated to this change (headless Tk login tests failing due to missing `$DISPLAY` and the same `test_load_config_logs` issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec3196c4083238250b856ebcba8a4)