### PR TITLE
Show disposition descriptions in history

### DIFF
--- a/gui_dyspozycje_creator.py
+++ b/gui_dyspozycje_creator.py
@@ -49,7 +49,11 @@ def _dysp_date_text(row: dict[str, Any]) -> str:
 
 
 def _dysp_title_text(row: dict[str, Any]) -> str:
-    return str(row.get("tytul") or row.get("opis") or "Dyspozycja").strip()
+    return str(row.get("tytul") or "Dyspozycja").strip()
+
+
+def _dysp_description_text(row: dict[str, Any]) -> str:
+    return str(row.get("opis") or row.get("description") or "").strip()
 
 
 def _dysp_assignee_text(row: dict[str, Any]) -> str:
@@ -118,13 +122,17 @@ def _format_dyspozycje_history(rows: list[dict[str, Any]]) -> str:
         priority = str(row.get("priorytet") or "normalny").strip()
         status = str(row.get("status") or "—").strip()
         title = _dysp_title_text(row)
+        opis = _dysp_description_text(row)
         assignee = _dysp_assignee_text(row)
 
-        lines.append(
+        block = (
             f"{date_text or '—'} | {priority} | {status}\n"
-            f"{title}\n"
-            f"Przypisane: {assignee}"
+            f"{title}"
         )
+        if opis and opis != title:
+            block += f"\nOpis: {opis}"
+        block += f"\nPrzypisane: {assignee}"
+        lines.append(block)
 
     return "\n\n".join(lines)
 


### PR DESCRIPTION
### Motivation
- Improve how disposition history entries render by keeping the title distinct from the description to avoid duplicated lines.
- Support both the primary `opis` field and legacy `description` field when rendering a disposition description.
- Only surface a labeled description line when it is meaningful (non-empty and different from the title) to keep history concise and readable.

### Description
- Stop using the description as a fallback for `title` by changing ` _dysp_title_text` to fall back only to the literal `"Dyspozycja"` when `tytul` is missing.
- Add a new helper ` _dysp_description_text` that returns `opis` or legacy `description` normalized to a stripped string.
- Update `_format_dyspozycje_history` to build a `block` for each row and append an `Opis: ...` line only when the description is present and differs from the title, preserving the `Przypisane:` line.

### Testing
- Ran `pytest` after the change as required, but the full suite did not complete due to unrelated GUI test failures and a subsequent stall in the existing test run.
- Ran `python -m py_compile gui_dyspozycje_creator.py` which succeeded.
- Executed a small script that asserts expected outputs from `_format_dyspozycje_history` for several cases (title+description, description-only, identical title+description), and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0108ae84832398d21ad704e0ac17)