### PR TITLE
Wycisz popup konfiguracji przy pierwszym renderze modułu Narzędzia

### DIFF
--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -1190,6 +1190,17 @@ _TOOLS_CFG_CACHE: dict | None = None
 _TOOLS_PRIMARY_PATH: str | None = None
 _TOOLS_MIGRATED = False
 _TOOLS_BRIDGE = ToolDataBridge()
+_SUPPRESS_TOOL_CONFIG_POPUPS = 0
+
+
+@contextmanager
+def _suppress_tool_config_popups():
+    global _SUPPRESS_TOOL_CONFIG_POPUPS
+    _SUPPRESS_TOOL_CONFIG_POPUPS += 1
+    try:
+        yield
+    finally:
+        _SUPPRESS_TOOL_CONFIG_POPUPS = max(0, _SUPPRESS_TOOL_CONFIG_POPUPS - 1)
 
 
 def _init_tools_data(cfg: dict | None = None) -> tuple[dict, list[dict], str, bool]:
@@ -2327,6 +2338,13 @@ except Exception:  # pragma: no cover - tolerancja środowiska
 def _notify_missing_configuration(category: str, message: str) -> None:
     """Show one-time warning for missing configuration pieces."""
 
+    if _SUPPRESS_TOOL_CONFIG_POPUPS:
+        try:
+            print(f"[WM-DBG][NARZ][WARN] {message}")
+        except Exception:
+            pass
+        return
+
     key = category.strip().lower()
     if not key:
         key = message.strip().lower()
@@ -3226,7 +3244,8 @@ def build_task_template(parent):
     """Build simple comboboxes for collection/type/status and a tasks list."""
 
     LZ.invalidate_cache()
-    ui = _TaskTemplateUI(parent)
+    with _suppress_tool_config_popups():
+        ui = _TaskTemplateUI(parent)
     return {
         "cb_collection": ui.cb_collection,
         "cb_type": ui.cb_type,


### PR DESCRIPTION
### Motivation
- Nie blokować użytkownika popupem o brakującej konfiguracji przy automatycznym pierwszym renderze modułu Narzędzia, przy jednoczesnym zachowaniu widocznego ostrzeżenia w konsoli.

### Description
- Dodano globalną zmienną ` _SUPPRESS_TOOL_CONFIG_POPUPS` oraz context manager ` _suppress_tool_config_popups()` do tymczasowego wyciszania popupów konfiguracji w `gui_narzedzia.py`.
- Na początku funkcji ` _notify_missing_configuration` dodano wczesny `return` gdy tłumienie jest aktywne i wypisywanie komunikatu w konsoli jako `[WM-DBG][NARZ][WARN] ...` zamiast wyświetlania `messagebox`.
- Objęto tłumieniem tworzenie UI szablonu zadań (`_TaskTemplateUI`) wewnątrz `build_task_template` aby zapobiec popupowi podczas automatycznego pierwszego renderu.
- Nie wprowadzono żadnych zmian w plikach JSON, seedowaniu statusów, automatycznym dodawaniu zadań ani logice `done/status` — zmiana jest ograniczona do `gui_narzedzia.py`.

### Testing
- Uruchomiono `python -m py_compile gui_narzedzia.py` i kompilacja składniowa zakończyła się powodzeniem (pozostały istniejące `SyntaxWarning` niezwiązane z patchem).
- Wykonano kontrolny skrypt Pythona sprawdzający zachowanie ` _suppress_tool_config_popups()` który potwierdził, że wewnątrz kontekstu popup nie jest wywoływany a komunikat jest logowany do stdout, licznik wraca do zera i poza kontekstem `messagebox.showwarning` działa jak wcześniej.
- Uruchomiono `pytest test_gui_narzedzia_config.py test_gui_narzedzia_enter.py test_gui_narzedzia_tasks.py` z wynikiem `5 passed, 1 failed`, gdzie niepowodzenie dotyczy `test_gui_narzedzia_config.py::test_load_config_logs` i jest niezwiązane z wprowadzonym tłumieniem popupów.
- Pełne uruchomienie `pytest` ujawniło istniejące, niezależne niepowodzenia w testach projektu i nie zostało zmodyfikowane przez ten patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec8045db88323ae3d39185cbcc814)