### PR TITLE
Reposition machine action buttons

### DIFF
--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -2497,17 +2497,20 @@ def _open_machines_panel(
     )
     ttk.Label(toolbar, textvariable=mode_hint_var).pack(side="left", padx=(0, 12))
 
+    actions_toolbar = ttk.Frame(left)
+    actions_toolbar.pack(fill="x", padx=8, pady=(4, 0))
+
     btn_import = ttk.Button(toolbar, text="Importuj harmonogram…")
     # Stary import harmonogramu ukryty. Docelowym modelem są machine["reviews"].
 
     btn_add, btn_edit, btn_del, btn_save = (
-        ttk.Button(toolbar, text=text)
+        ttk.Button(actions_toolbar, text=text)
         for text in ("Dodaj", "Edytuj", "Usuń", "Zapisz")
     )
-    btn_change_status = ttk.Button(toolbar, text="Zmień status")
+    btn_change_status = ttk.Button(actions_toolbar, text="Zmień status")
     edit_mode_buttons = [btn_add, btn_edit, btn_del, btn_save]
-    for button in (btn_save, btn_del, btn_edit, btn_change_status, btn_add):
-        button.pack(side="right", padx=4)
+    for button in (btn_add, btn_change_status, btn_edit, btn_del, btn_save):
+        button.pack(side="left", padx=(0, 6))
 
     def _refresh_machine_mode_ui(*_args) -> None:
         edit_mode = _is_machine_edit_mode()


### PR DESCRIPTION
### Motivation
- Reduce horizontal clutter in the machines toolbar by separating action controls from filters and mode hints. 
- Make machine actions appear in a clear left-to-right workflow order for better discoverability and ergonomics.

### Description
- Add a new `actions_toolbar = ttk.Frame(left)` placed under the main toolbar and packed with `fill="x"`.
- Move machine action buttons (`Dodaj`, `Edytuj`, `Usuń`, `Zapisz`, `Zmień status`) into the new `actions_toolbar` and create them with `ttk.Button(actions_toolbar, ...)`.
- Change button packing from `side="right"` to `side="left"` and adjust ordering and `padx` to present actions left-to-right; keep the import button in the original toolbar.

### Testing
- Ran the full test suite with `pytest`, which was started but the run was interrupted after early unrelated failures were observed. 
- Ran `pytest tests/test_gui_maszyny_status_history.py test_logika_zlecenia_i_maszyny.py`, where the machines status history tests passed and `test_logika_zlecenia_i_maszyny.py::test_wczytanie_wielu_zlecen_filtracja` failed with `KeyError: 'status'`.
- Verified the UI change by inspecting the updated `gui_maszyny.py` diff and ensuring no syntax errors were introduced when running the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc5c280cc8323a9b4cc70c39bce01)