### PR TITLE
Uprość dostęp do operacji magazynowych

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -64,13 +64,13 @@ COLUMNS = ("id", "typ", "rozmiar", "nazwa", "stan", "zadania")
 
 
 ROLE_PERMS = {
-    "view": "brygadzista",
-    "add": "magazynier",
-    "edit": "magazynier",
-    "pz": "magazynier",
-    "reserve": "brygadzista",
-    "unreserve": "brygadzista",
-    "to_orders": "brygadzista",
+    "view": "",
+    "add": "",
+    "edit": "",
+    "pz": "",
+    "reserve": "",
+    "unreserve": "",
+    "to_orders": "",
 }
 
 
@@ -206,6 +206,18 @@ def build_magazyn_toolbar(toolbar: ttk.Frame, owner):
         toolbar,
         text="Zwolnij rez.",
         command=owner._rez_release,
+        style="WM.Side.TButton",
+    ).pack(side="right", padx=(0, 6))
+    ttk.Button(
+        toolbar,
+        text="Edytuj",
+        command=owner._edit_selected_item,
+        style="WM.Side.TButton",
+    ).pack(side="right", padx=(0, 6))
+    ttk.Button(
+        toolbar,
+        text="Dodaj",
+        command=owner._add_item,
         style="WM.Side.TButton",
     ).pack(side="right", padx=(0, 6))
     ttk.Button(
@@ -758,16 +770,20 @@ class MagazynFrame(ttk.Frame):
             _tag_low_stock(self, node, item)
 
     def _on_double_click(self, _e):
-        sel = self.tree.selection()
-        if not sel:
-            return
-        if not _can(self, "edit"):
-            messagebox.showwarning(
-                "Uprawnienia", "Tylko magazynier może edytować pozycje."
+        self._edit_selected_item()
+
+    def _add_item(self):
+        open_edit_dialog(self, None, on_saved=lambda _id=None: self.refresh())
+
+    def _edit_selected_item(self):
+        item_id = self._selected_item_id()
+        if not item_id:
+            messagebox.showinfo(
+                "Magazyn",
+                "Najpierw wybierz pozycję magazynową do edycji.",
+                parent=self,
             )
             return
-        values = self.tree.item(sel[0], "values")
-        item_id = values[0]
         open_edit_dialog(self, item_id, on_saved=lambda _id=item_id: self.refresh())
 
     def _selected_item_id(self):


### PR DESCRIPTION
### Motivation
- Uprościć dostęp do operacji magazynowych tak, aby nie blokowały ich wcześniejsze role użytkowników.
- Ułatwić dodawanie i edycję pozycji bez konieczności przechodzenia do oddzielnych dialogów.

### Description
- Zmieniono `ROLE_PERMS` tak, aby wymagania ról dla akcji magazynowych są puste i nie blokowały dostępu.
- Dodano przyciski na pasku narzędzi `Dodaj` i `Edytuj` wywołujące nowe akcje z poziomu widoku magazynu (`build_magazyn_toolbar`).
- Wydzielono obsługę dodawania i edycji do metod `MagazynFrame._add_item` oraz `MagazynFrame._edit_selected_item` i zmieniono `MagazynFrame._on_double_click` na wywołanie wspólnego edytora.
- Przy próbie edycji bez zaznaczenia pozycji dodano informacyjny komunikat (`messagebox.showinfo`) zamiast jedynie ignorować zdarzenie.

### Testing
- Uruchomiono `python -m py_compile gui_magazyn.py` i sprawdzono brak błędów składniowych; komenda zakończyła się powodzeniem.
- Sprawdzono `git diff --check` bez nowych problemów formatowania/składniowych w zmienionym pliku.
- Uruchomiono testy modułowe związane z magazynem: `pytest tests/test_gui_magazyn_basic.py` (3 passed) oraz zestaw `pytest tests/test_gui_magazyn_basic.py tests/test_gui_magazyn_add.py tests/test_gui_magazyn_bom_ops.py tests/test_gui_magazyn_pz.py tests/test_inventory_bridge.py` which reported `11 passed, 1 skipped`.
- Pełny test suite `pytest` został uruchomiony z timeoutem 120s i przerwany; przed timeoutem pojawiły się istniejące, niepowiązane z modułem magazynu błędy w `test_gui_logowanie.py` i `test_gui_narzedzia_config.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1f827f7c832386b0f5f113a33d8d)