### PR TITLE
Przenieś przycisk „Dodaj” obok „Odśwież” w pasku narzędzi magazynu

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -216,12 +216,6 @@ def build_magazyn_toolbar(toolbar: ttk.Frame, owner):
     ).pack(side="right", padx=(0, 6))
     ttk.Button(
         toolbar,
-        text="Dodaj",
-        command=owner._add_item,
-        style="WM.Side.TButton",
-    ).pack(side="right", padx=(0, 6))
-    ttk.Button(
-        toolbar,
         text="Wyczyść",
         command=owner._clear_filters,
         style="WM.Side.TButton",
@@ -230,6 +224,12 @@ def build_magazyn_toolbar(toolbar: ttk.Frame, owner):
         toolbar,
         text="Odśwież",
         command=owner.refresh,
+        style="WM.Side.TButton",
+    ).pack(side="right", padx=(0, 6))
+    ttk.Button(
+        toolbar,
+        text="Dodaj",
+        command=owner._add_item,
         style="WM.Side.TButton",
     ).pack(side="right", padx=(0, 6))
 


### PR DESCRIPTION
### Motivation
- Ułatwić układ przycisków w panelu magazynu poprzez umieszczenie przycisku `Dodaj` bezpośrednio po przycisku `Odśwież` dla lepszej spójności interfejsu.

### Description
- Przeniesiono definicję przycisku `ttk.Button(..., text="Dodaj", command=owner._add_item)` w funkcji `build_magazyn_toolbar` w pliku `gui_magazyn.py` tak, aby była tworzona po przycisku `Odśwież`, bez duplikowania logiki i pozostawiając istniejącą metodę `owner._add_item` bez zmian.

### Testing
- Uruchomiono `python -m py_compile gui_magazyn.py` i `git diff --check` bez błędów.
- Uruchomiono ukierunkowane testy `pytest tests/test_gui_magazyn_basic.py` i wszystkie testy w tym module zakończyły się sukcesem (`3 passed`).
- Pełny przebieg `pytest` został uruchomiony zgodnie z repozytoryjnymi instrukcjami, ale nie przeszedł z powodu niezależnych błędów środowiskowych i istniejących problemów w `test_gui_logowanie.py` oraz `test_gui_narzedzia_config.py` (m.in. brak `$DISPLAY` dla Tkinter i jedna asercja), które nie są związane z tą zmianą.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f23a510fc8323b067e7caa83d4c1b)