### PR TITLE
Dodaj historię dyspozycji do podglądu obiektów

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -17,6 +17,7 @@ from dyspozycje_sources import (
 from dyspozycje_store import (
     add_dyspozycja,
     close_dyspozycja,
+    load_dyspozycje,
     make_dyspozycja,
     update_dyspozycja,
 )
@@ -35,6 +36,97 @@ def _normalize_object_id(value: str) -> set[str]:
         out.add(raw.zfill(3))
         out.add(str(int(raw)))
     return {item for item in out if item}
+
+
+def _dysp_date_text(row: dict[str, Any]) -> str:
+    return str(
+        row.get("updated_at")
+        or row.get("created_at")
+        or row.get("utworzono")
+        or row.get("data")
+        or ""
+    ).strip()
+
+
+def _dysp_title_text(row: dict[str, Any]) -> str:
+    return str(row.get("tytul") or row.get("opis") or "Dyspozycja").strip()
+
+
+def _dysp_assignee_text(row: dict[str, Any]) -> str:
+    if bool(row.get("dla_wszystkich")):
+        return "wszyscy"
+    return str(row.get("przypisane_do") or "—").strip() or "—"
+
+
+def _find_recent_dyspozycje_for_object(
+    typ: str,
+    object_id: str,
+    *,
+    limit: int = 5,
+    skip_id: str = "",
+) -> list[dict[str, Any]]:
+    typ_norm = str(typ or "").strip().lower()
+    variants = _normalize_object_id(object_id)
+    if not typ_norm or not variants:
+        return []
+
+    try:
+        rows = load_dyspozycje()
+    except Exception:
+        rows = []
+
+    matched: list[dict[str, Any]] = []
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+
+        row_id = str(row.get("id") or "").strip()
+        if skip_id and row_id == skip_id:
+            continue
+
+        row_typ = str(
+            row.get("typ_dyspozycji") or row.get("typ") or ""
+        ).strip().lower()
+        if row_typ != typ_norm:
+            continue
+
+        row_object_id = str(
+            row.get("obiekt_id")
+            or row.get("object_id")
+            or row.get("narzedzie_id")
+            or row.get("maszyna_id")
+            or ""
+        ).strip()
+        if not variants.intersection(_normalize_object_id(row_object_id)):
+            continue
+
+        matched.append(row)
+
+    matched.sort(key=_dysp_date_text, reverse=True)
+    return matched[:limit]
+
+
+def _format_dyspozycje_history(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return "Brak wcześniejszych dyspozycji dla tego obiektu"
+
+    lines: list[str] = []
+    for row in rows:
+        date_text = _dysp_date_text(row)
+        if len(date_text) >= 10:
+            date_text = date_text[:10]
+        priority = str(row.get("priorytet") or "normalny").strip()
+        status = str(row.get("status") or "—").strip()
+        title = _dysp_title_text(row)
+        assignee = _dysp_assignee_text(row)
+
+        lines.append(
+            f"{date_text or '—'} | {priority} | {status}\n"
+            f"{title}\n"
+            f"Przypisane: {assignee}"
+        )
+
+    return "\n\n".join(lines)
 
 
 def _task_title(task: Any) -> str:
@@ -677,9 +769,18 @@ def open_dyspozycje_creator(
                 "Narzędzie powiązane z dyspozycją: "
                 f"{selected_label or object_id or 'brak wyboru'}"
             )
+            tool_preview = _find_tool_preview(object_id)
+            history = _find_recent_dyspozycje_for_object(
+                "narzedzie",
+                object_id,
+                skip_id=existing_id,
+            )
+            tool_preview["Ostatnie dyspozycje"] = _format_dyspozycje_history(
+                history
+            )
             _render_object_card(
                 "Karta narzędzia",
-                _find_tool_preview(object_id),
+                tool_preview,
             )
             btn_open_tool.pack(side="left")
             btn_print_tool_card.pack(side="left", padx=(8, 0))
@@ -689,9 +790,18 @@ def open_dyspozycje_creator(
                 "Maszyna powiązana z dyspozycją: "
                 f"{selected_label or object_id or 'brak wyboru'}"
             )
+            machine_preview = _find_machine_preview(object_id)
+            history = _find_recent_dyspozycje_for_object(
+                "maszyna",
+                object_id,
+                skip_id=existing_id,
+            )
+            machine_preview["Ostatnie dyspozycje"] = (
+                _format_dyspozycje_history(history)
+            )
             _render_object_card(
                 "Karta maszyny",
-                _find_machine_preview(object_id),
+                machine_preview,
             )
             btn_open_machine.pack(side="left")
             btn_print_machine_card.pack(side="left", padx=(8, 0))


### PR DESCRIPTION
### Motivation
- W dolnym panelu edycji dyspozycji należy pokazać historię ostatnich dyspozycji powiązanego narzędzia lub maszyny bez zmiany zapisu danych ani logiki statusów.
- Dla narzędzia podgląd ma zawierać podstawową kartę, zadania narzędzia (jeśli istnieją) oraz listę „Ostatnie dyspozycje”.
- Dla maszyny podgląd ma zawierać podstawową kartę, informacje serwisowe oraz listę „Ostatnie dyspozycje”.

### Description
- Dodano import `load_dyspozycje` oraz helpery: `_dysp_date_text`, `_dysp_title_text`, `_dysp_assignee_text`, `_find_recent_dyspozycje_for_object` oraz `_format_dyspozycje_history` odpowiedzialne za pobranie, filtrowanie (w tym pominięcie bieżącej dyspozycji) i sformatowanie ostatnich wpisów.
- Historyczne dyspozycje są wyszukiwane po znormalizowanych wariantach identyfikatora obiektu i dopasowywane po typie (np. `narzedzie` / `maszyna`).
- W `_refresh_object_panel` dla gałęzi `narzedzie` i `maszyna` pobierane są preview obiektu i dołączane pole `"Ostatnie dyspozycje"` z sformatowanym tekstem, przy czym zachowano dokładnie jedno wywołanie `_render_object_card` w każdej gałęzi.
- Patch ogranicza się do widoku w `gui_dyspozycje_creator.py` i nie zmienia formatu JSON, zapisu dyspozycji ani logiki statusów.

### Testing
- `python -m py_compile gui_dyspozycje_creator.py` zakończyło się powodzeniem.
- Uruchomiono lokalny smoke test helperów historii (zamockowano `load_dyspozycje`) sprawdzający normalizację ID, pominięcie bieżącej dyspozycji, filtrowanie typu i formatowanie; test przeszedł pomyślnie.
- Wykonano `git diff --check` i statyczne sprawdzenie wywołań `_render_object_card` aby potwierdzić pojedyncze wywołania w obu gałęziach; oba kontrole przeszły pomyślnie.
- Uruchomiono `pytest` zgodnie z `AGENTS.md`, jednak pełny zestaw testów zgłosił niepowiązane z patchem problemy środowiskowe (m.in. brak `$DISPLAY` dla Tkinter) i zakończył się częściowymi porażkami (`5 failed, 35 passed, 5 skipped`), które nie były spowodowane wprowadzonymi zmianami.
- Próba uruchomienia `py -3.13 -m py_compile gui_dyspozycje_creator.py` nie powiodła się, ponieważ launcher `py` nie jest dostępny w kontenerze, natomiast równoważna kompilacja z `python` była OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efdf1603883238c5b501e836e7f3a)