### PR TITLE
Maszyny: lokalizacja w użytkowaniu i szybkie przypisanie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
             widok_hali/machine_rooms_patch.py \
             widok_hali/machine_rooms_persistence.py \
             widok_hali/machine_rooms_ui_patch.py \
-            widok_hali/machine_rooms_editor_patch.py
+            widok_hali/machine_rooms_editor_patch.py \
+            widok_hali/machine_usage_location_patch.py
       - name: Run hall and machine integration tests
         run: |
           pytest -q \
@@ -39,10 +40,13 @@ jobs:
             tests/test_gui_maszyny_rooms_integration.py \
             tests/test_gui_maszyny_rooms_persistence.py \
             tests/test_gui_maszyny_room_ui.py \
-            tests/test_gui_maszyny_room_editor.py
+            tests/test_gui_maszyny_room_editor.py \
+            tests/test_gui_maszyny_usage_location.py
       - name: Run Tk hall smoke under Xvfb
         run: |
-          xvfb-run -a pytest -q tests/test_gui_maszyny_rooms_tk_smoke.py
+          xvfb-run -a pytest -q \
+            tests/test_gui_maszyny_rooms_tk_smoke.py \
+            tests/test_gui_maszyny_usage_location_tk.py
   static-checks:
     runs-on: ubuntu-latest
     steps:

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1,4 +1,4 @@
-# version: 2.1
+# version: 2.2
 """Bezpieczny punkt wejścia modułu Maszyny z warstwowym rozszerzeniem hali.
 
 Oryginalna, działająca implementacja Maszyn pozostaje bez zmian w
@@ -21,11 +21,15 @@ from widok_hali.machine_rooms_ui_patch import (
 from widok_hali.machine_rooms_editor_patch import (
     install_machine_room_editor as _install_machine_room_editor,
 )
+from widok_hali.machine_usage_location_patch import (
+    install_machine_usage_location as _install_machine_usage_location,
+)
 
 _install_machine_rooms(_legacy)
 _install_machine_room_persistence(_legacy)
 _install_machine_room_ui(_legacy)
 _install_machine_room_editor(_legacy)
+_install_machine_usage_location(_legacy)
 
 # Kluczowe dla zgodności: użytkownik ``import gui_maszyny`` dostaje dokładnie
 # moduł z dotychczasową implementacją, a nie proxy z kopiami jego symboli.

--- a/tests/test_gui_maszyny_usage_location.py
+++ b/tests/test_gui_maszyny_usage_location.py
@@ -1,0 +1,153 @@
+# version: 1.0
+from copy import deepcopy
+
+import gui_maszyny
+import widok_hali.machine_rooms_ui_patch as ui_patch
+import widok_hali.machine_usage_location_patch as usage_patch
+from widok_hali.rooms import Room, point_in_polygon
+
+
+def _rooms():
+    return [
+        Room(
+            id="POM_0001",
+            name="Tokarnia",
+            hala="1",
+            polygon=[(0, 0), (200, 0), (200, 200), (0, 200)],
+        ),
+        Room(
+            id="POM_0002",
+            name="Spawalnia",
+            hala="1",
+            polygon=[(300, 0), (500, 0), (500, 200), (300, 200)],
+        ),
+    ]
+
+
+def test_usage_location_extension_is_installed():
+    assert gui_maszyny._WM_USAGE_LOCATION_INSTALLED is True
+    assert callable(gui_maszyny._wm_assign_machine_to_room)
+
+
+def test_click_assignment_persists_room_and_relocates_machine(monkeypatch):
+    rooms = _rooms()
+    rows = [
+        {
+            "id": "M-27",
+            "nazwa": "Tokarka",
+            "status": "ok",
+            "nr_hali": "1",
+            "x": 700,
+            "y": 700,
+            "lokalizacja": "",
+            "lokalizacja_id": "",
+            "placement_status": "unplaced",
+        }
+    ]
+    saved = {}
+
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (deepcopy(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: deepcopy(rows))
+
+    def fake_save(path, new_rows):
+        saved["path"] = path
+        saved["rows"] = deepcopy(new_rows)
+        return True
+
+    monkeypatch.setattr(gui_maszyny, "_save_machines", fake_save)
+
+    changed = gui_maszyny._wm_assign_machine_to_room("M-27", "Tokarnia")
+
+    assert changed["lokalizacja"] == "Tokarnia"
+    assert changed["lokalizacja_id"] == "POM_0001"
+    assert changed["placement_status"] == "placed"
+    assert point_in_polygon(changed["x"], changed["y"], rooms[0].polygon)
+    assert saved["path"] == "/tmp/maszyny.json"
+    assert saved["rows"][0]["lokalizacja"] == "Tokarnia"
+
+
+def test_fresh_location_survives_later_stale_status_save(monkeypatch):
+    rooms = _rooms()
+    original = {
+        "id": "M-27",
+        "nazwa": "Tokarka",
+        "status": "ok",
+        "nr_hali": "1",
+        "x": 700,
+        "y": 700,
+        "lokalizacja": "",
+        "lokalizacja_id": "",
+        "placement_status": "unplaced",
+    }
+    rows = [deepcopy(original)]
+
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (deepcopy(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: deepcopy(rows))
+    monkeypatch.setattr(gui_maszyny, "_save_machines", lambda path, new_rows: True)
+
+    changed = gui_maszyny._wm_assign_machine_to_room("M-27", "Tokarnia")
+    assert changed["lokalizacja"] == "Tokarnia"
+
+    stale_status_update = deepcopy(original)
+    stale_status_update["status"] = "warn"
+    merged = gui_maszyny.upsert_machine(rows, stale_status_update)
+    merged_row = merged[0]
+
+    assert merged_row["status"] == "warn"
+    assert merged_row["lokalizacja"] == "Tokarnia"
+    assert merged_row["lokalizacja_id"] == "POM_0001"
+    assert merged_row["placement_status"] == "placed"
+
+
+def test_explicit_later_room_change_is_not_blocked(monkeypatch):
+    rooms = _rooms()
+    original = {
+        "id": "M-27",
+        "status": "ok",
+        "nr_hali": "1",
+        "x": 700,
+        "y": 700,
+        "lokalizacja": "",
+        "lokalizacja_id": "",
+        "placement_status": "unplaced",
+    }
+    rows = [deepcopy(original)]
+
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (deepcopy(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: deepcopy(rows))
+    monkeypatch.setattr(gui_maszyny, "_save_machines", lambda path, new_rows: True)
+
+    gui_maszyny._wm_assign_machine_to_room("M-27", "Tokarnia")
+
+    explicit = deepcopy(original)
+    explicit["lokalizacja"] = "Spawalnia"
+    explicit["lokalizacja_id"] = "POM_0002"
+    explicit["placement_status"] = "outside_room"
+    changed_rows = gui_maszyny.upsert_machine(rows, explicit)
+    changed = changed_rows[0]
+
+    assert changed["lokalizacja"] == "Spawalnia"
+    assert changed["lokalizacja_id"] == "POM_0002"
+    assert changed["placement_status"] == "placed"
+    assert point_in_polygon(changed["x"], changed["y"], rooms[1].polygon)

--- a/tests/test_gui_maszyny_usage_location.py
+++ b/tests/test_gui_maszyny_usage_location.py
@@ -1,7 +1,8 @@
-# version: 1.0
+# version: 1.1
 from copy import deepcopy
 
 import gui_maszyny
+import widok_hali.machine_rooms_patch as rooms_patch
 import widok_hali.machine_rooms_ui_patch as ui_patch
 import widok_hali.machine_usage_location_patch as usage_patch
 from widok_hali.rooms import Room, point_in_polygon
@@ -22,6 +23,12 @@ def _rooms():
             polygon=[(300, 0), (500, 0), (500, 200), (300, 200)],
         ),
     ]
+
+
+def _patch_rooms(monkeypatch, rooms):
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(rooms_patch, "load_rooms", lambda: list(rooms))
 
 
 def test_usage_location_extension_is_installed():
@@ -46,8 +53,7 @@ def test_click_assignment_persists_room_and_relocates_machine(monkeypatch):
     ]
     saved = {}
 
-    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
-    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    _patch_rooms(monkeypatch, rooms)
     monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
     monkeypatch.setattr(
         gui_maszyny,
@@ -88,8 +94,7 @@ def test_fresh_location_survives_later_stale_status_save(monkeypatch):
     }
     rows = [deepcopy(original)]
 
-    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
-    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    _patch_rooms(monkeypatch, rooms)
     monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
     monkeypatch.setattr(
         gui_maszyny,
@@ -127,8 +132,7 @@ def test_explicit_later_room_change_is_not_blocked(monkeypatch):
     }
     rows = [deepcopy(original)]
 
-    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
-    monkeypatch.setattr(ui_patch, "load_rooms", lambda: list(rooms))
+    _patch_rooms(monkeypatch, rooms)
     monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
     monkeypatch.setattr(
         gui_maszyny,

--- a/tests/test_gui_maszyny_usage_location_tk.py
+++ b/tests/test_gui_maszyny_usage_location_tk.py
@@ -1,0 +1,130 @@
+# version: 1.0
+"""Headless Tk smoke dla lokalizacji w nagłówku Użytkowania maszyny."""
+
+import tkinter.font as tkfont
+
+import gui_maszyny
+import widok_hali.machine_usage_location_patch as usage_patch
+from widok_hali.rooms import Room
+
+
+def test_usage_status_frame_shows_location_on_right_and_missing_is_clickable(monkeypatch):
+    tk = gui_maszyny.tk
+    ttk = gui_maszyny.ttk
+    rows = [
+        {
+            "id": "27",
+            "nazwa": "Tokarka",
+            "status": "ok",
+            "nr_hali": "1",
+            "x": 900,
+            "y": 900,
+            "lokalizacja": "",
+            "lokalizacja_id": "",
+            "placement_status": "unplaced",
+        }
+    ]
+    rooms = [
+        Room(
+            id="POM_0001",
+            name="Tokarnia",
+            hala="1",
+            polygon=[(0, 0), (300, 0), (300, 300), (0, 300)],
+        )
+    ]
+
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (list(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: list(rows))
+
+    root = tk.Tk()
+    try:
+        win = tk.Toplevel(root)
+        win.title("Użytkowanie maszyny — 27")
+        outer = ttk.Frame(win)
+        outer.pack(fill="both", expand=True)
+        status_box = ttk.LabelFrame(outer, text="Aktualny status")
+        status_box.pack(fill="x")
+        status = ttk.Label(
+            status_box,
+            text="Sprawna",
+            foreground="#16a34a",
+            font=("TkDefaultFont", 24, "bold"),
+        )
+        status.pack(anchor="w", padx=10, pady=8)
+        root.update()
+
+        location = status._wm_location_label
+        assert location is not None
+        assert str(location.cget("text")) == "Brak lokalizacji"
+        assert status.pack_info()["side"] == "left"
+        assert location.pack_info()["side"] == "right"
+        assert tkfont.Font(font=location.cget("font")).cget("size") == 22
+        assert str(location.cget("cursor")) == "hand2"
+        assert location.bind("<Button-1>")
+    finally:
+        root.destroy()
+
+
+def test_usage_status_frame_shows_existing_room_without_click_binding(monkeypatch):
+    tk = gui_maszyny.tk
+    ttk = gui_maszyny.ttk
+    rows = [
+        {
+            "id": "27",
+            "status": "ok",
+            "nr_hali": "1",
+            "x": 100,
+            "y": 100,
+            "lokalizacja": "Tokarnia",
+            "lokalizacja_id": "POM_0001",
+            "placement_status": "placed",
+        }
+    ]
+    rooms = [
+        Room(
+            id="POM_0001",
+            name="Tokarnia",
+            hala="1",
+            polygon=[(0, 0), (300, 0), (300, 300), (0, 300)],
+        )
+    ]
+
+    monkeypatch.setattr(usage_patch, "load_rooms", lambda: list(rooms))
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (list(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: list(rows))
+
+    root = tk.Tk()
+    try:
+        win = tk.Toplevel(root)
+        win.title("Użytkowanie maszyny — 27")
+        outer = ttk.Frame(win)
+        outer.pack(fill="both", expand=True)
+        status_box = ttk.LabelFrame(outer, text="Aktualny status")
+        status_box.pack(fill="x")
+        status = ttk.Label(
+            status_box,
+            text="Sprawna",
+            foreground="#16a34a",
+            font=("TkDefaultFont", 24, "bold"),
+        )
+        status.pack(anchor="w", padx=10, pady=8)
+        root.update()
+
+        location = status._wm_location_label
+        assert location is not None
+        assert str(location.cget("text")) == "Tokarnia"
+        assert str(location.cget("cursor")) in ("", "arrow")
+        assert not location.bind("<Button-1>")
+    finally:
+        root.destroy()

--- a/widok_hali/machine_usage_location_patch.py
+++ b/widok_hali/machine_usage_location_patch.py
@@ -1,0 +1,364 @@
+# version: 1.0
+"""Lokalizacja w nagłówku „Użytkowanie maszyny”.
+
+Dodatek jest celowo warstwowy: nie zmienia gui_maszyny_legacy.py. Rozszerza
+aktualny proxy ttk o prawą etykietę lokalizacji oraz udostępnia prosty wybór
+pomieszczenia po kliknięciu „Brak lokalizacji”.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import weakref
+from typing import Any, MutableMapping, Optional
+
+from .rooms import (
+    Room,
+    load_rooms,
+    normalize_hall_id,
+    point_in_polygon,
+    room_by_id,
+    room_by_name,
+    sync_location_fields,
+)
+
+_LOCATION_KEYS = ("lokalizacja", "lokalizacja_id", "placement_status")
+
+
+def _machine_id(row: MutableMapping[str, Any]) -> str:
+    return str(row.get("id") or row.get("nr_ewid") or row.get("nr") or "").strip()
+
+
+def _location_signature(row: MutableMapping[str, Any]) -> tuple[object, object, object]:
+    return tuple(row.get(key) for key in _LOCATION_KEYS)  # type: ignore[return-value]
+
+
+def _location_patch(row: MutableMapping[str, Any]) -> dict[str, Any]:
+    return {key: row.get(key) for key in _LOCATION_KEYS}
+
+
+def _patch_signature(patch: MutableMapping[str, Any]) -> tuple[object, object, object]:
+    return tuple(patch.get(key) for key in _LOCATION_KEYS)  # type: ignore[return-value]
+
+
+def _usage_machine_id(widget) -> str:
+    """Odczytaj ID z tytułu „Użytkowanie maszyny — ID”."""
+    try:
+        title = str(widget.winfo_toplevel().title() or "").strip()
+    except Exception:
+        return ""
+    if not title.lower().startswith("użytkowanie maszyny"):
+        return ""
+    tail = title[len("Użytkowanie maszyny") :].strip()
+    for separator in ("—", "–", "-"):
+        if tail.startswith(separator):
+            return tail[len(separator) :].strip()
+    return tail.strip()
+
+
+def _row_for_machine(rows, machine_id: str) -> Optional[dict[str, Any]]:
+    target = str(machine_id or "").strip()
+    for row in rows or []:
+        if isinstance(row, dict) and _machine_id(row) == target:
+            return row
+    return None
+
+
+def _display_location(row: Optional[MutableMapping[str, Any]], rooms: list[Room]) -> str:
+    if row is None:
+        return "Brak lokalizacji"
+    candidate = deepcopy(dict(row))
+    sync_location_fields(candidate, rooms)
+    value = str(candidate.get("lokalizacja") or "").strip()
+    if value and value.casefold() != "brak lokalizacji":
+        return value
+    return "Brak lokalizacji"
+
+
+def _rooms_for_machine(row: MutableMapping[str, Any], rooms: list[Room]) -> list[Room]:
+    hall = normalize_hall_id(row.get("nr_hali") or row.get("hala") or "1")
+    return [
+        room
+        for room in rooms
+        if room.active and normalize_hall_id(room.hala) == hall
+    ]
+
+
+def install_machine_usage_location(legacy_module) -> None:
+    """Dodaj lokalizację do widoku użytkowania maszyny dokładnie raz."""
+    if getattr(legacy_module, "_WM_USAGE_LOCATION_INSTALLED", False):
+        return
+
+    wrapped_ttk = legacy_module.ttk
+    real_ttk = getattr(wrapped_ttk, "_real", wrapped_ttk)
+    tk = legacy_module.tk
+    messagebox = legacy_module.messagebox
+    base_upsert = legacy_module.upsert_machine
+    base_renderer = legacy_module.MachineHallRenderer
+
+    # Po zapisie z okna Użytkowanie panel może nadal trzymać poprzednią kopię
+    # rows_cache. Override chroni świeżą lokalizację przed nadpisaniem przez
+    # późniejszy zapis statusu/serwisu z tej starej kopii.
+    overrides: dict[str, dict[str, Any]] = {}
+    renderers: "weakref.WeakSet[object]" = weakref.WeakSet()
+
+    def _load_rows_and_path() -> tuple[list[dict], str]:
+        cfg = legacy_module.get_config() or {}
+        rows, primary_path = legacy_module.load_machines_rows_with_fallback(
+            cfg, legacy_module.resolve_rel
+        )
+        if not rows:
+            rows = list(legacy_module.load_machines_rows() or [])
+        return list(rows or []), str(primary_path or "")
+
+    def _current_row(machine_id: str) -> Optional[dict[str, Any]]:
+        rows, _path = _load_rows_and_path()
+        return _row_for_machine(rows, machine_id)
+
+    def _current_display(machine_id: str) -> str:
+        return _display_location(_current_row(machine_id), load_rooms())
+
+    def _refresh_live_renderers(rows: list[dict]) -> None:
+        for renderer in list(renderers):
+            try:
+                renderer.update_rows(deepcopy(rows))
+            except Exception:
+                pass
+
+    def _assign_machine_to_room(machine_id: str, room_name: str) -> dict[str, Any]:
+        rows, primary_path = _load_rows_and_path()
+        existing = _row_for_machine(rows, machine_id)
+        if existing is None:
+            raise ValueError(f"Nie znaleziono maszyny {machine_id}.")
+
+        rooms = load_rooms()
+        candidates = _rooms_for_machine(existing, rooms)
+        room = room_by_name(candidates, room_name)
+        if room is None:
+            raise ValueError(f'Nie znaleziono pomieszczenia „{room_name}” dla tej hali.')
+
+        before = _location_signature(existing)
+        candidate = deepcopy(existing)
+        candidate["lokalizacja"] = room.name
+        candidate["lokalizacja_id"] = room.id
+
+        # base_upsert zawiera już wdrożoną logikę relokacji do wolnego punktu
+        # wewnątrz wybranego pomieszczenia.
+        new_rows = base_upsert(rows, candidate)
+        changed = _row_for_machine(new_rows, machine_id)
+        if changed is None:
+            raise ValueError(f"Nie udało się zaktualizować maszyny {machine_id}.")
+
+        if not legacy_module._save_machines(primary_path, new_rows):
+            raise OSError("Nie udało się zapisać lokalizacji maszyny.")
+
+        after = _location_patch(changed)
+        overrides[str(machine_id)] = {
+            "before": before,
+            "after": dict(after),
+        }
+        _refresh_live_renderers(list(new_rows))
+        return deepcopy(changed)
+
+    def upsert_with_usage_location_guard(rows, new_row):
+        candidate = dict(new_row or {})
+        mid = _machine_id(candidate)
+        guard = overrides.get(mid)
+        if guard:
+            incoming = _location_signature(candidate)
+            before = tuple(guard.get("before") or ())
+            after_patch = dict(guard.get("after") or {})
+            after = _patch_signature(after_patch)
+            if incoming == before:
+                # Stary rows_cache zapisuje np. nowy status – dokładamy świeżą
+                # lokalizację zamiast pozwolić mu ją cofnąć.
+                candidate.update(after_patch)
+            elif incoming == after:
+                # Panel dogonił już zapis na dysku; strażnik nie jest potrzebny.
+                overrides.pop(mid, None)
+            else:
+                # Użytkownik jawnie wybrał inną lokalizację w formularzu.
+                overrides.pop(mid, None)
+        return base_upsert(rows, candidate)
+
+    def _ask_room(parent, machine_id: str, on_saved) -> None:
+        row = _current_row(machine_id)
+        if row is None:
+            messagebox.showerror(
+                "Lokalizacja maszyny",
+                f"Nie znaleziono maszyny {machine_id}.",
+                parent=parent,
+            )
+            return
+        rooms = _rooms_for_machine(row, load_rooms())
+        if not rooms:
+            messagebox.showinfo(
+                "Lokalizacja maszyny",
+                "Dla tej hali nie ma jeszcze narysowanych pomieszczeń.",
+                parent=parent,
+            )
+            return
+
+        win = tk.Toplevel(parent)
+        win.title(f"Przypisz lokalizację — {machine_id}")
+        win.transient(parent)
+        win.resizable(False, False)
+        try:
+            win.grab_set()
+        except Exception:
+            pass
+
+        body = real_ttk.Frame(win, padding=14)
+        body.pack(fill="both", expand=True)
+        real_ttk.Label(
+            body,
+            text="Wybierz pomieszczenie dla maszyny:",
+        ).pack(anchor="w", pady=(0, 6))
+        names = [room.name for room in rooms]
+        combo = real_ttk.Combobox(body, values=tuple(names), state="readonly", width=34)
+        combo.pack(fill="x")
+        combo.set(names[0])
+
+        buttons = real_ttk.Frame(body)
+        buttons.pack(fill="x", pady=(12, 0))
+
+        def save_choice() -> None:
+            selected = str(combo.get() or "").strip()
+            if not selected:
+                return
+            try:
+                changed = _assign_machine_to_room(machine_id, selected)
+            except Exception as exc:
+                messagebox.showerror(
+                    "Lokalizacja maszyny",
+                    f"Nie udało się zapisać lokalizacji:\n{exc}",
+                    parent=win,
+                )
+                return
+            try:
+                on_saved(str(changed.get("lokalizacja") or selected))
+            finally:
+                win.destroy()
+
+        real_ttk.Button(buttons, text="Anuluj", command=win.destroy).pack(side="right")
+        real_ttk.Button(buttons, text="Zapisz", command=save_choice).pack(
+            side="right", padx=(0, 6)
+        )
+        try:
+            combo.focus_set()
+        except Exception:
+            pass
+
+    class UsageStatusLabel(real_ttk.Label):
+        """Status po lewej + lokalizacja 2 pkt mniejsza po prawej."""
+
+        def __init__(self, master=None, *args, machine_id: str = "", **kwargs):
+            self._wm_machine_id = machine_id
+            self._wm_location_label = None
+            self._wm_location_installed = False
+            super().__init__(master, *args, **kwargs)
+
+        def pack(self, cnf=None, **kwargs):
+            options = dict(cnf or {})
+            options.update(kwargs)
+            options.pop("side", None)
+            result = super().pack(side="left", **options)
+            if not self._wm_location_installed:
+                self._wm_location_installed = True
+                try:
+                    self.after_idle(self._wm_install_location)
+                except Exception:
+                    self._wm_install_location()
+            return result
+
+        def _wm_install_location(self) -> None:
+            if self._wm_location_label is not None:
+                return
+            location = _current_display(self._wm_machine_id)
+            label = real_ttk.Label(
+                self.master,
+                text=location,
+                font=("TkDefaultFont", 22, "bold"),
+                anchor="e",
+                justify="right",
+            )
+            label.pack(side="right", anchor="e", padx=10, pady=8)
+            self._wm_location_label = label
+            self._wm_configure_location_click()
+
+        def _wm_configure_location_click(self) -> None:
+            label = self._wm_location_label
+            if label is None:
+                return
+            try:
+                label.unbind("<Button-1>")
+            except Exception:
+                pass
+            if str(label.cget("text") or "").strip().casefold() != "brak lokalizacji":
+                try:
+                    label.configure(cursor="")
+                except Exception:
+                    pass
+                return
+            try:
+                label.configure(cursor="hand2")
+            except Exception:
+                pass
+
+            def clicked(_event=None):
+                top = self.winfo_toplevel()
+
+                def saved(value: str) -> None:
+                    label.configure(text=value, cursor="")
+                    self._wm_configure_location_click()
+
+                _ask_room(top, self._wm_machine_id, saved)
+
+            label.bind("<Button-1>", clicked)
+
+    class UsageLocationTtkProxy:
+        def __init__(self):
+            self._wrapped = wrapped_ttk
+            self._real = real_ttk
+
+        def __getattr__(self, name: str):
+            return getattr(self._wrapped, name)
+
+        def LabelFrame(self, master=None, *args, **kwargs):  # noqa: N802
+            frame = self._wrapped.LabelFrame(master, *args, **kwargs)
+            if str(kwargs.get("text") or "") == "Aktualny status":
+                mid = _usage_machine_id(frame)
+                if mid:
+                    setattr(frame, "_wm_usage_machine_id", mid)
+            return frame
+
+        def Label(self, master=None, *args, **kwargs):  # noqa: N802
+            mid = str(getattr(master, "_wm_usage_machine_id", "") or "").strip()
+            if mid:
+                return UsageStatusLabel(master, *args, machine_id=mid, **kwargs)
+            return self._wrapped.Label(master, *args, **kwargs)
+
+    class UsageLocationRenderer(base_renderer):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            try:
+                renderers.add(self)
+            except Exception:
+                pass
+
+    UsageLocationRenderer.__name__ = "MachineHallRenderer"
+    UsageLocationRenderer.__qualname__ = "MachineHallRenderer"
+
+    legacy_module.upsert_machine = upsert_with_usage_location_guard
+    legacy_module.ttk = UsageLocationTtkProxy()
+    legacy_module.MachineHallRenderer = UsageLocationRenderer
+    legacy_module._wm_assign_machine_to_room = _assign_machine_to_room
+    legacy_module._WM_USAGE_LOCATION_OVERRIDES = overrides
+    legacy_module._WM_USAGE_LOCATION_INSTALLED = True
+
+
+__all__ = [
+    "_display_location",
+    "_location_signature",
+    "_usage_machine_id",
+    "install_machine_usage_location",
+]


### PR DESCRIPTION
Drobna warstwowa poprawka widoku Użytkowanie maszyny:
- lokalizacja jest pokazana po prawej stronie ramki Aktualny status,
- status pozostaje 24 pt, lokalizacja ma 22 pt bold i zwykły kolor tekstu,
- gdy brak przypisania, widoczny jest klikalny tekst Brak lokalizacji,
- kliknięcie otwiera listę pomieszczeń z bieżącej hali i zapisuje wybrane pomieszczenie,
- używany jest istniejący mechanizm relokacji, więc przy przypisaniu marker trafia do wolnego punktu wewnątrz pomieszczenia,
- dodatkowy guard chroni nową lokalizację przed nadpisaniem przez stary rows_cache po późniejszej zmianie statusu/serwisu,
- gui_maszyny_legacy.py pozostaje nietknięty.

Dodane testy zapisu, relokacji, ochrony przed stale-cache oraz headless Tk dla układu status po lewej / lokalizacja po prawej.