### PR TITLE
Ułatw zarządzanie rezerwacjami magazynu

### DIFF
--- a/gui_magazyn.py
+++ b/gui_magazyn.py
@@ -204,14 +204,20 @@ def build_magazyn_toolbar(toolbar: ttk.Frame, owner):
     ).pack(side="right", padx=(0, 6))
     ttk.Button(
         toolbar,
-        text="Zwolnij rez.",
-        command=owner._rez_release,
+        text="Edytuj",
+        command=owner._edit_selected_item,
         style="WM.Side.TButton",
     ).pack(side="right", padx=(0, 6))
     ttk.Button(
         toolbar,
-        text="Edytuj",
-        command=owner._edit_selected_item,
+        text="Dodaj",
+        command=owner._add_item,
+        style="WM.Side.TButton",
+    ).pack(side="right", padx=(0, 6))
+    ttk.Button(
+        toolbar,
+        text="Zwolnij rez.",
+        command=owner._rez_release,
         style="WM.Side.TButton",
     ).pack(side="right", padx=(0, 6))
     ttk.Button(
@@ -224,12 +230,6 @@ def build_magazyn_toolbar(toolbar: ttk.Frame, owner):
         toolbar,
         text="Odśwież",
         command=owner.refresh,
-        style="WM.Side.TButton",
-    ).pack(side="right", padx=(0, 6))
-    ttk.Button(
-        toolbar,
-        text="Dodaj",
-        command=owner._add_item,
         style="WM.Side.TButton",
     ).pack(side="right", padx=(0, 6))
 
@@ -793,11 +793,6 @@ class MagazynFrame(ttk.Frame):
         return self.tree.item(sel[0], "values")[0]
 
     def _rez_do_polproduktu(self):
-        if not _can(self, "reserve"):
-            messagebox.showwarning(
-                "Uprawnienia", "Brak uprawnień do rezerwacji."
-            )
-            return
         item_id = self._selected_item_id()
         if not item_id:
             return
@@ -805,11 +800,6 @@ class MagazynFrame(ttk.Frame):
         self.refresh()
 
     def _rez_release(self):
-        if not _can(self, "unreserve"):
-            messagebox.showwarning(
-                "Uprawnienia", "Brak uprawnień do zwolnienia rezerwacji."
-            )
-            return
         item_id = self._selected_item_id()
         if not item_id:
             return


### PR DESCRIPTION
### Motivation
- Uporządkować pasek narzędzi magazynu aby podstawowe akcje edycji i dodawania były łatwo dostępne obok akcji rezerwacji.
- Usunąć blokady uprawnień, które uniemożliwiały wykonywanie akcji rezerwacji/zwalniania w niektórych scenariuszach interfejsu.

### Description
- Przemieszczono i uporządkowano przyciski w `build_magazyn_toolbar` tak, że przyciski `Rezerwuj`, `Edytuj`, `Dodaj` i `Zwolnij rez.` występują obok siebie w logicznej kolejności. 
- Dodano wywołania metod `owner._edit_selected_item` i `owner._add_item` w toolbarze oraz usunięto duplikujące się przyciskowe bloki, zachowując istniejące style i pack-owanie. 
- Usunięto sprawdzenia uprawnień (`_can(self, "reserve")` i `_can(self, "unreserve")`) z metod `MagazynFrame._rez_do_polproduktu` i `MagazynFrame._rez_release`, pozostawiając tylko walidację wyboru pozycji i otwieranie odpowiednich dialogów rezerwacji. 
- Zostawiono istniejące metody `MagazynFrame._add_item` i `MagazynFrame._edit_selected_item` oraz zachowano wywołanie edycji przy podwójnym kliknięciu.

### Testing
- Uruchomiono `python -m py_compile gui_magazyn.py` i wynik był poprawny. 
- Uruchomiono `git diff --check` bez problemów. 
- Uruchomiono wybrane testy związane z magazynem: `pytest tests/test_gui_magazyn_basic.py tests/test_gui_magazyn_pz.py tests/test_gui_magazyn_bom_ops.py tests/test_gui_magazyn_add.py tests/test_inventory_bridge.py` — wynik: `11 passed, 1 skipped`.
- Pełny `pytest` został uruchomiony zgodnie z wytycznymi repozytorium, jednak został przerwany po ~162 s z powodu zawieszenia jednego testu multiprocessing; przed przerwaniem zgłoszono 5 niepowodzeń w niezwiązanych testach GUI/logowania i konfiguracji (m.in. brak `$DISPLAY`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f26e01a588323bd3d9a3d09ca1e9a)