### PR TITLE
Maszyny: komunikat drag i Brak lokalizacji poza pomieszczeniem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
             widok_hali/machine_rooms_persistence.py \
             widok_hali/machine_rooms_ui_patch.py \
             widok_hali/machine_rooms_editor_patch.py \
-            widok_hali/machine_usage_location_patch.py
+            widok_hali/machine_usage_location_patch.py \
+            widok_hali/machine_drag_location_feedback.py
       - name: Run hall and machine integration tests
         run: |
           pytest -q \
@@ -46,7 +47,8 @@ jobs:
         run: |
           xvfb-run -a pytest -q \
             tests/test_gui_maszyny_rooms_tk_smoke.py \
-            tests/test_gui_maszyny_usage_location_tk.py
+            tests/test_gui_maszyny_usage_location_tk.py \
+            tests/test_gui_maszyny_drag_location_feedback_tk.py
   static-checks:
     runs-on: ubuntu-latest
     steps:

--- a/gui_maszyny.py
+++ b/gui_maszyny.py
@@ -1,4 +1,4 @@
-# version: 2.2
+# version: 2.3
 """Bezpieczny punkt wejścia modułu Maszyny z warstwowym rozszerzeniem hali.
 
 Oryginalna, działająca implementacja Maszyn pozostaje bez zmian w
@@ -24,12 +24,16 @@ from widok_hali.machine_rooms_editor_patch import (
 from widok_hali.machine_usage_location_patch import (
     install_machine_usage_location as _install_machine_usage_location,
 )
+from widok_hali.machine_drag_location_feedback import (
+    install_machine_drag_location_feedback as _install_machine_drag_location_feedback,
+)
 
 _install_machine_rooms(_legacy)
 _install_machine_room_persistence(_legacy)
 _install_machine_room_ui(_legacy)
 _install_machine_room_editor(_legacy)
 _install_machine_usage_location(_legacy)
+_install_machine_drag_location_feedback(_legacy)
 
 # Kluczowe dla zgodności: użytkownik ``import gui_maszyny`` dostaje dokładnie
 # moduł z dotychczasową implementacją, a nie proxy z kopiami jego symboli.

--- a/tests/test_gui_maszyny_drag_location_feedback_tk.py
+++ b/tests/test_gui_maszyny_drag_location_feedback_tk.py
@@ -1,0 +1,88 @@
+# version: 1.0
+"""Tk smoke dla informacji o lokalizacji po drag&drop maszyny."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import gui_maszyny
+from widok_hali.rooms import Room
+
+
+@pytest.mark.skipif(gui_maszyny.Image is None, reason="Pillow wymagany do smoke tła")
+def test_drag_shows_room_message_and_outside_sets_no_location(tmp_path):
+    tk = gui_maszyny.tk
+    ttk = gui_maszyny.ttk
+
+    background = tmp_path / "hala_drag_feedback.png"
+    gui_maszyny.Image.new("RGB", (1000, 500), "white").save(background)
+
+    root = tk.Tk()
+    try:
+        root._wm_role = "brygadzista"
+        root.geometry("1200x800")
+        frame = ttk.Frame(root)
+        frame.pack(fill="both", expand=True)
+        root.update_idletasks()
+
+        row = {
+            "id": "M-TEST",
+            "nazwa": "Tokarka",
+            "status": "ok",
+            "nr_hali": "1",
+            "x": 100,
+            "y": 100,
+            "lokalizacja": "Tokarnia",
+            "lokalizacja_id": "POM_0001",
+            "placement_status": "placed",
+        }
+        commits = []
+        renderer = gui_maszyny.MachineHallRenderer(
+            frame,
+            [row],
+            cfg={},
+            bg_path=str(background),
+            on_drag_commit=lambda mid, x, y: commits.append((mid, x, y)),
+        )
+        renderer._rooms = [
+            Room(
+                id="POM_0001",
+                name="Tokarnia",
+                hala="1",
+                polygon=[(0, 0), (400, 0), (400, 400), (0, 400)],
+            ),
+            Room(
+                id="POM_0002",
+                name="Spawalnia",
+                hala="1",
+                polygon=[(500, 0), (900, 0), (900, 400), (500, 400)],
+            ),
+        ]
+        renderer.render()
+        root.update()
+
+        start_x, start_y = renderer._map_bg_to_canvas(100, 100)
+        room_x, room_y = renderer._map_bg_to_canvas(700, 100)
+        renderer._on_press(SimpleNamespace(x=start_x, y=start_y))
+        renderer._on_motion(SimpleNamespace(x=room_x, y=room_y))
+        renderer._on_release(SimpleNamespace(x=room_x, y=room_y))
+        root.update_idletasks()
+
+        assert row["lokalizacja"] == "Spawalnia"
+        assert row["lokalizacja_id"] == "POM_0002"
+        assert row["placement_status"] == "placed"
+        assert renderer._status_var.get() == "Maszyna M-TEST → Spawalnia"
+
+        outside_x, outside_y = renderer._map_bg_to_canvas(950, 450)
+        renderer._on_press(SimpleNamespace(x=room_x, y=room_y))
+        renderer._on_motion(SimpleNamespace(x=outside_x, y=outside_y))
+        renderer._on_release(SimpleNamespace(x=outside_x, y=outside_y))
+        root.update_idletasks()
+
+        assert len(commits) == 2
+        assert row["lokalizacja"] == ""
+        assert row["lokalizacja_id"] == ""
+        assert row["placement_status"] == "unplaced"
+        assert renderer._status_var.get() == "Maszyna M-TEST → Brak lokalizacji"
+    finally:
+        root.destroy()

--- a/tests/test_gui_maszyny_usage_location.py
+++ b/tests/test_gui_maszyny_usage_location.py
@@ -1,4 +1,4 @@
-# version: 1.1
+# version: 1.2
 from copy import deepcopy
 
 import gui_maszyny
@@ -33,6 +33,7 @@ def _patch_rooms(monkeypatch, rooms):
 
 def test_usage_location_extension_is_installed():
     assert gui_maszyny._WM_USAGE_LOCATION_INSTALLED is True
+    assert gui_maszyny._WM_DRAG_LOCATION_FEEDBACK_INSTALLED is True
     assert callable(gui_maszyny._wm_assign_machine_to_room)
 
 
@@ -155,3 +156,53 @@ def test_explicit_later_room_change_is_not_blocked(monkeypatch):
     assert changed["lokalizacja_id"] == "POM_0002"
     assert changed["placement_status"] == "placed"
     assert point_in_polygon(changed["x"], changed["y"], rooms[1].polygon)
+
+
+def test_explicit_drag_outside_clears_quick_assignment_guard(monkeypatch):
+    rooms = _rooms()
+    original = {
+        "id": "M-27",
+        "nazwa": "Tokarka",
+        "status": "ok",
+        "nr_hali": "1",
+        "x": 700,
+        "y": 700,
+        "lokalizacja": "",
+        "lokalizacja_id": "",
+        "placement_status": "unplaced",
+    }
+    rows = [deepcopy(original)]
+
+    _patch_rooms(monkeypatch, rooms)
+    monkeypatch.setattr(gui_maszyny, "get_config", lambda: {})
+    monkeypatch.setattr(
+        gui_maszyny,
+        "load_machines_rows_with_fallback",
+        lambda cfg, resolve_rel: (deepcopy(rows), "/tmp/maszyny.json"),
+    )
+    monkeypatch.setattr(gui_maszyny, "load_machines_rows", lambda: deepcopy(rows))
+    monkeypatch.setattr(gui_maszyny, "_save_machines", lambda path, new_rows: True)
+
+    assigned = gui_maszyny._wm_assign_machine_to_room("M-27", "Tokarnia")
+    assert assigned["lokalizacja_id"] == "POM_0001"
+    assert "M-27" in gui_maszyny._WM_USAGE_LOCATION_OVERRIDES
+
+    pending = gui_maszyny._WM_ROOM_LOCATION_PATCHES
+    pending["M-27"] = {
+        "lokalizacja": "",
+        "lokalizacja_id": "",
+        "placement_status": "unplaced",
+    }
+    try:
+        dragged = deepcopy(assigned)
+        dragged["x"] = 700
+        dragged["y"] = 700
+        changed_rows = gui_maszyny.upsert_machine([assigned], dragged)
+    finally:
+        pending.pop("M-27", None)
+
+    changed = changed_rows[0]
+    assert changed["lokalizacja"] == ""
+    assert changed["lokalizacja_id"] == ""
+    assert changed["placement_status"] == "unplaced"
+    assert "M-27" not in gui_maszyny._WM_USAGE_LOCATION_OVERRIDES

--- a/tests/test_hall_rooms.py
+++ b/tests/test_hall_rooms.py
@@ -1,4 +1,4 @@
-# version: 1.0
+# version: 1.1
 from pathlib import Path
 
 from widok_hali.rooms import (
@@ -104,7 +104,7 @@ def test_drag_between_rooms_updates_location_and_keeps_exact_xy():
     assert (row["x"], row["y"]) == (150, 60)
 
 
-def test_drag_outside_rooms_does_not_destroy_assignment():
+def test_drag_outside_rooms_clears_assignment():
     row = {
         "id": "42",
         "lokalizacja": "Tokarnia",
@@ -116,9 +116,9 @@ def test_drag_outside_rooms_does_not_destroy_assignment():
 
     sync_record_from_point(row, 250, 150, _rooms())
 
-    assert row["lokalizacja_id"] == "POM_0001"
-    assert row["lokalizacja"] == "Tokarnia"
-    assert row["placement_status"] == "outside_room"
+    assert row["lokalizacja_id"] == ""
+    assert row["lokalizacja"] == ""
+    assert row["placement_status"] == "unplaced"
     assert (row["x"], row["y"]) == (250, 150)
 
 

--- a/widok_hali/machine_drag_location_feedback.py
+++ b/widok_hali/machine_drag_location_feedback.py
@@ -1,0 +1,99 @@
+# version: 1.0
+"""Informacja o lokalizacji po drag&drop maszyny na planie hali.
+
+Warstwa jest instalowana jako ostatnia, po adapterach pomieszczeń i widoku
+Użytkowanie maszyny. Nie zmienia bazowego modułu Maszyn: dodaje tylko komunikat
+w istniejącym pasku statusu hali i rozstrzyga konflikt pomiędzy jawnym dragiem
+a ochroną przed starym ``rows_cache``.
+"""
+from __future__ import annotations
+
+from typing import Any, MutableMapping, Optional
+
+
+def _machine_id(row: MutableMapping[str, Any]) -> str:
+    return str(row.get("id") or row.get("nr_ewid") or row.get("nr") or "").strip()
+
+
+def _row_for_machine(rows, machine_id: str) -> Optional[MutableMapping[str, Any]]:
+    target = str(machine_id or "").strip()
+    for row in rows or []:
+        if isinstance(row, dict) and _machine_id(row) == target:
+            return row
+    return None
+
+
+def _display_location(row: Optional[MutableMapping[str, Any]]) -> str:
+    if row is None:
+        return "Brak lokalizacji"
+    value = str(row.get("lokalizacja") or "").strip()
+    if not value or value.casefold() == "brak lokalizacji":
+        return "Brak lokalizacji"
+    return value
+
+
+def install_machine_drag_location_feedback(legacy_module) -> None:
+    """Dodaj symetryczne przypisanie/odpinanie lokalizacji i komunikat po dropie."""
+    if getattr(legacy_module, "_WM_DRAG_LOCATION_FEEDBACK_INSTALLED", False):
+        return
+
+    base_upsert = legacy_module.upsert_machine
+    base_renderer = legacy_module.MachineHallRenderer
+
+    def upsert_with_explicit_drag_priority(rows, new_row):
+        """Jawny drag ma pierwszeństwo przed strażnikiem starego rows_cache.
+
+        Warstwa persistence ustawia wpis w ``_WM_ROOM_LOCATION_PATCHES`` tuż
+        przed wywołaniem callbacka zapisu. To jednoznacznie oznacza, że zmiana
+        lokalizacji pochodzi z aktualnego drag&drop, a nie ze starej kopii
+        rekordu. W takim przypadku usuwamy historyczny override z okna
+        Użytkowanie i pozwalamy persistence wstrzyknąć świeży patch.
+        """
+        candidate = dict(new_row or {})
+        mid = _machine_id(candidate)
+        pending = getattr(legacy_module, "_WM_ROOM_LOCATION_PATCHES", {})
+        if mid and isinstance(pending, dict) and mid in pending:
+            overrides = getattr(legacy_module, "_WM_USAGE_LOCATION_OVERRIDES", {})
+            if isinstance(overrides, dict):
+                overrides.pop(mid, None)
+        return base_upsert(rows, candidate)
+
+    class DragLocationFeedbackRenderer(base_renderer):
+        def _on_release(self, event):
+            layout_edit = bool(getattr(self, "_layout_edit", False))
+            drag_active = bool(getattr(self, "_drag_active", False))
+            mid = str(getattr(self, "_drag_id", "") or "").strip()
+            is_machine_drop = bool(mid and drag_active and not layout_edit)
+            before_row = _row_for_machine(getattr(self, "rows", []), mid)
+            before_location = _display_location(before_row)
+
+            result = super()._on_release(event)
+
+            if not is_machine_drop:
+                return result
+
+            after_row = _row_for_machine(getattr(self, "rows", []), mid)
+            after_location = _display_location(after_row)
+            status_var = getattr(self, "_status_var", None)
+            if status_var is not None:
+                try:
+                    if before_location != after_location:
+                        status_var.set(f"Maszyna {mid} → {after_location}")
+                    else:
+                        status_var.set(f"Maszyna {mid}: {after_location}")
+                except Exception:
+                    pass
+            return result
+
+    DragLocationFeedbackRenderer.__name__ = "MachineHallRenderer"
+    DragLocationFeedbackRenderer.__qualname__ = "MachineHallRenderer"
+
+    legacy_module.upsert_machine = upsert_with_explicit_drag_priority
+    legacy_module.MachineHallRenderer = DragLocationFeedbackRenderer
+    legacy_module._WM_DRAG_LOCATION_FEEDBACK_INSTALLED = True
+
+
+__all__ = [
+    "_display_location",
+    "install_machine_drag_location_feedback",
+]

--- a/widok_hali/rooms.py
+++ b/widok_hali/rooms.py
@@ -1,4 +1,4 @@
-# version: 1.0
+# version: 1.1
 """Pomieszczenia i lokalizacje dla widoku hali WM.
 
 Geometria jest zapisywana w układzie współrzędnych tła planu (piksele obrazu),
@@ -363,16 +363,18 @@ def sync_record_from_point(
 ) -> MutableMapping[str, Any]:
     """Synchronizuj pozycję po drag&drop z pomieszczeniem pod punktem.
 
-    Gdy punkt wypada poza każdym pomieszczeniem, nie kasujemy istniejącego
-    przypisania. Oznaczamy rekord jako ``outside_room`` – użytkownik może
-    poprawić położenie bez utraty informacji o dotychczasowej lokalizacji.
+    Drag&drop jest źródłem prawdy dla położenia na planie: punkt wewnątrz
+    pomieszczenia przypisuje je do maszyny, a punkt poza wszystkimi
+    pomieszczeniami czyści przypisanie i oznacza maszynę jako nieumieszczoną.
     """
     px, py = _as_int(x), _as_int(y)
     record["x"], record["y"] = px, py
     hall = record.get("nr_hali") or record.get("hala") or "1"
     room = room_at_point(rooms, px, py, hala=hall)
     if room is None:
-        record["placement_status"] = "outside_room"
+        record["lokalizacja_id"] = ""
+        record["lokalizacja"] = ""
+        record["placement_status"] = "unplaced"
         return record
     record["lokalizacja_id"] = room.id
     record["lokalizacja"] = room.name


### PR DESCRIPTION
Drobna poprawka zachowania lokalizacji na planie hali:
- przeciągnięcie maszyny do pomieszczenia zapisuje lokalizację jak dotychczas,
- po dropie pasek statusu pokazuje np. `Maszyna 27 → Tokarnia`,
- przeciągnięcie poza wszystkie pomieszczenia czyści `lokalizacja` i `lokalizacja_id` oraz ustawia `placement_status=unplaced`,
- pasek pokazuje wtedy `Maszyna 27 → Brak lokalizacji`,
- jawny drag ma pierwszeństwo przed ochroną starego `rows_cache`, więc wcześniejsze szybkie przypisanie z okna Użytkowanie nie blokuje późniejszego odpięcia,
- gui_maszyny_legacy.py pozostaje nietknięty.

Dodane testy geometrii, konfliktu ze stale-cache oraz headless Tk dla sekwencji pomieszczenie → inne pomieszczenie → poza pomieszczeniami.