### PR TITLE
Profile: jedno źródło ustawień i prawdziwa edycja własnych danych

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
             tests/test_gui_maszyny_rooms_tk_smoke.py \
             tests/test_gui_maszyny_usage_location_tk.py \
             tests/test_gui_maszyny_drag_location_feedback_tk.py \
-            tests/test_profile_settings_runtime_tk.py
+            tests/test_profile_settings_runtime_tk.py \
+            tests/test_profile_admin_foreman_tk.py
   static-checks:
     runs-on: ubuntu-latest
     steps:

--- a/gui_profile.py
+++ b/gui_profile.py
@@ -1,5 +1,5 @@
-# version: 1.9.3
-"""Aktywny Profil WM z Kalendarzem dla każdego i panelem Brygadzisty."""
+# version: 1.9.4
+"""Aktywny Profil WM z Kalendarzem i panelem Brygadzisty."""
 from __future__ import annotations
 
 try:
@@ -29,7 +29,18 @@ except Exception as _foreman_shift_runtime_exc:
         f"{_foreman_shift_runtime_exc}"
     )
 
+try:
+    from profile_admin_foreman_runtime import install as _install_profile_admin_foreman_runtime
+
+    _install_profile_admin_foreman_runtime()
+except Exception as _profile_admin_runtime_exc:
+    print(
+        "[WM-DBG][PROFILE][WARN] unified admin runtime install failed: "
+        f"{_profile_admin_runtime_exc}"
+    )
+
 import gui_profile_core as _core
+from profile_settings_fields import normalize_editable_fields
 
 # Zachowaj zgodność z kodem i testami importującymi także pomocnicze nazwy
 # bezpośrednio z gui_profile.py.
@@ -50,7 +61,7 @@ _BaseProfileView = _core.ProfileView
 
 
 class ProfileView(_BaseProfileView):
-    """Profil użytkownika z kalendarzem oraz panelem brygadzisty."""
+    """Profil użytkownika z jedną konfiguracją pól i administracji."""
 
     def _logged_user_is_brygadzista(self) -> bool:
         """Uprawnienie wynika z roli zalogowanej osoby, nie oglądanego profilu."""
@@ -67,30 +78,117 @@ class ProfileView(_BaseProfileView):
                 active_user.get("rola") or active_user.get("role") or ""
             ).strip().lower()
             return role == "brygadzista"
-        # Zachowaj działanie podglądu/testów bez aktywnej sesji.
         return self._is_brygadzista()
 
+    @staticmethod
+    def _cfg_bool(key: str, fallback_key: str, default: bool) -> bool:
+        try:
+            cfg = ConfigManager()
+            value = cfg.get(key, None)
+            if value is None:
+                value = cfg.get(fallback_key, default)
+            return bool(value)
+        except Exception:
+            return default
+
+    def _profile_card_enabled(self) -> bool:
+        return self._cfg_bool(
+            "profiles.ui.enable_profile_card",
+            "ui.profile.enabled",
+            True,
+        )
+
+    def _show_name_in_header(self) -> bool:
+        return self._cfg_bool(
+            "profiles.ui.show_name_in_header",
+            "ui.profile.show_name_header",
+            True,
+        )
+
+    def _avatar_enabled(self) -> bool:
+        return self._cfg_bool(
+            "profiles.avatar.enabled",
+            "ui.profile.avatar_enabled",
+            False,
+        )
+
+    def _build_header(self, parent) -> None:
+        """Nagłówek aktywnego ProfileView respektujący ustawienie imienia."""
+        wrap = ttk.Frame(parent, style="WM.Card.TFrame", padding=12)
+        wrap.pack(fill="x")
+        user = get_user(self.login) or {}
+        display = (
+            user.get("display_name")
+            or self.display_name
+            or " ".join(
+                part
+                for part in (
+                    str(user.get("imie") or "").strip(),
+                    str(user.get("nazwisko") or "").strip(),
+                )
+                if part
+            )
+            or self.login
+            or "—"
+        )
+        role = user.get("rola") or self.rola or "—"
+        login_label = f"@{self.login}" if self.login else "@—"
+
+        if self._show_name_in_header():
+            ttk.Label(wrap, text=str(display), style="WM.H1.TLabel").pack(anchor="w")
+            ttk.Label(wrap, text=login_label, style="WM.Muted.TLabel").pack(
+                anchor="w", pady=(2, 0)
+            )
+        else:
+            ttk.Label(wrap, text=str(self.login or "—"), style="WM.H1.TLabel").pack(anchor="w")
+        ttk.Label(wrap, text=f"Rola: {role}", style="WM.Muted.TLabel").pack(
+            anchor="w", pady=(2, 0)
+        )
+
+    def _make_avatar(self, parent):
+        """Wyłączony avatar daje placeholder zamiast ignorowania ustawienia."""
+        if not self._avatar_enabled():
+            return self._avatar_placeholder(parent)
+        return super()._make_avatar(parent)
+
+    def _user_editable_fields(self) -> tuple[list[str], bool, int]:
+        """Czytaj dokładnie pola wybrane w Ustawienia → Profile."""
+        cfg = ConfigManager()
+        raw_fields = cfg.get("profiles.editable_fields", None)
+        if raw_fields is None:
+            raw_fields = cfg.get(
+                "profiles.fields_editable_by_user",
+                ["telefon", "email"],
+            )
+        fields = normalize_editable_fields(raw_fields)
+        allow_pin = bool(
+            cfg.get(
+                "profiles.pin.change_allowed",
+                cfg.get("profiles.allow_pin_change", False),
+            )
+        )
+        pin_cfg = cfg.get("profiles.pin", {}) or {}
+        pin_min_length = max(1, int(pin_cfg.get("min_length", 4) or 4))
+        return fields, allow_pin, pin_min_length
+
     def _open_edit_profile(self) -> None:
-        """Brygadzista przechodzi do Ustawienia → Profile.
+        """Edycja własnego profilu działa tak samo również dla brygadzisty."""
+        return super()._open_edit_profile()
 
-        Zwykły użytkownik zachowuje dotychczasowe, ograniczone okno edycji
-        własnych danych. Dzięki temu skrót nie rozszerza nikomu uprawnień do
-        administracyjnych Ustawień.
-        """
+    def _open_profile_settings(self) -> None:
+        """Osobny skrót brygadzisty do Ustawienia → Profile."""
         if not self._logged_user_is_brygadzista():
-            return super()._open_edit_profile()
-
+            return
         try:
             root = self.winfo_toplevel()
             container = self.master
-            active_login = str(ProfileService.ensure_active_user_or_none() or self.login or "").strip()
+            active_login = str(
+                ProfileService.ensure_active_user_or_none() or self.login or ""
+            ).strip()
             active_user = get_user(active_login) or {}
             active_role = str(
                 active_user.get("rola") or active_user.get("role") or "brygadzista"
             ).strip() or "brygadzista"
-
-            # settings_users_runtime odczyta ten cel po zbudowaniu panelu i
-            # wybierze dokładnie podzakładkę Profile.
             setattr(root, "_wm_settings_target_tab", "Profile")
             from ustawienia_systemu import panel_ustawien
 
@@ -100,7 +198,6 @@ class ProfileView(_BaseProfileView):
                 login=active_login,
                 rola=active_role,
             )
-            return
         except Exception as exc:
             try:
                 root = self.winfo_toplevel()
@@ -114,8 +211,29 @@ class ProfileView(_BaseProfileView):
                 )
             except Exception:
                 pass
-            # Awaryjnie zostawiamy stare, bezpieczne okno edycji profilu.
-            return super()._open_edit_profile()
+
+    def _render_simple_profile(self, parent) -> None:
+        """Dane użytkownika + osobna administracja tylko dla brygadzisty."""
+        super()._render_simple_profile(parent)
+        if self._logged_user_is_brygadzista():
+            admin = ttk.LabelFrame(
+                parent,
+                text="Administracja profili",
+                style="WM.Section.TLabelframe",
+                padding=10,
+            )
+            admin.pack(fill="x", pady=(0, 10))
+            ttk.Label(
+                admin,
+                text="Ustawienia pól, kont i rang są zarządzane w jednym miejscu.",
+                style="WM.Muted.TLabel",
+            ).pack(side="left")
+            ttk.Button(
+                admin,
+                text="Ustawienia profili",
+                command=self._open_profile_settings,
+                style="WM.Button.TButton",
+            ).pack(side="right")
 
     def _render_profile_body(self, parent) -> None:
         """Pokaż Profil + Kalendarz oraz opcjonalnie Brygadzistę."""
@@ -136,7 +254,29 @@ class ProfileView(_BaseProfileView):
         calendar_tab = ttk.Frame(notebook, style="WM.Container.TFrame")
         notebook.add(profile_tab, text="Profil")
         notebook.add(calendar_tab, text="Kalendarz")
-        self._render_simple_profile(profile_tab)
+
+        if self._profile_card_enabled():
+            self._render_simple_profile(profile_tab)
+        else:
+            box = ttk.LabelFrame(
+                profile_tab,
+                text="Profil",
+                style="WM.Section.TLabelframe",
+                padding=12,
+            )
+            box.pack(fill="x", padx=12, pady=12)
+            ttk.Label(
+                box,
+                text="Karta Profil jest wyłączona w Ustawienia → Profile.",
+                style="WM.Muted.TLabel",
+            ).pack(side="left")
+            if self._logged_user_is_brygadzista():
+                ttk.Button(
+                    box,
+                    text="Ustawienia profili",
+                    command=self._open_profile_settings,
+                    style="WM.Button.TButton",
+                ).pack(side="right")
 
         foreman_tab = None
         is_foreman = self._logged_user_is_brygadzista()

--- a/profile_admin_foreman_runtime.py
+++ b/profile_admin_foreman_runtime.py
@@ -1,0 +1,46 @@
+# version: 1.0
+"""Ujednolica Brygadzista → Profile z Ustawienia → Użytkownicy."""
+from __future__ import annotations
+
+from profile_admin_ui import ProfileAdminNotebook
+
+_INSTALLED = False
+
+
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    import gui_profile_foreman as foreman
+
+    cls = foreman.ForemanProfilePanel
+    if getattr(cls, "_wm_profile_admin_unified", False):
+        _INSTALLED = True
+        return
+
+    original_build = cls._build
+
+    def _build(self, *args, **kwargs):
+        result = original_build(self, *args, **kwargs)
+        profile_tab = getattr(self, "_tabs", {}).get("Profile")
+        if profile_tab is None:
+            return result
+
+        for child in list(profile_tab.winfo_children()):
+            try:
+                child.destroy()
+            except Exception:
+                pass
+
+        admin = ProfileAdminNotebook(profile_tab)
+        admin.pack(fill="both", expand=True)
+        self._wm_profile_admin = admin
+        return result
+
+    cls._build = _build
+    cls._wm_profile_admin_unified = True
+    _INSTALLED = True
+
+
+__all__ = ["install"]

--- a/profile_admin_ui.py
+++ b/profile_admin_ui.py
@@ -1,0 +1,461 @@
+# version: 1.0
+"""Wspólny interfejs administracji profilami dla Ustawień i panelu brygadzisty."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Any
+
+from config_manager import ConfigManager
+from profile_settings_fields import EDITABLE_PROFILE_FIELDS, editable_fields_csv, normalize_editable_fields
+from services.profile_service import ProfileService
+from wm_access import get_role_modules, normalize_module_name, normalize_role_name, set_role_modules
+
+
+def _legacy_profiles_module():
+    import ustawienia_uzytkownicy as legacy
+
+    return legacy
+
+
+def _invalidate_profile_cache() -> None:
+    try:
+        ProfileService._profiles_cache = None
+    except Exception:
+        pass
+
+
+class UsersAdminPanel(ttk.Frame):
+    """Płaski menedżer kont użytkowników bez dodatkowego Notebooka."""
+
+    COLUMNS = ("login", "pin", "rola", "zatrudniony_od", "status")
+    HEADERS = {
+        "login": "LOGIN",
+        "pin": "PIN",
+        "rola": "ROLA",
+        "zatrudniony_od": "ZATRUDNIONY OD",
+        "status": "STATUS",
+    }
+
+    def __init__(self, master: tk.Misc, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+        self.users: list[dict[str, Any]] = []
+        self._build()
+        self.reload()
+
+    def _build(self) -> None:
+        toolbar = ttk.Frame(self)
+        toolbar.pack(fill="x", padx=8, pady=(8, 4))
+        ttk.Button(toolbar, text="Dodaj profil", command=self._add_profile).pack(side="left")
+        ttk.Button(toolbar, text="Edytuj", command=self._edit_selected).pack(side="left", padx=6)
+        ttk.Button(toolbar, text="Usuń profil", command=self._delete_selected).pack(side="left", padx=6)
+        ttk.Button(toolbar, text="Zapisz", command=self._save_now).pack(side="right")
+
+        wrap = ttk.Frame(self)
+        wrap.pack(fill="both", expand=True, padx=8, pady=(0, 8))
+        wrap.rowconfigure(0, weight=1)
+        wrap.columnconfigure(0, weight=1)
+        self.tree = ttk.Treeview(
+            wrap,
+            columns=self.COLUMNS,
+            show="headings",
+            selectmode="browse",
+            height=14,
+        )
+        for column in self.COLUMNS:
+            self.tree.heading(column, text=self.HEADERS[column])
+            width = 85 if column == "pin" else 150
+            self.tree.column(column, width=width, stretch=True)
+        y = ttk.Scrollbar(wrap, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=y.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        y.grid(row=0, column=1, sticky="ns")
+        self.tree.bind("<Double-1>", lambda _event: self._edit_selected())
+
+    def reload(self) -> None:
+        legacy = _legacy_profiles_module()
+        try:
+            self.users = [dict(user) for user in legacy._load_users()]
+        except Exception as exc:
+            messagebox.showerror("Profile", f"Nie udało się wczytać profili:\n{exc}", parent=self)
+            self.users = []
+        self._refresh_tree()
+
+    def _refresh_tree(self) -> None:
+        self.tree.delete(*self.tree.get_children())
+        for user in self.users:
+            self.tree.insert(
+                "",
+                "end",
+                values=(
+                    user.get("login", ""),
+                    user.get("pin", ""),
+                    user.get("rola", "operator"),
+                    user.get("zatrudniony_od", "—"),
+                    user.get("status", "aktywny"),
+                ),
+            )
+
+    def _selected_index(self) -> int | None:
+        selected = self.tree.selection()
+        if not selected:
+            return None
+        values = self.tree.item(selected[0]).get("values", [])
+        login = str(values[0]) if values else ""
+        for index, user in enumerate(self.users):
+            if str(user.get("login") or "") == login:
+                return index
+        return None
+
+    def _select_login(self, login: str) -> None:
+        for item in self.tree.get_children():
+            values = self.tree.item(item).get("values", [])
+            if values and str(values[0]) == str(login):
+                self.tree.selection_set(item)
+                self.tree.focus(item)
+                self.tree.see(item)
+                return
+
+    def _login_exists(self, login: str, skip_index: int | None = None) -> bool:
+        key = str(login or "").strip().casefold()
+        for index, user in enumerate(self.users):
+            if skip_index is not None and index == skip_index:
+                continue
+            if str(user.get("login") or "").strip().casefold() == key:
+                return True
+        return False
+
+    def _add_profile(self) -> None:
+        legacy = _legacy_profiles_module()
+        legacy.ProfileEditDialog(self, on_ok=self._on_added)
+
+    def _on_added(self, item: dict[str, Any]) -> bool:
+        login = str(item.get("login") or "").strip()
+        if self._login_exists(login):
+            messagebox.showerror("Profil", "Login już istnieje.", parent=self)
+            return False
+        self.users.append(dict(item))
+        self._refresh_tree()
+        self._select_login(login)
+        return True
+
+    def _edit_selected(self) -> None:
+        index = self._selected_index()
+        if index is None:
+            messagebox.showinfo("Profil", "Wybierz profil do edycji.", parent=self)
+            return
+        legacy = _legacy_profiles_module()
+        legacy.ProfileEditDialog(
+            self,
+            seed=self.users[index],
+            on_ok=lambda item: self._on_edited(index, item),
+        )
+
+    def _on_edited(self, index: int, item: dict[str, Any]) -> bool:
+        login = str(item.get("login") or "").strip()
+        if self._login_exists(login, skip_index=index):
+            messagebox.showerror("Profil", "Login już istnieje.", parent=self)
+            return False
+        self.users[index] = dict(item)
+        self._refresh_tree()
+        self._select_login(login)
+        return True
+
+    def _save_now(self) -> None:
+        legacy = _legacy_profiles_module()
+        legacy._save_users([dict(user) for user in self.users])
+        _invalidate_profile_cache()
+        messagebox.showinfo("Profile", "Zapisano zmiany.", parent=self)
+
+    def _delete_selected(self) -> None:
+        index = self._selected_index()
+        if index is None:
+            messagebox.showinfo("Usuń profil", "Zaznacz użytkownika do usunięcia.", parent=self)
+            return
+        user = self.users[index]
+        login = str(user.get("login") or "").strip()
+        try:
+            active_login = str(ProfileService.ensure_active_user_or_none() or "").strip()
+        except Exception:
+            active_login = ""
+        if active_login and active_login.casefold() == login.casefold():
+            messagebox.showerror("Usuń profil", "Nie można usunąć aktualnie zalogowanego użytkownika.", parent=self)
+            return
+        active_admins = sum(
+            1
+            for item in self.users
+            if item.get("active", True)
+            and normalize_role_name(item.get("rola", "")) == "administrator"
+        )
+        if normalize_role_name(user.get("rola", "")) == "administrator" and active_admins <= 1:
+            messagebox.showerror("Usuń profil", "Nie można usunąć ostatniego aktywnego administratora.", parent=self)
+            return
+        if not messagebox.askyesno("Usuń profil", f"Czy na pewno usunąć profil '{login}'?", parent=self):
+            return
+        self.users.pop(index)
+        legacy = _legacy_profiles_module()
+        legacy._save_users([dict(entry) for entry in self.users])
+        _invalidate_profile_cache()
+        self._refresh_tree()
+
+
+class RolesAdminPanel(ttk.Frame):
+    """Płaski edytor uprawnień rang."""
+
+    def __init__(self, master: tk.Misc, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+        legacy = _legacy_profiles_module()
+        self.role_labels = list(legacy.ROLE_LABELS)
+        self.module_labels = list(legacy.MODULE_LABELS)
+        self._vars: dict[str, tk.BooleanVar] = {}
+        self._build()
+
+    def _build(self) -> None:
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(0, weight=1)
+        left = ttk.Frame(self)
+        left.grid(row=0, column=0, sticky="ns", padx=(10, 12), pady=10)
+        ttk.Label(left, text="Rangi / role").pack(anchor="w", pady=(0, 6))
+        self.roles = tk.Listbox(left, height=12, exportselection=False)
+        self.roles.pack(fill="y", expand=True)
+        for _role_key, role_label in self.role_labels:
+            self.roles.insert("end", role_label)
+
+        right = ttk.Frame(self)
+        right.grid(row=0, column=1, sticky="nsew", padx=(0, 10), pady=10)
+        right.columnconfigure(0, weight=1)
+        self.title_var = tk.StringVar(value="")
+        ttk.Label(right, textvariable=self.title_var).grid(row=0, column=0, sticky="w", pady=(0, 8))
+        checks = ttk.Frame(right)
+        checks.grid(row=1, column=0, sticky="nsew")
+        for idx, (module_key, module_label) in enumerate(self.module_labels):
+            var = tk.BooleanVar(value=False)
+            self._vars[module_key] = var
+            ttk.Checkbutton(checks, text=module_label, variable=var).grid(
+                row=idx, column=0, sticky="w", pady=2
+            )
+        self.roles.bind("<<ListboxSelect>>", self._load_role)
+        ttk.Button(right, text="Zapisz rangę", command=self._save_role).grid(
+            row=2, column=0, sticky="e", pady=(12, 0)
+        )
+        if self.role_labels:
+            self.roles.selection_set(0)
+            self._load_role()
+
+    def _selected_role_key(self) -> str:
+        selected = self.roles.curselection()
+        return self.role_labels[int(selected[0])][0] if selected else ""
+
+    def _load_role(self, _event=None) -> None:
+        role_key = self._selected_role_key()
+        if not role_key:
+            return
+        self.title_var.set(f"Uprawnienia rangi: {dict(self.role_labels).get(role_key, role_key)}")
+        modules = get_role_modules(role_key)
+        for module_key, var in self._vars.items():
+            var.set(bool(modules.get(normalize_module_name(module_key), False)))
+
+    def _save_role(self) -> None:
+        role_key = self._selected_role_key()
+        if not role_key:
+            messagebox.showwarning("Rangi", "Wybierz rangę do zapisania.", parent=self)
+            return
+        modules_map = {module_key: bool(var.get()) for module_key, var in self._vars.items()}
+        set_role_modules(normalize_role_name(role_key), modules_map)
+        messagebox.showinfo("Rangi", "Zapisano uprawnienia rangi.", parent=self)
+
+
+class ProfileSettingsPanel(ttk.Frame):
+    """Ustawienia wyglądu i samodzielnej edycji Profilu."""
+
+    def __init__(self, master: tk.Misc, *, settings_owner: Any | None = None, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+        self.settings_owner = settings_owner
+        self.cfg = getattr(settings_owner, "cfg", None) or ConfigManager()
+        self._standalone = settings_owner is None
+        self._prepare_vars()
+        self._build()
+
+    def _cfg_bool(self, key: str, fallback_key: str, default: bool) -> bool:
+        value = self.cfg.get(key, None)
+        if value is None:
+            value = self.cfg.get(fallback_key, default)
+        return bool(value)
+
+    def _prepare_vars(self) -> None:
+        owner = self.settings_owner
+        if owner is not None:
+            self.var_enabled = owner.var_profile_enabled
+            self.var_header = owner.var_profile_header
+            self.var_avatar = owner.var_profile_avatar
+            self.var_pin = owner.var_profile_pin_change
+            self.var_fields = owner.var_profile_editable_fields
+            self.var_fields.set(editable_fields_csv(self.var_fields.get()))
+            return
+        self.var_enabled = tk.BooleanVar(
+            master=self,
+            value=self._cfg_bool("profiles.ui.enable_profile_card", "ui.profile.enabled", True),
+        )
+        self.var_header = tk.BooleanVar(
+            master=self,
+            value=self._cfg_bool("profiles.ui.show_name_in_header", "ui.profile.show_name_header", True),
+        )
+        self.var_avatar = tk.BooleanVar(
+            master=self,
+            value=self._cfg_bool("profiles.avatar.enabled", "ui.profile.avatar_enabled", False),
+        )
+        self.var_pin = tk.BooleanVar(
+            master=self,
+            value=self._cfg_bool("profiles.pin.change_allowed", "profiles.allow_pin_change", False),
+        )
+        raw = self.cfg.get("profiles.editable_fields", None)
+        if raw is None:
+            raw = self.cfg.get("profiles.fields_editable_by_user", ["telefon", "email"])
+        self.var_fields = tk.StringVar(master=self, value=editable_fields_csv(raw))
+
+    def _changed(self) -> None:
+        owner = self.settings_owner
+        if owner is None:
+            return
+        marker = getattr(owner, "_mark_dirty", None)
+        if callable(marker):
+            try:
+                marker()
+            except Exception:
+                pass
+        else:
+            try:
+                owner._dirty = True
+                owner._unsaved = True
+            except Exception:
+                pass
+        status = getattr(owner, "_mark_save_dirty", None)
+        if callable(status):
+            try:
+                status()
+            except Exception:
+                pass
+
+    def _build(self) -> None:
+        intro = ttk.Label(
+            self,
+            text="Jedno źródło ustawień Profilu. Zmiany pól poniżej określają dokładnie, co użytkownik może zmienić w „Edytuj mój profil”.",
+            wraplength=900,
+            justify="left",
+        )
+        intro.pack(anchor="w", padx=12, pady=(10, 8))
+
+        groups = ttk.Frame(self)
+        groups.pack(fill="x", padx=10, pady=(0, 8))
+        groups.columnconfigure(0, weight=1)
+        groups.columnconfigure(1, weight=1)
+
+        visibility = ttk.LabelFrame(groups, text="Widoczność profilu")
+        visibility.grid(row=0, column=0, sticky="nsew", padx=(0, 5))
+        ttk.Checkbutton(
+            visibility, text="Włącz kartę Profil", variable=self.var_enabled, command=self._changed
+        ).pack(anchor="w", padx=10, pady=(8, 4))
+        ttk.Checkbutton(
+            visibility, text="Pokazuj imię w nagłówku", variable=self.var_header, command=self._changed
+        ).pack(anchor="w", padx=10, pady=4)
+        ttk.Checkbutton(
+            visibility, text="Włącz avatar", variable=self.var_avatar, command=self._changed
+        ).pack(anchor="w", padx=10, pady=(4, 8))
+
+        edit = ttk.LabelFrame(groups, text="Edycja własnego profilu")
+        edit.grid(row=0, column=1, sticky="nsew", padx=(5, 0))
+        ttk.Checkbutton(
+            edit,
+            text="Zezwól użytkownikowi na zmianę PIN",
+            variable=self.var_pin,
+            command=self._changed,
+        ).pack(anchor="w", padx=10, pady=(8, 6))
+        ttk.Label(edit, text="Pola, które użytkownik może edytować:").pack(
+            anchor="w", padx=10, pady=(2, 4)
+        )
+        fields_frame = ttk.Frame(edit)
+        fields_frame.pack(fill="x", padx=8, pady=(0, 8))
+
+        selected = set(normalize_editable_fields(self.var_fields.get()))
+        self.field_vars: dict[str, tk.BooleanVar] = {}
+
+        def sync_fields() -> None:
+            values = [key for key, _label in EDITABLE_PROFILE_FIELDS if self.field_vars[key].get()]
+            self.var_fields.set(", ".join(values))
+            self._changed()
+
+        for idx, (key, label) in enumerate(EDITABLE_PROFILE_FIELDS):
+            var = tk.BooleanVar(master=fields_frame, value=key in selected)
+            self.field_vars[key] = var
+            ttk.Checkbutton(fields_frame, text=label, variable=var, command=sync_fields).grid(
+                row=idx // 2,
+                column=idx % 2,
+                sticky="w",
+                padx=(2, 18),
+                pady=3,
+            )
+
+        note = ttk.Label(
+            self,
+            text="Konta użytkowników są w zakładce Użytkownicy, a uprawnienia rang w zakładce Rangi.",
+        )
+        note.pack(anchor="w", padx=12, pady=(0, 8))
+
+        if self._standalone:
+            ttk.Button(self, text="Zapisz ustawienia profilu", command=self.save).pack(
+                anchor="e", padx=12, pady=(0, 10)
+            )
+
+    def save(self) -> None:
+        values = normalize_editable_fields(self.var_fields.get())
+        self.var_fields.set(", ".join(values))
+        self.cfg.set("profiles.ui.enable_profile_card", bool(self.var_enabled.get()))
+        self.cfg.set("profiles.ui.show_name_in_header", bool(self.var_header.get()))
+        self.cfg.set("profiles.avatar.enabled", bool(self.var_avatar.get()))
+        self.cfg.set("profiles.pin.change_allowed", bool(self.var_pin.get()))
+        self.cfg.set("profiles.editable_fields", values)
+        self.cfg.save_all()
+        messagebox.showinfo("Profile", "Zapisano ustawienia profilu.", parent=self)
+
+
+class ProfileAdminNotebook(ttk.Frame):
+    """Jednolity układ: Użytkownicy | Profile | Rangi."""
+
+    def __init__(self, master: tk.Misc, *, settings_owner: Any | None = None, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+        self.nb = ttk.Notebook(self)
+        self.nb.pack(fill="both", expand=True)
+
+        self.users_tab = ttk.Frame(self.nb)
+        self.profile_tab = ttk.Frame(self.nb)
+        self.roles_tab = ttk.Frame(self.nb)
+        self.nb.add(self.users_tab, text="Użytkownicy")
+        self.nb.add(self.profile_tab, text="Profile")
+        self.nb.add(self.roles_tab, text="Rangi")
+
+        self.users_panel = UsersAdminPanel(self.users_tab)
+        self.users_panel.pack(fill="both", expand=True)
+        self.profile_panel = ProfileSettingsPanel(
+            self.profile_tab,
+            settings_owner=settings_owner,
+        )
+        self.profile_panel.pack(fill="both", expand=True)
+        self.roles_panel = RolesAdminPanel(self.roles_tab)
+        self.roles_panel.pack(fill="both", expand=True)
+
+    def select(self, name: str) -> bool:
+        wanted = str(name or "").strip().casefold()
+        for tab in self.nb.tabs():
+            text = str(self.nb.tab(tab, "text") or "").strip().casefold()
+            if text == wanted:
+                self.nb.select(tab)
+                return True
+        return False
+
+
+__all__ = [
+    "ProfileAdminNotebook",
+    "ProfileSettingsPanel",
+    "RolesAdminPanel",
+    "UsersAdminPanel",
+]

--- a/profile_settings_fields.py
+++ b/profile_settings_fields.py
@@ -1,0 +1,72 @@
+# version: 1.0
+"""Wspólna definicja pól edytowalnych własnego Profilu WM."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+EDITABLE_PROFILE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("imie", "Imię"),
+    ("nazwisko", "Nazwisko"),
+    ("zatrudniony_od", "Data zatrudnienia"),
+    ("telefon", "Telefon"),
+    ("email", "E-mail"),
+)
+
+_FIELD_KEYS = {key for key, _label in EDITABLE_PROFILE_FIELDS}
+_FIELD_ALIASES = {
+    "staz": "zatrudniony_od",
+    "staż": "zatrudniony_od",
+    "zatrudnienie": "zatrudniony_od",
+    "data_zatrudnienia": "zatrudniony_od",
+}
+
+
+def normalize_editable_fields(raw: Any) -> list[str]:
+    """Zwróć poprawną, unikalną listę pól Profilu.
+
+    Obsługuje stare listy oraz CSV. Legacy ``staz`` mapuje na realne pole
+    ``zatrudniony_od``. Nieznane/uszkodzone wpisy (np. ``im``) są odrzucane.
+    Kolejność zawsze odpowiada kolejności pól w interfejsie.
+    """
+
+    tokens: list[str] = []
+
+    def add(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, str):
+            for token in re.split(r"[,;\n]+", value):
+                text = token.strip().casefold()
+                if text:
+                    tokens.append(text)
+            return
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                add(item)
+            return
+        text = str(value).strip().casefold()
+        if text:
+            tokens.append(text)
+
+    add(raw)
+    selected: set[str] = set()
+    for token in tokens:
+        canonical = _FIELD_ALIASES.get(token, token)
+        if canonical in _FIELD_KEYS:
+            selected.add(canonical)
+
+    return [key for key, _label in EDITABLE_PROFILE_FIELDS if key in selected]
+
+
+def editable_fields_csv(raw: Any) -> str:
+    """Tekst pomocniczy dla istniejącego StringVar w Ustawieniach."""
+
+    return ", ".join(normalize_editable_fields(raw))
+
+
+__all__ = [
+    "EDITABLE_PROFILE_FIELDS",
+    "editable_fields_csv",
+    "normalize_editable_fields",
+]

--- a/settings_users_runtime.py
+++ b/settings_users_runtime.py
@@ -1,264 +1,61 @@
-# version: 1.1
+# version: 1.2
 # Moduł: settings_users_runtime
-# UI-only: porządkowanie Ustawienia → Użytkownicy / Profile.
+# Jednolity układ Ustawienia → Użytkownicy: Użytkownicy | Profile | Rangi.
 
 from __future__ import annotations
 
-import tkinter as tk
-from tkinter import ttk
 from typing import Any
 
-
-_FIELDS = (
-    ("imie", "Imię"),
-    ("nazwisko", "Nazwisko"),
-    ("staz", "Staż / data zatrudnienia"),
-    ("telefon", "Telefon"),
-    ("email", "E-mail"),
-)
+from profile_admin_ui import ProfileAdminNotebook
 
 
-def _all_descendants(widget: tk.Misc):
-    for child in widget.winfo_children():
-        yield child
-        yield from _all_descendants(child)
-
-
-def _hide(widget: tk.Misc) -> None:
-    try:
-        if widget.grid_info():
-            widget.grid_remove()
-            return
-    except Exception:
-        pass
-    try:
-        if widget.pack_info():
-            widget.pack_forget()
-    except Exception:
-        pass
-
-
-def _mark_dirty(panel: Any) -> None:
-    marker = getattr(panel, "_mark_dirty", None)
-    if callable(marker):
-        try:
-            marker()
-            return
-        except Exception:
-            pass
-    try:
-        panel._dirty = True
-        panel._unsaved = True
-    except Exception:
-        pass
-
-
-def _rename_tabs(panel: Any) -> None:
-    """Nazwij główne podzakładki sekcji Użytkownicy jednoznacznie."""
-    nb = getattr(panel, "_users_notebook", None)
-    if nb is None:
-        return
-
-    profile_widget = None
-    users_widget = None
-    for tab_id in nb.tabs():
-        try:
-            text = str(nb.tab(tab_id, "text") or "").strip()
-        except Exception:
-            continue
-        if text in {"Lista i edycja", "Użytkownicy"}:
-            nb.tab(tab_id, text="Użytkownicy")
-            try:
-                users_widget = nb.nametowidget(tab_id)
-            except Exception:
-                users_widget = None
-        elif text in {"Profil użytkownika", "Profil", "Profile"}:
-            nb.tab(tab_id, text="Profile")
-            try:
-                profile_widget = nb.nametowidget(tab_id)
-            except Exception:
-                profile_widget = None
-
+def _register_tabs(panel: Any, admin: ProfileAdminNotebook) -> None:
     register = getattr(panel, "_register_nested_tab", None)
     top = getattr(panel, "tab_users", None)
-    if callable(register) and top is not None:
-        if users_widget is not None:
-            try:
-                register("Użytkownicy", top, nb, users_widget)
-            except Exception:
-                pass
-        if profile_widget is not None:
-            for alias in ("Profile", "Profil"):
-                try:
-                    register(alias, top, nb, profile_widget)
-                except Exception:
-                    pass
-
-
-def _cleanup_embedded_profile_manager(panel: Any) -> None:
-    """Usuń martwą, trzecią zakładkę Profil z menedżera kont.
-
-    Rzeczywiste ustawienia Profilu są w sąsiedniej zakładce ``Profile``.
-    W menedżerze kont zostają tylko ``Użytkownicy`` oraz ``Rangi``.
-    """
-    root = getattr(panel, "_users_container", None)
-    if root is None:
+    if not callable(register) or top is None:
         return
+    for name, widget in (
+        ("Użytkownicy", admin.users_tab),
+        ("Profile", admin.profile_tab),
+        ("Rangi", admin.roles_tab),
+    ):
+        try:
+            register(name, top, admin.nb, widget)
+        except Exception:
+            pass
+    # Zachowaj starszy alias używany przez część nawigacji.
     try:
-        from ustawienia_uzytkownicy import SettingsProfilesTab
+        register("Profil", top, admin.nb, admin.profile_tab)
     except Exception:
-        return
-
-    for widget in _all_descendants(root):
-        if not isinstance(widget, SettingsProfilesTab):
-            continue
-        nb = getattr(widget, "nb", None)
-        if nb is None or getattr(widget, "_wm_profile_manager_clean", False):
-            continue
-        for tab_id in list(nb.tabs()):
-            try:
-                text = str(nb.tab(tab_id, "text") or "").strip()
-            except Exception:
-                continue
-            if text == "Lista i edycja":
-                nb.tab(tab_id, text="Użytkownicy")
-            elif text == "Profil użytkownika":
-                try:
-                    nb.forget(tab_id)
-                except Exception:
-                    pass
-        setattr(widget, "_wm_profile_manager_clean", True)
+        pass
 
 
-def _profile_settings_frame(panel: Any):
+def _rebuild_profile_admin(panel: Any) -> ProfileAdminNotebook | None:
+    """Zastąp wielopoziomowy układ jednym wspólnym notebookiem."""
     root = getattr(panel, "_users_container", None)
     if root is None:
         return None
-    for widget in _all_descendants(root):
-        if not isinstance(widget, ttk.LabelFrame):
-            continue
-        try:
-            text = str(widget.cget("text") or "").strip()
-        except Exception:
-            continue
-        if text in {"Ustawienia profilu użytkownika", "Profil — wygląd i edycja", "Profile — ustawienia"}:
-            return widget
-    return None
 
-
-def _rebuild_profile_settings(panel: Any) -> None:
-    """Podziel ustawienia Profilu na czytelne grupy bez zmiany danych."""
-    frame = _profile_settings_frame(panel)
-    if frame is None or getattr(frame, "_wm_profile_settings_clean", False):
-        return
-
-    required = (
-        "var_profile_enabled",
-        "var_profile_header",
-        "var_profile_avatar",
-        "var_profile_pin_change",
-        "var_profile_editable_fields",
-    )
-    if any(not hasattr(panel, name) for name in required):
-        return
-
-    for child in list(frame.winfo_children()):
-        _hide(child)
-
-    frame.configure(text="Profile — ustawienia")
+    current = getattr(panel, "_wm_profile_admin", None)
     try:
-        frame.columnconfigure(0, weight=1)
-        frame.columnconfigure(1, weight=1)
+        if current is not None and bool(current.winfo_exists()):
+            _register_tabs(panel, current)
+            return current
     except Exception:
         pass
 
-    ttk.Label(
-        frame,
-        text="Tu ustawiasz wygląd Profilu i zakres danych, które użytkownik może zmieniać samodzielnie.",
-        style="WM.Muted.TLabel",
-        wraplength=760,
-        justify="left",
-    ).grid(row=0, column=0, columnspan=2, sticky="w", padx=10, pady=(8, 10))
+    for child in list(root.winfo_children()):
+        try:
+            child.destroy()
+        except Exception:
+            pass
 
-    visibility = ttk.LabelFrame(frame, text="Widoczność profilu")
-    visibility.grid(row=1, column=0, sticky="nsew", padx=(8, 4), pady=(0, 8))
-    ttk.Checkbutton(
-        visibility,
-        text="Włącz kartę Profil",
-        variable=panel.var_profile_enabled,
-        command=lambda: _mark_dirty(panel),
-    ).pack(anchor="w", padx=10, pady=(8, 4))
-    ttk.Checkbutton(
-        visibility,
-        text="Pokazuj imię w nagłówku",
-        variable=panel.var_profile_header,
-        command=lambda: _mark_dirty(panel),
-    ).pack(anchor="w", padx=10, pady=4)
-    ttk.Checkbutton(
-        visibility,
-        text="Włącz avatar",
-        variable=panel.var_profile_avatar,
-        command=lambda: _mark_dirty(panel),
-    ).pack(anchor="w", padx=10, pady=(4, 8))
-
-    edit = ttk.LabelFrame(frame, text="Edycja własnego profilu")
-    edit.grid(row=1, column=1, sticky="nsew", padx=(4, 8), pady=(0, 8))
-    ttk.Checkbutton(
-        edit,
-        text="Zezwól użytkownikowi na zmianę PIN",
-        variable=panel.var_profile_pin_change,
-        command=lambda: _mark_dirty(panel),
-    ).pack(anchor="w", padx=10, pady=(8, 6))
-    ttk.Label(
-        edit,
-        text="Pola, które użytkownik może edytować:",
-        style="WM.Muted.TLabel",
-    ).pack(anchor="w", padx=10, pady=(2, 4))
-
-    try:
-        raw = str(panel.var_profile_editable_fields.get() or "")
-    except Exception:
-        raw = ""
-    current = [x.strip() for x in raw.replace(";", ",").split(",") if x.strip()]
-    known = {key for key, _label in _FIELDS}
-    extras = [x for x in current if x not in known]
-    vars_by_key: dict[str, tk.BooleanVar] = {}
-
-    fields = ttk.Frame(edit)
-    fields.pack(fill="x", padx=8, pady=(0, 8))
-
-    def _sync_fields() -> None:
-        values = [key for key, _label in _FIELDS if vars_by_key[key].get()]
-        values.extend(x for x in extras if x not in values)
-        panel.var_profile_editable_fields.set(", ".join(values))
-        _mark_dirty(panel)
-
-    for idx, (key, label) in enumerate(_FIELDS):
-        var = tk.BooleanVar(master=fields, value=key in current)
-        vars_by_key[key] = var
-        ttk.Checkbutton(fields, text=label, variable=var, command=_sync_fields).grid(
-            row=idx // 2,
-            column=idx % 2,
-            sticky="w",
-            padx=(2, 14),
-            pady=3,
-        )
-
-    if extras:
-        ttk.Label(
-            edit,
-            text="Pozostałe zapisane pola: " + ", ".join(extras),
-            style="WM.Muted.TLabel",
-        ).pack(anchor="w", padx=10, pady=(0, 8))
-
-    ttk.Label(
-        frame,
-        text="Konta, role i uprawnienia znajdują się w zakładce Użytkownicy / Rangi.",
-        style="WM.Muted.TLabel",
-    ).grid(row=2, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 8))
-
-    frame._wm_profile_field_vars = vars_by_key
-    setattr(frame, "_wm_profile_settings_clean", True)
+    admin = ProfileAdminNotebook(root, settings_owner=panel)
+    admin.pack(fill="both", expand=True, padx=4, pady=4)
+    panel._wm_profile_admin = admin
+    panel._users_notebook = admin.nb
+    _register_tabs(panel, admin)
+    return admin
 
 
 def _open_requested_profile_tab(panel: Any) -> None:
@@ -270,12 +67,20 @@ def _open_requested_profile_tab(panel: Any) -> None:
     target = str(getattr(root, "_wm_settings_target_tab", "") or "").strip().casefold()
     if target not in {"profil", "profile", "profiles"}:
         return
-    opener = getattr(panel, "open_tab", None)
-    if callable(opener):
+
+    admin = getattr(panel, "_wm_profile_admin", None)
+    if admin is not None:
         try:
-            opener("Profile")
+            admin.select("Profile")
         except Exception:
             pass
+    else:
+        opener = getattr(panel, "open_tab", None)
+        if callable(opener):
+            try:
+                opener("Profile")
+            except Exception:
+                pass
     try:
         delattr(root, "_wm_settings_target_tab")
     except Exception:
@@ -283,16 +88,23 @@ def _open_requested_profile_tab(panel: Any) -> None:
 
 
 def _decorate(panel: Any) -> None:
-    for action in (
-        _rename_tabs,
-        _cleanup_embedded_profile_manager,
-        _rebuild_profile_settings,
-        _open_requested_profile_tab,
-    ):
-        try:
-            action(panel)
-        except Exception:
-            pass
+    try:
+        _rebuild_profile_admin(panel)
+    finally:
+        _open_requested_profile_tab(panel)
+
+
+# Nazwy zachowane dla testów/wtyczek starszej wersji runtime.
+def _rename_tabs(panel: Any) -> None:
+    _rebuild_profile_admin(panel)
+
+
+def _cleanup_embedded_profile_manager(panel: Any) -> None:
+    _rebuild_profile_admin(panel)
+
+
+def _rebuild_profile_settings(panel: Any) -> None:
+    _rebuild_profile_admin(panel)
 
 
 def install_settings_users_runtime(settings_panel_cls: type) -> None:
@@ -314,6 +126,8 @@ def install_settings_users_runtime(settings_panel_cls: type) -> None:
 __all__ = [
     "_cleanup_embedded_profile_manager",
     "_open_requested_profile_tab",
+    "_rebuild_profile_admin",
     "_rebuild_profile_settings",
+    "_rename_tabs",
     "install_settings_users_runtime",
 ]

--- a/settings_users_runtime.py
+++ b/settings_users_runtime.py
@@ -1,4 +1,4 @@
-# version: 1.2
+# version: 1.2.1
 # Moduł: settings_users_runtime
 # Jednolity układ Ustawienia → Użytkownicy: Użytkownicy | Profile | Rangi.
 
@@ -7,6 +7,14 @@ from __future__ import annotations
 from typing import Any
 
 from profile_admin_ui import ProfileAdminNotebook
+
+_REQUIRED_PROFILE_VARS = (
+    "var_profile_enabled",
+    "var_profile_header",
+    "var_profile_avatar",
+    "var_profile_pin_change",
+    "var_profile_editable_fields",
+)
 
 
 def _register_tabs(panel: Any, admin: ProfileAdminNotebook) -> None:
@@ -23,7 +31,6 @@ def _register_tabs(panel: Any, admin: ProfileAdminNotebook) -> None:
             register(name, top, admin.nb, widget)
         except Exception:
             pass
-    # Zachowaj starszy alias używany przez część nawigacji.
     try:
         register("Profil", top, admin.nb, admin.profile_tab)
     except Exception:
@@ -33,7 +40,7 @@ def _register_tabs(panel: Any, admin: ProfileAdminNotebook) -> None:
 def _rebuild_profile_admin(panel: Any) -> ProfileAdminNotebook | None:
     """Zastąp wielopoziomowy układ jednym wspólnym notebookiem."""
     root = getattr(panel, "_users_container", None)
-    if root is None:
+    if root is None or any(not hasattr(panel, name) for name in _REQUIRED_PROFILE_VARS):
         return None
 
     current = getattr(panel, "_wm_profile_admin", None)

--- a/tests/test_profile_admin_foreman_tk.py
+++ b/tests/test_profile_admin_foreman_tk.py
@@ -1,0 +1,28 @@
+# version: 1.0
+import tkinter as tk
+
+import gui_profile  # noqa: F401 - instaluje runtime panelu brygadzisty
+import ustawienia_uzytkownicy as users_settings
+from gui_profile_foreman import ForemanProfilePanel
+
+
+def _texts(notebook):
+    return [str(notebook.tab(tab_id, "text")) for tab_id in notebook.tabs()]
+
+
+def test_foreman_profile_tab_uses_unified_admin_notebook(monkeypatch):
+    monkeypatch.setattr(users_settings, "_load_users", lambda: [])
+    monkeypatch.setattr(ForemanProfilePanel, "refresh_data", lambda self: None)
+
+    root = tk.Tk()
+    try:
+        panel = ForemanProfilePanel(root)
+        panel.pack(fill="both", expand=True)
+        root.update_idletasks()
+
+        assert "Profile" in panel._tabs
+        admin = panel._wm_profile_admin
+        assert _texts(admin.nb) == ["Użytkownicy", "Profile", "Rangi"]
+        assert panel._tabs["Profile"] is not admin
+    finally:
+        root.destroy()

--- a/tests/test_profile_settings_navigation.py
+++ b/tests/test_profile_settings_navigation.py
@@ -1,8 +1,9 @@
-# version: 1.0
+# version: 1.1
 from types import SimpleNamespace
 
 import gui_profile
 import settings_users_runtime as settings_runtime
+from profile_settings_fields import normalize_editable_fields
 
 
 def test_requested_profile_settings_tab_is_opened_and_consumed():
@@ -24,7 +25,7 @@ def test_requested_profile_settings_tab_is_opened_and_consumed():
     assert not hasattr(root, "_wm_settings_target_tab")
 
 
-def test_foreman_edit_profile_redirects_to_profile_settings(monkeypatch):
+def test_foreman_has_separate_profile_settings_shortcut(monkeypatch):
     root = SimpleNamespace()
     container = object()
     calls = {}
@@ -62,10 +63,57 @@ def test_foreman_edit_profile_redirects_to_profile_settings(monkeypatch):
 
     monkeypatch.setattr(ustawienia_systemu, "panel_ustawien", fake_panel_ustawien)
 
-    gui_profile.ProfileView._open_edit_profile(FakeProfile())
+    gui_profile.ProfileView._open_profile_settings(FakeProfile())
 
     assert calls["root"] is root
     assert calls["frame"] is container
     assert calls["login"] == "edwin"
     assert calls["rola"] == "brygadzista"
     assert calls["target"] == "Profile"
+
+
+def test_editable_fields_normalize_legacy_and_garbage():
+    assert normalize_editable_fields(
+        ["imie", "staz", "telefon", "im", "EMAIL", "telefon"]
+    ) == ["imie", "zatrudniony_od", "telefon", "email"]
+    assert normalize_editable_fields("imie, nazwisko; staz\nim") == [
+        "imie",
+        "nazwisko",
+        "zatrudniony_od",
+    ]
+
+
+def test_profile_respects_explicit_empty_editable_fields(monkeypatch):
+    class FakeConfig:
+        def get(self, key, default=None):
+            values = {
+                "profiles.editable_fields": [],
+                "profiles.pin.change_allowed": False,
+                "profiles.pin": {"min_length": 4},
+            }
+            return values.get(key, default)
+
+    monkeypatch.setattr(gui_profile, "ConfigManager", lambda: FakeConfig())
+    fields, allow_pin, pin_min = gui_profile.ProfileView._user_editable_fields(object())
+
+    assert fields == []
+    assert allow_pin is False
+    assert pin_min == 4
+
+
+def test_profile_maps_staz_to_real_employment_date_field(monkeypatch):
+    class FakeConfig:
+        def get(self, key, default=None):
+            values = {
+                "profiles.editable_fields": ["imie", "staz", "telefon", "im"],
+                "profiles.pin.change_allowed": True,
+                "profiles.pin": {"min_length": 5},
+            }
+            return values.get(key, default)
+
+    monkeypatch.setattr(gui_profile, "ConfigManager", lambda: FakeConfig())
+    fields, allow_pin, pin_min = gui_profile.ProfileView._user_editable_fields(object())
+
+    assert fields == ["imie", "zatrudniony_od", "telefon"]
+    assert allow_pin is True
+    assert pin_min == 5

--- a/tests/test_profile_settings_runtime_tk.py
+++ b/tests/test_profile_settings_runtime_tk.py
@@ -1,4 +1,4 @@
-# version: 1.0
+# version: 1.1
 import tkinter as tk
 from tkinter import ttk
 
@@ -10,7 +10,13 @@ def _texts(notebook):
     return [str(notebook.tab(tab_id, "text")) for tab_id in notebook.tabs()]
 
 
-def test_profile_settings_are_grouped_and_duplicate_profile_tab_is_removed(monkeypatch):
+def _descendants(widget):
+    for child in widget.winfo_children():
+        yield child
+        yield from _descendants(child)
+
+
+def test_profile_settings_use_single_users_profile_roles_level(monkeypatch):
     monkeypatch.setattr(users_settings, "_load_users", lambda: [])
 
     root = tk.Tk()
@@ -28,15 +34,16 @@ def test_profile_settings_are_grouped_and_duplicate_profile_tab_is_removed(monke
         panel.var_profile_header = tk.BooleanVar(master=root, value=True)
         panel.var_profile_avatar = tk.BooleanVar(master=root, value=False)
         panel.var_profile_pin_change = tk.BooleanVar(master=root, value=False)
-        panel.var_profile_editable_fields = tk.StringVar(master=root, value="imie, email")
+        panel.var_profile_editable_fields = tk.StringVar(
+            master=root,
+            value="imie, staz, email, im",
+        )
 
-        outer_nb = ttk.Notebook(panel._users_container)
-        outer_nb.pack(fill="both", expand=True)
-        panel._users_notebook = outer_nb
-        users_frame = ttk.Frame(outer_nb)
-        profile_frame = ttk.Frame(outer_nb)
-        outer_nb.add(users_frame, text="Lista i edycja")
-        outer_nb.add(profile_frame, text="Profil użytkownika")
+        old_nb = ttk.Notebook(panel._users_container)
+        old_nb.pack(fill="both", expand=True)
+        panel._users_notebook = old_nb
+        old_nb.add(ttk.Frame(old_nb), text="Lista i edycja")
+        old_nb.add(ttk.Frame(old_nb), text="Profil użytkownika")
 
         registrations = {}
 
@@ -45,55 +52,40 @@ def test_profile_settings_are_grouped_and_duplicate_profile_tab_is_removed(monke
 
         panel._register_nested_tab = register
 
-        manager = users_settings.SettingsProfilesTab(users_frame)
-        manager.pack(fill="both", expand=True)
-
-        settings_box = ttk.LabelFrame(profile_frame, text="Ustawienia profilu użytkownika")
-        settings_box.pack(fill="x")
-        ttk.Checkbutton(settings_box, text="Włącz kartę profilu").grid(row=0, column=0)
-        ttk.Checkbutton(settings_box, text="Pokazuj imię w nagłówku").grid(row=1, column=0)
-        ttk.Checkbutton(settings_box, text="Włącz avatar").grid(row=2, column=0)
-        ttk.Checkbutton(settings_box, text="Zezwól na zmianę PIN").grid(row=3, column=0)
-        ttk.Label(settings_box, text="Pola edytowane przez użytkownika (CSV):").grid(row=4, column=0)
-        ttk.Entry(settings_box, textvariable=panel.var_profile_editable_fields).grid(row=4, column=1)
-        ttk.Label(settings_box, text="Np.: imie, nazwisko, telefon, email").grid(row=5, column=0)
-
-        settings_runtime._rename_tabs(panel)
-        settings_runtime._cleanup_embedded_profile_manager(panel)
-        settings_runtime._rebuild_profile_settings(panel)
+        admin = settings_runtime._rebuild_profile_admin(panel)
         root.update_idletasks()
 
-        assert _texts(outer_nb) == ["Użytkownicy", "Profile"]
-        assert "Profile" in registrations
-        assert "Profil" in registrations
-        assert _texts(manager.nb) == ["Użytkownicy", "Rangi"]
+        assert admin is not None
+        assert panel._users_notebook is admin.nb
+        assert _texts(admin.nb) == ["Użytkownicy", "Profile", "Rangi"]
+        assert set(registrations) >= {"Użytkownicy", "Profile", "Profil", "Rangi"}
 
-        assert str(settings_box.cget("text")) == "Profile — ustawienia"
-        group_titles = {
-            str(widget.cget("text"))
-            for widget in settings_box.winfo_children()
-            if isinstance(widget, ttk.LabelFrame)
-        }
-        assert "Widoczność profilu" in group_titles
-        assert "Edycja własnego profilu" in group_titles
+        # Legacy staz jest mapowany na realne pole, a śmieć "im" znika.
+        assert panel.var_profile_editable_fields.get() == "imie, zatrudniony_od, email"
 
-        edit_group = next(
+        # Zakładka Użytkownicy nie ma już kolejnego Notebooka Użytkownicy/Rangi.
+        nested_notebooks = [
             widget
-            for widget in settings_box.winfo_children()
-            if isinstance(widget, ttk.LabelFrame)
-            and str(widget.cget("text")) == "Edycja własnego profilu"
+            for widget in _descendants(admin.users_tab)
+            if isinstance(widget, ttk.Notebook)
+        ]
+        assert nested_notebooks == []
+
+        phone = next(
+            widget
+            for widget in _descendants(admin.profile_tab)
+            if isinstance(widget, ttk.Checkbutton)
+            and str(widget.cget("text")) == "Telefon"
         )
-        field_checks = []
-        for child in edit_group.winfo_children():
-            if isinstance(child, ttk.Frame):
-                field_checks.extend(
-                    grandchild
-                    for grandchild in child.winfo_children()
-                    if isinstance(grandchild, ttk.Checkbutton)
-                )
-        phone = next(w for w in field_checks if str(w.cget("text")) == "Telefon")
         phone.invoke()
         assert "telefon" in panel.var_profile_editable_fields.get()
         assert panel._dirty is True
+
+        labels = [
+            str(widget.cget("text"))
+            for widget in _descendants(admin.profile_tab)
+            if isinstance(widget, ttk.Label)
+        ]
+        assert not any("Pozostałe zapisane pola" in text for text in labels)
     finally:
         root.destroy()


### PR DESCRIPTION
Naprawia niespójność widoczną między Ustawienia → Profile i Profil → Brygadzista → Profile.

Zakres:
- jeden wspólny układ administracji: Użytkownicy | Profile | Rangi,
- ten sam komponent w Ustawieniach i panelu Brygadzisty,
- `Edytuj mój profil` znowu edytuje własne dane również brygadziście,
- osobny przycisk `Ustawienia profili` dla brygadzisty,
- jedno źródło pól edytowalnych: Imię, Nazwisko, Data zatrudnienia, Telefon, E-mail,
- legacy `staz` mapowany do `zatrudniony_od`, uszkodzone wpisy typu `im` są odrzucane,
- aktywny ProfileView respektuje ustawienia: karta Profil, imię w nagłówku, avatar,
- jawnie pusta lista pól oznacza brak edycji zamiast fallbacku do Telefon/E-mail,
- testy czystej logiki i testy Tkinter dla obu miejsc.

Zmiana jest na osobnej gałęzi i nie dotyka innych modułów funkcjonalnych.