### PR TITLE
Profil: przywróć edycję własnego profilu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
             tests/test_gui_maszyny_usage_location_tk.py \
             tests/test_gui_maszyny_drag_location_feedback_tk.py \
             tests/test_profile_settings_runtime_tk.py \
-            tests/test_profile_admin_foreman_tk.py
+            tests/test_profile_admin_foreman_tk.py \
+            tests/test_profile_own_edit_tk.py
   static-checks:
     runs-on: ubuntu-latest
     steps:

--- a/gui_profile.py
+++ b/gui_profile.py
@@ -1,4 +1,4 @@
-# version: 1.9.4
+# version: 1.9.5
 """Aktywny Profil WM z Kalendarzem i panelem Brygadzisty."""
 from __future__ import annotations
 
@@ -172,11 +172,11 @@ class ProfileView(_BaseProfileView):
         return fields, allow_pin, pin_min_length
 
     def _open_edit_profile(self) -> None:
-        """Edycja własnego profilu działa tak samo również dla brygadzisty."""
+        """Edycja własnego profilu działa tak samo dla każdej rangi."""
         return super()._open_edit_profile()
 
     def _open_profile_settings(self) -> None:
-        """Osobny skrót brygadzisty do Ustawienia → Profile."""
+        """Administracyjny skrót brygadzisty do Ustawienia → Profile."""
         if not self._logged_user_is_brygadzista():
             return
         try:
@@ -213,27 +213,26 @@ class ProfileView(_BaseProfileView):
                 pass
 
     def _render_simple_profile(self, parent) -> None:
-        """Dane użytkownika + osobna administracja tylko dla brygadzisty."""
+        """Zwykły Profil zawsze daje dostęp do edycji własnych danych."""
+        account = ttk.LabelFrame(
+            parent,
+            text="Mój profil",
+            style="WM.Section.TLabelframe",
+            padding=10,
+        )
+        account.pack(fill="x", pady=(0, 10))
+        ttk.Label(
+            account,
+            text="Dane własnego profilu i pola udostępnione do samodzielnej edycji.",
+            style="WM.Muted.TLabel",
+        ).pack(side="left")
+        ttk.Button(
+            account,
+            text="Edytuj mój profil",
+            command=self._open_edit_profile,
+            style="WM.Button.TButton",
+        ).pack(side="right")
         super()._render_simple_profile(parent)
-        if self._logged_user_is_brygadzista():
-            admin = ttk.LabelFrame(
-                parent,
-                text="Administracja profili",
-                style="WM.Section.TLabelframe",
-                padding=10,
-            )
-            admin.pack(fill="x", pady=(0, 10))
-            ttk.Label(
-                admin,
-                text="Ustawienia pól, kont i rang są zarządzane w jednym miejscu.",
-                style="WM.Muted.TLabel",
-            ).pack(side="left")
-            ttk.Button(
-                admin,
-                text="Ustawienia profili",
-                command=self._open_profile_settings,
-                style="WM.Button.TButton",
-            ).pack(side="right")
 
     def _render_profile_body(self, parent) -> None:
         """Pokaż Profil + Kalendarz oraz opcjonalnie Brygadzistę."""
@@ -270,13 +269,12 @@ class ProfileView(_BaseProfileView):
                 text="Karta Profil jest wyłączona w Ustawienia → Profile.",
                 style="WM.Muted.TLabel",
             ).pack(side="left")
-            if self._logged_user_is_brygadzista():
-                ttk.Button(
-                    box,
-                    text="Ustawienia profili",
-                    command=self._open_profile_settings,
-                    style="WM.Button.TButton",
-                ).pack(side="right")
+            ttk.Button(
+                box,
+                text="Edytuj mój profil",
+                command=self._open_edit_profile,
+                style="WM.Button.TButton",
+            ).pack(side="right")
 
         foreman_tab = None
         is_foreman = self._logged_user_is_brygadzista()

--- a/tests/test_profile_own_edit_tk.py
+++ b/tests/test_profile_own_edit_tk.py
@@ -1,0 +1,58 @@
+# version: 1.0
+import tkinter as tk
+from tkinter import ttk
+
+import gui_profile
+
+
+def _texts(widget):
+    out = []
+    try:
+        text = str(widget.cget("text") or "")
+    except Exception:
+        text = ""
+    if text:
+        out.append(text)
+    for child in widget.winfo_children():
+        out.extend(_texts(child))
+    return out
+
+
+def test_regular_profile_shows_own_edit_and_no_admin_banner(monkeypatch):
+    monkeypatch.setattr(
+        gui_profile._BaseProfileView,
+        "_render_simple_profile",
+        lambda _self, _parent: None,
+    )
+    calls = []
+    monkeypatch.setattr(
+        gui_profile.ProfileView,
+        "_open_edit_profile",
+        lambda _self: calls.append("edit"),
+    )
+
+    root = tk.Tk()
+    try:
+        parent = ttk.Frame(root)
+        parent.pack(fill="both", expand=True)
+        view = gui_profile.ProfileView.__new__(gui_profile.ProfileView)
+        gui_profile.ProfileView._render_simple_profile(view, parent)
+        root.update_idletasks()
+
+        texts = _texts(parent)
+        assert "Mój profil" in texts
+        assert "Edytuj mój profil" in texts
+        assert "Administracja profili" not in texts
+        assert "Ustawienia profili" not in texts
+
+        button = next(
+            child
+            for frame in parent.winfo_children()
+            for child in frame.winfo_children()
+            if isinstance(child, ttk.Button)
+            and str(child.cget("text")) == "Edytuj mój profil"
+        )
+        button.invoke()
+        assert calls == ["edit"]
+    finally:
+        root.destroy()


### PR DESCRIPTION
Naprawia regresję po ujednoliceniu profili.

Zakres:
- usuwa widoczny pasek „Administracja profili” ze zwykłej zakładki Profil,
- dodaje zawsze widoczne „Mój profil” → „Edytuj mój profil” dla każdego zalogowanego użytkownika, niezależnie od rangi,
- checkboxy w Ustawienia → Profile nadal określają tylko zakres pól dostępnych w formularzu,
- administracja kont/rang pozostaje wyłącznie w Brygadzista → Profile / Ustawienia,
- także przy wyłączonej karcie Profil użytkownik zachowuje wejście do własnej edycji,
- test Tkinter sprawdza brak administracji i właściwy przycisk.