### PR TITLE
Add printing of blank tool and machine cards

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -212,6 +212,46 @@ def _print_machine_card_from_dyspo(
         )
 
 
+def _print_blank_tool_card_from_dyspo(
+    master: tk.Widget,
+    dyspozycja: dict[str, Any] | None = None,
+) -> None:
+    try:
+        from tool_card_pdf import generate_blank_tool_card
+
+        generate_blank_tool_card(
+            _cards_output_dir(),
+            dyspozycja=dyspozycja,
+            open_after=True,
+        )
+    except Exception as exc:
+        messagebox.showerror(
+            "Dyspozycje",
+            f"Nie udało się wygenerować pustej karty narzędzia:\n{exc}",
+            parent=master,
+        )
+
+
+def _print_blank_machine_card_from_dyspo(
+    master: tk.Widget,
+    dyspozycja: dict[str, Any] | None = None,
+) -> None:
+    try:
+        from machine_card_pdf import generate_blank_machine_card
+
+        generate_blank_machine_card(
+            _cards_output_dir(),
+            dyspozycja=dyspozycja,
+            open_after=True,
+        )
+    except Exception as exc:
+        messagebox.showerror(
+            "Dyspozycje",
+            f"Nie udało się wygenerować pustej karty maszyny:\n{exc}",
+            parent=master,
+        )
+
+
 def _try_open_tool_editor(master: tk.Widget, object_id: str) -> None:
     """Otwiera normalny widok narzędzia używany przez moduł Narzędzia."""
     tool_id = str(object_id or "").strip()
@@ -475,6 +515,15 @@ def open_dyspozycje_creator(
             _current_dyspozycja_for_print(),
         ),
     )
+    btn_print_blank_tool_card = ttk.Button(
+        object_panel_buttons,
+        text="Drukuj pustą kartę narzędzia",
+        command=lambda: _print_blank_tool_card_from_dyspo(
+            win,
+            _current_dyspozycja_for_print(),
+        ),
+    )
+
     btn_open_machine = ttk.Button(
         object_panel_buttons,
         text="Otwórz użytkowanie maszyny",
@@ -491,6 +540,15 @@ def open_dyspozycje_creator(
         command=lambda: _print_machine_card_from_dyspo(
             win,
             options_map.get(var_object_display.get().strip(), ""),
+            _current_dyspozycja_for_print(),
+        ),
+    )
+
+    btn_print_blank_machine_card = ttk.Button(
+        object_panel_buttons,
+        text="Drukuj pustą kartę maszyny",
+        command=lambda: _print_blank_machine_card_from_dyspo(
+            win,
             _current_dyspozycja_for_print(),
         ),
     )
@@ -520,6 +578,7 @@ def open_dyspozycje_creator(
             )
             btn_open_tool.pack(side="left")
             btn_print_tool_card.pack(side="left", padx=(8, 0))
+            btn_print_blank_tool_card.pack(side="left", padx=(8, 0))
         elif typ == "maszyna":
             var_object_panel_info.set(
                 "Maszyna powiązana z dyspozycją: "
@@ -531,6 +590,7 @@ def open_dyspozycje_creator(
             )
             btn_open_machine.pack(side="left")
             btn_print_machine_card.pack(side="left", padx=(8, 0))
+            btn_print_blank_machine_card.pack(side="left", padx=(8, 0))
         else:
             var_object_panel_info.set(
                 "Dla tego typu dyspozycji nie ma jeszcze edytora "

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tkinter as tk
 from logging import getLogger
+from pathlib import Path
 from tkinter import filedialog, messagebox, simpledialog, ttk
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
@@ -2214,6 +2215,27 @@ def _open_machines_panel(
         wm_set_module_source(root, "Maszyny", primary_path)
     except Exception:
         pass
+
+    def _cards_output_dir() -> Path:
+        base = Path.cwd() / "wydruki" / "karty"
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    def _print_blank_machine_card_from_machines() -> None:
+        try:
+            from machine_card_pdf import generate_blank_machine_card
+
+            generate_blank_machine_card(
+                _cards_output_dir(),
+                open_after=True,
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Maszyny",
+                f"Nie udało się wygenerować pustej karty maszyny:\n{exc}",
+                parent=root if hasattr(root, "winfo_exists") else None,
+            )
+
     had_rows = bool(rows)
     rows = ensure_machines_sample_if_empty(rows, primary_path)
     source_path = _detect_real_source(rows, primary_path, cfg)
@@ -2267,6 +2289,14 @@ def _open_machines_panel(
     info.set(
         f"Wczytano {len(rows_cache)} maszyn." if had_rows else "Brak danych – dodano przykładowe pozycje."
     )
+
+    machine_actions = ttk.Frame(left)
+    machine_actions.pack(fill="x", pady=(0, 6))
+    ttk.Button(
+        machine_actions,
+        text="Drukuj pustą kartę maszyny",
+        command=_print_blank_machine_card_from_machines,
+    ).pack(side="left")
 
     tree = _build_tree(left, visible_rows)
     _bind_tree_tooltips(tree, visible_rows, root)

--- a/gui_narzedzia.py
+++ b/gui_narzedzia.py
@@ -4202,6 +4202,27 @@ def panel_narzedzia(root, frame, login=None, rola=None):
     bridge = _TOOLS_BRIDGE
     STATE.current_login = login
     STATE.current_role = rola
+
+    def _cards_output_dir() -> Path:
+        base = Path.cwd() / "wydruki" / "karty"
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    def _print_blank_tool_card_from_tools() -> None:
+        try:
+            from tool_card_pdf import generate_blank_tool_card
+
+            generate_blank_tool_card(
+                _cards_output_dir(),
+                open_after=True,
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Narzędzia",
+                f"Nie udało się wygenerować pustej karty narzędzia:\n{exc}",
+                parent=root if hasattr(root, "winfo_exists") else None,
+            )
+
     STATE.assign_tree = None
     STATE.assign_row_data.clear()
     STATE.cmb_user_var = None
@@ -4384,8 +4405,17 @@ def panel_narzedzia(root, frame, login=None, rola=None):
         def bind_open_detail(self, *_args: object, **_kwargs: object) -> None:
             return None
 
+    tools_actions = ttk.Frame(frame, style="WM.TFrame")
+    tools_actions.pack(fill="x", padx=10, pady=(10, 0))
+    ttk.Button(
+        tools_actions,
+        text="Drukuj pustą kartę narzędzia",
+        command=_print_blank_tool_card_from_tools,
+        style="WM.Side.TButton",
+    ).pack(side="left")
+
     tools_wrap = ttk.Frame(frame, style="WM.Card.TFrame")
-    tools_wrap.pack(fill="both", expand=True, padx=10, pady=10)
+    tools_wrap.pack(fill="both", expand=True, padx=10, pady=(6, 10))
     try:
         tools_view = ToolsThreeTabsView(
             tools_wrap,

--- a/machine_card_pdf.py
+++ b/machine_card_pdf.py
@@ -380,3 +380,38 @@ def generate_machine_card(
         _open_file(generated)
 
     return generated
+
+
+def generate_blank_machine_card(
+    output_dir: str | Path,
+    *,
+    dyspozycja: dict[str, Any] | None = None,
+    open_after: bool = True,
+) -> Path:
+    """Generuje pustą kartę maszyny do ręcznego wypełnienia."""
+    blank_machine: dict[str, Any] = {
+        "id": "---",
+        "nr_ewid": "---",
+        "numer": "---",
+        "nazwa": "",
+        "typ": "",
+        "status": "",
+        "lokalizacja": "",
+        "hala": "",
+        "default_review_type": "",
+        "review_months": [],
+        "review_workers": [],
+        "reviews": [
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+        ],
+    }
+    return generate_machine_card(
+        blank_machine,
+        output_dir,
+        dyspozycja=dyspozycja,
+        open_after=open_after,
+    )

--- a/tool_card_pdf.py
+++ b/tool_card_pdf.py
@@ -396,3 +396,36 @@ def generate_tool_card(
         _open_file(generated)
 
     return generated
+
+
+def generate_blank_tool_card(
+    output_dir: str | Path,
+    *,
+    dyspozycja: dict[str, Any] | None = None,
+    open_after: bool = True,
+) -> Path:
+    """Generuje pustą kartę narzędzia do ręcznego wypełnienia."""
+    blank_tool: dict[str, Any] = {
+        "id": "---",
+        "nr": "---",
+        "numer": "---",
+        "nazwa": "",
+        "typ": "",
+        "tryb": "",
+        "status": "",
+        "pracownik": "",
+        "data_dodania": "",
+        "zadania": [
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+            "................................................................................",
+        ],
+    }
+    return generate_tool_card(
+        blank_tool,
+        output_dir,
+        dyspozycja=dyspozycja,
+        open_after=open_after,
+    )


### PR DESCRIPTION
### Motivation
- Provide a quick way to produce blank printable cards for tools and machines so staff can fill them manually from the UI.
- Allow printing blank cards both from the Tools/Machines modules and from the Dyspozycje creator while preserving current dyspozycja metadata.

### Description
- Added `generate_blank_tool_card(...)` in `tool_card_pdf.py` and `generate_blank_machine_card(...)` in `machine_card_pdf.py`, which build blank card objects and reuse existing PDF/HTML generation paths while accepting an optional `dyspozycja` parameter.
- Added helper functions and buttons to the dyspozycja creator (`gui_dyspozycje_creator.py`) to print blank tool/machine cards for the selected dyspozycja context.
- Added actions/buttons to the Tools panel (`gui_narzedzia.py`) and Machines panel (`gui_maszyny.py`) to print blank cards and implemented output directory creation under `wydruki/karty`.
- Errors during generation are reported to the user via messagebox dialogs and the UI layout was slightly adjusted to accommodate the new controls.

### Testing
- Ran `python -m py_compile` for the modified modules (`tool_card_pdf.py`, `machine_card_pdf.py`, `gui_dyspozycje_creator.py`, `gui_narzedzia.py`, `gui_maszyny.py`) and the files compiled successfully.
- Performed a smoke test by programmatically invoking `generate_blank_tool_card(..., open_after=False)` and `generate_blank_machine_card(..., open_after=False)` which produced PDF files as expected.
- Executed the full test suite with `pytest`; the run produced `5 failed, 35 passed, 5 skipped` before being interrupted, and the failing tests are in GUI login/config areas that require a display/Tk environment or are unrelated to these changes.
- Ran `git diff --check` and basic repository checks and found no new diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecb3eab1c8323b8e42a5ebb70735c)