### PR TITLE
Normalize machine statuses in orders

### DIFF
--- a/gui_zlecenia.py
+++ b/gui_zlecenia.py
@@ -158,6 +158,14 @@ def _load_tool_status_cache() -> dict[str, str]:
     return cache
 
 
+def _load_machine_rows_with_status_label() -> tuple[
+    list[dict], Callable[[Any], str] | None
+]:
+    from gui_maszyny import _machine_status_label, load_machines_rows
+
+    return load_machines_rows(), _machine_status_label
+
+
 def _load_machine_status_cache() -> dict[str, str]:
     global _DYSP_MACHINE_STATUS_CACHE
     if _DYSP_MACHINE_STATUS_CACHE is not None:
@@ -165,11 +173,10 @@ def _load_machine_status_cache() -> dict[str, str]:
 
     cache: dict[str, str] = {}
     try:
-        from gui_maszyny import load_machines_rows
-
-        rows = load_machines_rows()
+        rows, machine_status_label = _load_machine_rows_with_status_label()
     except Exception:
         rows = []
+        machine_status_label = None
 
     for row in rows or []:
         if not isinstance(row, dict):
@@ -181,7 +188,11 @@ def _load_machine_status_cache() -> dict[str, str]:
             or row.get("numer")
             or ""
         ).strip()
-        status = str(row.get("status") or "").strip()
+        raw_status = row.get("status")
+        if machine_status_label is not None:
+            status = machine_status_label(raw_status)
+        else:
+            status = str(raw_status or "").strip()
         if not rid or not status:
             continue
         for key in _normalize_object_id(rid):

--- a/test_logika_zlecenia_i_maszyny.py
+++ b/test_logika_zlecenia_i_maszyny.py
@@ -113,6 +113,24 @@ def test_surowce_check_and_reserve(tmp_path, monkeypatch):
     assert updated["SR002"] == mag_after["SR002"]["stan"]
 
 
+def test_machine_status_cache_uses_machine_status_label(monkeypatch):
+    monkeypatch.setattr(gui_zlecenia, "_DYSP_MACHINE_STATUS_CACHE", None)
+
+    def fake_loader():
+        return (
+            [{"nr_ewid": "27", "status": "awaria_serwis"}],
+            lambda v: f"label:{v}",
+        )
+
+    monkeypatch.setattr(
+        gui_zlecenia, "_load_machine_rows_with_status_label", fake_loader
+    )
+
+    cache = gui_zlecenia._load_machine_status_cache()
+
+    assert cache["27"] == "label:awaria_serwis"
+
+
 def test_role_without_permission_cannot_edit(monkeypatch):
     try:
         import tkinter as tk


### PR DESCRIPTION
### Motivation
- Ensure machine-related statuses shown in the orders/dyspozycje panel use the same human-friendly labels as the machines UI, instead of raw status keys.
- Provide a small, testable contract so the machine status cache consistently stores display-ready labels.

### Description
- Add helper `def _load_machine_rows_with_status_label()` that returns machine rows and the `_machine_status_label` formatter from `gui_maszyny`.
- Update `_load_machine_status_cache()` to format raw machine `status` values via the returned `machine_status_label` and fall back to string trimming when the labeler is unavailable.
- Add unit test `test_machine_status_cache_uses_machine_status_label` in `test_logika_zlecenia_i_maszyny.py` to verify the cache contains the formatted label.

### Testing
- Ran the focused test `python -m pytest test_logika_zlecenia_i_maszyny.py::test_machine_status_cache_uses_machine_status_label` which passed.
- Ran `python -m pytest test_logika_zlecenia_i_maszyny.py` where the new test passed but the file has an existing unrelated failure (`test_wczytanie_wielu_zlecen_filtracja` raises `KeyError: 'status'`).
- Attempted broader test runs (`python -m pytest test_gui_logowanie.py test_gui_narzedzia_config.py -q` and the full suite) which surfaced pre-existing GUI/headless-related failures and timed out; those failures are unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab15f9f0832387ad971597286645)